### PR TITLE
raftstore: add cost for call command failed.

### DIFF
--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -15,7 +15,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use rocksdb::DB;
 use tempdir::TempDir;
@@ -127,7 +127,11 @@ impl<T: Simulator> Cluster<T> {
                         request: RaftCmdRequest,
                         timeout: Duration)
                         -> Result<RaftCmdResponse> {
-        self.sim.rl().call_command(request, timeout)
+        let t = Instant::now();
+        self.sim
+            .rl()
+            .call_command(request, timeout)
+            .map_err(|e| box_err!("call command failed {:?}, cost {:?}", e, t.elapsed()))
     }
 
     pub fn call_command_on_leader(&mut self,


### PR DESCRIPTION
add a time cost error to check whether `resource temporary Unavailable` is caused by timeout or not. 

Now if we send a command to a not leader peer, the connection will be hung up then meet a timeout error. How do we handle this case in test?

@ngaut @BusyJay  