### PR TITLE
*: fix pd alloc ID failed.

### DIFF
--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -310,7 +310,7 @@ mod tests {
     #[test]
     fn test_pd_client() {
         let mut client = Client::new(MockRpcClient).unwrap();
-        assert_eq!(client.alloc_id(1).unwrap(), 42u64);
+        assert_eq!(client.alloc_id(1).unwrap(), 42);
         assert!(client.is_cluster_bootstrapped(1).is_err());
 
         let mut store = metapb::Store::new();

--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -310,7 +310,7 @@ mod tests {
     #[test]
     fn test_pd_client() {
         let mut client = Client::new(MockRpcClient).unwrap();
-        assert_eq!(client.alloc_id().unwrap(), 42u64);
+        assert_eq!(client.alloc_id(1).unwrap(), 42u64);
         assert!(client.is_cluster_bootstrapped(1).is_err());
 
         let mut store = metapb::Store::new();

--- a/src/pd/mod.rs
+++ b/src/pd/mod.rs
@@ -55,7 +55,7 @@ pub trait PdClient: Send + Sync {
     fn is_cluster_bootstrapped(&self, cluster_id: u64) -> Result<bool>;
 
     // Allocate a unique positive id.
-    fn alloc_id(&mut self) -> Result<u64>;
+    fn alloc_id(&mut self, cluster_id: u64) -> Result<u64>;
 
     // When the store starts, or some store information changed, it
     // uses put_store to inform pd.

--- a/src/pd/protocol.rs
+++ b/src/pd/protocol.rs
@@ -42,8 +42,8 @@ impl<T: TRpcClient + 'static> super::PdClient for Client<T> {
         Ok(resp.get_is_bootstrapped().get_bootstrapped())
     }
 
-    fn alloc_id(&mut self) -> Result<u64> {
-        let mut req = new_request(0, pdpb::CommandType::AllocId);
+    fn alloc_id(&mut self, cluster_id: u64) -> Result<u64> {
+        let mut req = new_request(cluster_id, pdpb::CommandType::AllocId);
         req.set_alloc_id(pdpb::AllocIdRequest::new());
 
         let resp = try!(self.send(&req));

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -143,8 +143,13 @@ impl<T, Trans> Node<T, Trans>
         Ok(store_id)
     }
 
+    fn alloc_id(&self) -> Result<u64> {
+        let id = try!(self.pd_client.wl().alloc_id(self.cluster_id));
+        Ok(id)
+    }
+
     fn bootstrap_store(&self, engine: &DB) -> Result<u64> {
-        let store_id = try!(self.pd_client.wl().alloc_id());
+        let store_id = try!(self.alloc_id());
         debug!("alloc store id {} ", store_id);
 
         try!(store::bootstrap_store(engine, self.cluster_id, store_id));
@@ -153,12 +158,12 @@ impl<T, Trans> Node<T, Trans>
     }
 
     fn bootstrap_first_region(&self, engine: &DB, store_id: u64) -> Result<metapb::Region> {
-        let region_id = try!(self.pd_client.wl().alloc_id());
+        let region_id = try!(self.alloc_id());
         info!("alloc first region id {} for cluster {}, store {}",
               region_id,
               self.cluster_id,
               store_id);
-        let peer_id = try!(self.pd_client.wl().alloc_id());
+        let peer_id = try!(self.alloc_id());
         info!("alloc first peer id {} for first region {}",
               peer_id,
               region_id);

--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -420,12 +420,12 @@ impl<T: Simulator> Cluster<T> {
     }
 
     pub fn split_region(&mut self, region_id: u64, split_key: Option<Vec<u8>>) {
-        let new_region_id = self.pd_client.wl().alloc_id().unwrap();
+        let new_region_id = self.pd_client.wl().alloc_id(0).unwrap();
         let region = self.pd_client.rl().get_region_by_id(self.id(), region_id).unwrap();
         let peer_count = region.get_peers().len();
         let mut peer_ids: Vec<u64> = vec![];
         for _ in 0..peer_count {
-            let peer_id = self.pd_client.wl().alloc_id().unwrap();
+            let peer_id = self.pd_client.wl().alloc_id(0).unwrap();
             peer_ids.push(peer_id);
         }
 

--- a/tests/raftstore/pd.rs
+++ b/tests/raftstore/pd.rs
@@ -152,6 +152,7 @@ impl Cluster {
 }
 
 pub struct TestPdClient {
+    // TODO: use only one cluster later.
     clusters: HashMap<u64, Cluster>,
 
     base_id: u64,
@@ -226,7 +227,8 @@ impl PdClient for TestPdClient {
         Ok(self.clusters.contains_key(&cluster_id))
     }
 
-    fn alloc_id(&mut self) -> Result<u64> {
+    // We don't care cluster id here, so any value like 0 in tests is ok.
+    fn alloc_id(&mut self, _: u64) -> Result<u64> {
         self.base_id += 1;
         Ok(self.base_id)
     }

--- a/tests/raftstore/pd_ask.rs
+++ b/tests/raftstore/pd_ask.rs
@@ -100,7 +100,7 @@ impl<T: Simulator> AskHandler<T> {
             }
 
             let store = &stores[pos.unwrap()];
-            let peer_id = self.pd_client.wl().alloc_id().unwrap();
+            let peer_id = self.pd_client.wl().alloc_id(0).unwrap();
             let peer = new_peer(store.get_id(), peer_id);
             (ConfChangeType::AddNode, peer)
         };
@@ -133,10 +133,10 @@ impl<T: Simulator> AskHandler<T> {
             return;
         }
 
-        let new_region_id = self.pd_client.wl().alloc_id().unwrap();
+        let new_region_id = self.pd_client.wl().alloc_id(0).unwrap();
         let mut peer_ids: Vec<u64> = vec![];
         for _ in 0..region.get_peers().len() {
-            let peer_id = self.pd_client.wl().alloc_id().unwrap();
+            let peer_id = self.pd_client.wl().alloc_id(0).unwrap();
             peer_ids.push(peer_id);
         }
 

--- a/tests/raftstore/test_conf_change.rs
+++ b/tests/raftstore/test_conf_change.rs
@@ -170,7 +170,7 @@ fn test_simple_conf_change<T: Simulator>(cluster: &mut Cluster<T>) {
 fn new_conf_change_peer(store: &metapb::Store,
                         pd_client: &Arc<RwLock<TestPdClient>>)
                         -> metapb::Peer {
-    let peer_id = pd_client.wl().alloc_id().unwrap();
+    let peer_id = pd_client.wl().alloc_id(0).unwrap();
     new_peer(store.get_id(), peer_id)
 }
 


### PR DESCRIPTION
Now pd only supports one cluster, so all our commands should take cluster id.

@ngaut @BusyJay @qiuyesuifeng 