### PR TITLE
tests/raftstore: add SimulateTransport for testing bad network traffic

### DIFF
--- a/benches/bin/bench-tikv.rs
+++ b/benches/bin/bench-tikv.rs
@@ -13,6 +13,7 @@
 
 #![feature(plugin)]
 #![feature(test)]
+#![feature(box_syntax)]
 #![cfg_attr(feature = "dev", plugin(clippy))]
 #![cfg_attr(not(feature = "dev"), allow(unknown_lints))]
 #![feature(btree_range, collections_bound)]
@@ -45,6 +46,9 @@ mod server;
 mod pd;
 #[path="../../tests/raftstore/pd_ask.rs"]
 mod pd_ask;
+#[allow(unused)]
+#[path="../../tests/raftstore/transport_simulate.rs"]
+mod transport_simulate;
 
 use test::BenchSamples;
 

--- a/tests/raftstore/mod.rs
+++ b/tests/raftstore/mod.rs
@@ -17,6 +17,7 @@ mod node;
 mod server;
 pub mod pd;
 pub mod pd_ask;
+pub mod transport_simulate;
 
 mod test_single;
 mod test_multi;

--- a/tests/raftstore/test_multi.rs
+++ b/tests/raftstore/test_multi.rs
@@ -17,14 +17,20 @@ use super::util::*;
 use super::cluster::{Cluster, Simulator};
 use super::node::new_node_cluster;
 use super::server::new_server_cluster;
+use super::transport_simulate;
 
 fn test_multi_base<T: Simulator>(cluster: &mut Cluster<T>) {
+    test_multi_with_transport_strategy(cluster, vec![]);
+}
+
+fn test_multi_with_transport_strategy<T: Simulator>(cluster: &mut Cluster<T>,
+                                                    strategy: Vec<transport_simulate::Strategy>) {
     // init_log();
 
     // test a cluster with five nodes [1, 5], only one region (region 1).
     // every node has a store and a peer with same id as node's.
     cluster.bootstrap_region().expect("");
-    cluster.start();
+    cluster.start_with_strategy(strategy);
 
     let (key, value) = (b"a1", b"v1");
 
@@ -49,7 +55,6 @@ fn test_multi_base<T: Simulator>(cluster: &mut Cluster<T>) {
 
     // TODO add stale epoch test cases.
 }
-
 
 fn test_multi_leader_crash<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.bootstrap_region().expect("");
@@ -129,10 +134,40 @@ fn test_multi_node_base() {
 }
 
 #[test]
+fn test_multi_node_latency() {
+    let count = 5;
+    let mut cluster = new_node_cluster(0, count);
+    test_multi_with_transport_strategy(&mut cluster, vec![transport_simulate::Strategy::Delay(10)]);
+}
+
+#[test]
+fn test_multi_node_drop_packet() {
+    let count = 5;
+    let mut cluster = new_node_cluster(0, count);
+    test_multi_with_transport_strategy(&mut cluster,
+                                       vec![transport_simulate::Strategy::DropPacket(40)]);
+}
+
+#[test]
 fn test_multi_server_base() {
     let count = 5;
     let mut cluster = new_server_cluster(0, count);
     test_multi_base(&mut cluster)
+}
+
+#[test]
+fn test_multi_server_latency() {
+    let count = 5;
+    let mut cluster = new_server_cluster(0, count);
+    test_multi_with_transport_strategy(&mut cluster, vec![transport_simulate::Strategy::Delay(10)]);
+}
+
+#[test]
+fn test_multi_server_drop_packet() {
+    let count = 5;
+    let mut cluster = new_server_cluster(0, count);
+    test_multi_with_transport_strategy(&mut cluster,
+                                       vec![transport_simulate::Strategy::DropPacket(40)]);
 }
 
 #[test]

--- a/tests/raftstore/transport_simulate.rs
+++ b/tests/raftstore/transport_simulate.rs
@@ -1,0 +1,124 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use kvproto::raft_serverpb::RaftMessage;
+use tikv::raftstore::Result;
+use tikv::raftstore::store::Transport;
+use rand;
+use std::sync::{Arc, RwLock};
+
+use super::util::*;
+use self::Strategy::*;
+
+#[derive(Clone)]
+pub enum Strategy {
+    DropPacket(u32),
+    Delay(u64),
+    OutOfOrder,
+}
+
+trait Filter: Send + Sync {
+    // in a SimulateTransport, if any filter's before return true, msg will be discard
+    fn before(&self, msg: &RaftMessage) -> bool;
+    // with after provided, one can change the return value arbitrarily
+    fn after(&self, Result<()>) -> Result<()>;
+}
+
+struct FilterDropPacket {
+    rate: u32,
+}
+
+struct FilterDelay {
+    duration: u64,
+}
+
+struct FilterOutOfOrder;
+
+impl Filter for FilterDropPacket {
+    fn before(&self, _: &RaftMessage) -> bool {
+        rand::random::<u32>() % 100u32 < self.rate
+    }
+    fn after(&self, x: Result<()>) -> Result<()> {
+        x
+    }
+}
+
+impl Filter for FilterDelay {
+    fn before(&self, _: &RaftMessage) -> bool {
+        sleep_ms(self.duration);
+        false
+    }
+    fn after(&self, x: Result<()>) -> Result<()> {
+        x
+    }
+}
+
+impl Filter for FilterOutOfOrder {
+    fn before(&self, _: &RaftMessage) -> bool {
+        unimplemented!()
+    }
+    fn after(&self, _: Result<()>) -> Result<()> {
+        unimplemented!()
+    }
+}
+
+pub struct SimulateTransport<T: Transport> {
+    filters: Vec<Box<Filter>>,
+    trans: Arc<RwLock<T>>,
+}
+
+impl<T: Transport> SimulateTransport<T> {
+    pub fn new(strategy: Vec<Strategy>, trans: Arc<RwLock<T>>) -> SimulateTransport<T> {
+        let mut filters: Vec<Box<Filter>> = vec![];
+        for s in strategy {
+            match s {
+                DropPacket(rate) => {
+                    filters.push(box FilterDropPacket { rate: rate });
+                }
+                Delay(latency) => {
+                    filters.push(box FilterDelay { duration: latency });
+                }
+                OutOfOrder => {
+                    filters.push(box FilterOutOfOrder);
+                }
+            }
+        }
+
+        SimulateTransport {
+            filters: filters,
+            trans: trans,
+        }
+    }
+}
+
+impl<T: Transport> Transport for SimulateTransport<T> {
+    fn send(&self, msg: RaftMessage) -> Result<()> {
+        let mut discard = false;
+        for strategy in &self.filters {
+            if strategy.before(&msg) {
+                discard = true;
+            }
+        }
+
+        let mut res = Ok(());
+        if !discard {
+            res = self.trans.read().unwrap().send(msg);
+        }
+
+        for strategy in self.filters.iter().rev() {
+            res = strategy.after(res);
+        }
+
+        res
+    }
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -15,6 +15,7 @@
 #![cfg_attr(feature = "dev", plugin(clippy))]
 #![cfg_attr(not(feature = "dev"), allow(unknown_lints))]
 #![feature(btree_range, collections_bound)]
+#![feature(box_syntax)]
 #![allow(new_without_default)]
 
 #[macro_use]


### PR DESCRIPTION
SimulateTransport has a bundle of filters, while will do some addition work
before call the the underlying Transport to simulate bad network traffic,
such as Loss packet, Timeout, and so on.