### PR TITLE
[WIP] tests/raftstore: transport hijack for simulating bad network traffic

### DIFF
--- a/benches/bin/bench-tikv.rs
+++ b/benches/bin/bench-tikv.rs
@@ -41,6 +41,8 @@ mod node;
 mod server;
 #[path="../../tests/raftstore/pd.rs"]
 mod pd;
+#[path="../../tests/raftstore/transport_simulate.rs"]
+mod transport_simulate;
 #[path="../../tests/raftstore/pd_ask.rs"]
 mod pd_ask;
 

--- a/tests/raftstore/mod.rs
+++ b/tests/raftstore/mod.rs
@@ -17,6 +17,7 @@ mod node;
 mod server;
 pub mod pd;
 pub mod pd_ask;
+pub mod transport_simulate;
 
 mod test_single;
 mod test_multi;

--- a/tests/raftstore/node.rs
+++ b/tests/raftstore/node.rs
@@ -29,6 +29,7 @@ use tikv::util::HandyRwLock;
 use tikv::server::Config as ServerConfig;
 use tikv::server::transport::{ServerRaftStoreRouter, RaftStoreRouter};
 use super::pd::TestPdClient;
+use super::transport_simulate::{TransportHijack, SimulateTransport};
 use super::pd_ask::run_ask_loop;
 
 pub struct ChannelTransport {
@@ -57,7 +58,7 @@ pub struct NodeCluster {
     cluster_id: u64,
     trans: Arc<RwLock<ChannelTransport>>,
     pd_client: Arc<RwLock<TestPdClient>>,
-    nodes: HashMap<u64, Node<TestPdClient, ChannelTransport>>,
+    nodes: HashMap<u64, Node<TestPdClient, Box<SimulateTransport>>>,
 }
 
 impl NodeCluster {
@@ -72,15 +73,24 @@ impl NodeCluster {
 }
 
 impl Simulator for NodeCluster {
-    fn run_node(&mut self, node_id: u64, cfg: ServerConfig, engine: Arc<DB>) -> u64 {
+    fn run_node<T: TransportHijack>(&mut self,
+                                    node_id: u64,
+                                    cfg: ServerConfig,
+                                    engine: Arc<DB>,
+                                    trans_hijacker: T)
+                                    -> u64 {
         assert!(node_id == 0 || !self.nodes.contains_key(&node_id));
-
-        let mut node = Node::new(&cfg, self.pd_client.clone(), self.trans.clone());
+        let trans = self.trans.clone();
+        let boxed_trans = trans_hijacker.wrapper(Box::new(trans));
+        let mut node = Node::new(&cfg,
+                                 self.pd_client.clone(),
+                                 Arc::new(RwLock::new(boxed_trans)));
 
         node.start(engine).unwrap();
         assert!(node_id == 0 || node_id == node.id());
 
         let node_id = node.id();
+        node.raft_store_router();
         self.trans.wl().routers.insert(node_id, node.raft_store_router());
         self.nodes.insert(node_id, node);
 

--- a/tests/raftstore/transport_simulate.rs
+++ b/tests/raftstore/transport_simulate.rs
@@ -1,0 +1,172 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use kvproto::raft_serverpb::RaftMessage;
+use tikv::raftstore::store::Transport;
+use tikv::raftstore::Result as RaftStoreResult;
+// use tikv::raftstore::Error::Timeout;
+use rand;
+use std::sync::{Arc, RwLock};
+use super::util::*;
+use super::node::ChannelTransport;
+use super::pd::TestPdClient;
+use tikv::server::ServerTransport;
+
+// SimulateTransport is the same as Transport, just to avoid name conflict
+pub trait SimulateTransport: Send + Sync {
+    fn send(&self, msg: RaftMessage) -> RaftStoreResult<()>;
+}
+
+// TransportHijack hijack the underlying Transport
+pub trait TransportHijack {
+    fn wrapper(&self, Box<SimulateTransport>) -> Box<SimulateTransport>;
+}
+
+impl SimulateTransport for Arc<RwLock<ChannelTransport>> {
+    fn send(&self, msg: RaftMessage) -> RaftStoreResult<()> {
+        self.read().unwrap().send(msg)
+    }
+}
+
+impl SimulateTransport for Arc<RwLock<ServerTransport<TestPdClient>>> {
+    fn send(&self, msg: RaftMessage) -> RaftStoreResult<()> {
+        self.read().unwrap().send(msg)
+    }
+}
+
+impl Transport for Box<SimulateTransport> {
+    fn send(&self, msg: RaftMessage) -> RaftStoreResult<()> {
+        self.as_ref().send(msg)
+    }
+}
+
+pub struct IdentityTransportHijack;
+
+impl TransportHijack for IdentityTransportHijack {
+    fn wrapper(&self, input: Box<SimulateTransport>) -> Box<SimulateTransport> {
+        input
+    }
+}
+
+pub struct LossPacketHijack(pub u32);
+
+impl TransportHijack for LossPacketHijack {
+    fn wrapper(&self, input: Box<SimulateTransport>) -> Box<SimulateTransport> {
+        Box::new(LossPacket {
+            rate: self.0,
+            transport: input,
+        })
+    }
+}
+
+struct LossPacket {
+    // loss packet rate 100% means network unreachable
+    rate: u32,
+    transport: Box<SimulateTransport>,
+}
+
+impl SimulateTransport for LossPacket {
+    fn send(&self, msg: RaftMessage) -> RaftStoreResult<()> {
+        if rand::random::<u32>() % 100u32 < self.rate {
+            // discard msg and return
+            return Ok(());
+        }
+        self.transport.send(msg)
+    }
+}
+
+struct SlowNetworkHijack(u32);
+
+impl TransportHijack for SlowNetworkHijack {
+    fn wrapper(&self, input: Box<SimulateTransport>) -> Box<SimulateTransport> {
+        Box::new(SlowNetwork {
+            latency: self.0,
+            transport: input,
+        })
+    }
+}
+
+struct SlowNetwork {
+    latency: u32,
+    transport: Box<SimulateTransport>,
+}
+
+impl SimulateTransport for SlowNetwork {
+    fn send(&self, msg: RaftMessage) -> RaftStoreResult<()> {
+        sleep_ms(self.latency as u64);
+        self.transport.send(msg)
+    }
+}
+
+// struct OutOrder {
+//     transport: Box<SimulateTransport>,
+//     save_for_later: RaftMessage,
+//     future: u32,
+//     current: u32,
+// }
+//
+// impl OutOrder {
+//     fn new(latency: u32, transport: Box<SimulateTransport>) -> OutOrder {
+//         OutOrder {
+//             transport: transport,
+//             save_for_later: RaftMessage::new(),
+//             future: 0,
+//             current: 0,
+//         }
+//     }
+// }
+//
+// impl Transport for OutOrder<T> {
+//     fn send(&self, msg: RaftMessage) -> RaftStoreResult<()> {
+//         if self.future == 0 {
+//             self.future = 1 + rand::random::<u32>() % 10;
+//             self.save_for_later = msg;
+//             return Err(Timeout("transport simulator loss packet".to_string()));
+//         }
+//
+//         let result;
+//         if self.current == self.future {
+//             self.future = 1 + rand::random::<u32>() % 10;
+//             self.current = 0;
+//             result = self.transport.send(self.save_for_later);
+//             self.save_for_later = msg;
+//         }
+//         result
+//     }
+// }
+
+// // use composited transports, which are get by a function of time
+// struct TransportComposite<T: TimingTransportFunc> {
+//     time: u32,
+//     get_transport: T,
+// }
+//
+// impl TransportComposite {
+//     fn new<T: TimingTransportFunc, R: Transport>(func: T) -> TransportComposite<T> {
+//         TransportComposite {
+//             time: 0,
+//             get_transport: func,
+//         }
+//     }
+// }
+//
+// impl Transport for TransportComposite {
+//     fn send(&self, msg: RaftMessage) -> RaftStoreResult<()> {
+//         self.time += 1;
+//         self.get_transport(time).send(msg)
+//     }
+// }
+//
+// trait TransportTimingFunc {
+//     fn get_transport_at_time(time: u32) -> Transport;
+// }


### PR DESCRIPTION
This is the basic framework code.
TransportHijack trait receive a SimulateTransport and return a new SimulateTransport,
which use the underlying SimulateTransport but do some addition work, such as Loss packet,
Timeout, and so on.