### PR TITLE
util: Add make_std_tcp_conn to create no_delay tcp connection.

### DIFF
--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -17,6 +17,7 @@ use std::sync::{Arc, Mutex};
 use std::sync::mpsc::{self, Sender};
 use std::thread::{self, JoinHandle};
 use util::codec::rpc;
+use util::make_std_tcp_conn;
 use protobuf::{self, MessageStatic};
 use super::Result;
 
@@ -37,8 +38,7 @@ const SOCKET_WRITE_TIMEOUT: u64 = 3;
 
 impl RpcClient {
     pub fn new<A: ToSocketAddrs>(addr: A) -> Result<RpcClient> {
-        let stream = try!(TcpStream::connect(addr));
-        try!(stream.set_nodelay(true));
+        let stream = try!(make_std_tcp_conn(addr));
         try!(stream.set_read_timeout(Some(Duration::from_secs(SOCKET_READ_TIMEOUT))));
         try!(stream.set_write_timeout(Some(Duration::from_secs(SOCKET_WRITE_TIMEOUT))));
         Ok(RpcClient { stream: Mutex::new(stream) })

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -14,6 +14,7 @@
 use std::ops::Deref;
 use std::ops::DerefMut;
 use std::io::{self, Write};
+use std::net::{ToSocketAddrs, TcpStream};
 use time;
 use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use rand::{self, ThreadRng};
@@ -121,4 +122,11 @@ impl<T> HandyRwLock<T> for RwLock<T> {
     fn rl(&self) -> RwLockReadGuard<T> {
         self.read().unwrap()
     }
+}
+
+
+pub fn make_std_tcp_conn<A: ToSocketAddrs>(addr: A) -> io::Result<TcpStream> {
+    let stream = try!(TcpStream::connect(addr));
+    try!(stream.set_nodelay(false));
+    Ok(stream)
 }

--- a/tests/raftstore/server.rs
+++ b/tests/raftstore/server.rs
@@ -13,8 +13,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::thread;
-use std::net::SocketAddr;
-use std::net::TcpStream;
+use std::net::{SocketAddr, TcpStream};
 use std::sync::{Arc, Mutex, RwLock, mpsc};
 use std::time::Duration;
 
@@ -25,6 +24,7 @@ use tikv::server::{Server, ServerTransport, SendCh, create_event_loop, Msg, bind
 use tikv::server::{Node, Config, create_raft_storage};
 use tikv::raftstore::Result;
 use tikv::util::codec::rpc;
+use tikv::util::make_std_tcp_conn;
 use kvproto::raft_serverpb;
 use kvproto::msgpb::{Message, MessageType};
 use kvproto::raft_cmdpb::*;
@@ -75,8 +75,7 @@ impl ServerCluster {
             }
         }
 
-        let conn = TcpStream::connect(addr).unwrap();
-        conn.set_nodelay(true).unwrap();
+        let conn = make_std_tcp_conn(addr).unwrap();
         Ok(conn)
     }
 


### PR DESCRIPTION
We should always call make_std_tcp_conn instead of TcpStream::connect in case we forget to call set_nodelay. 