### PR TITLE
tests/raftstore: rename panic api put/delete/seek etc to must_xxx

### DIFF
--- a/benches/bin/raftstore.rs
+++ b/benches/bin/raftstore.rs
@@ -12,8 +12,6 @@
 // limitations under the License.
 
 use test::BenchSamples;
-use rocksdb::Writable;
-
 use test_util::*;
 use util::*;
 use cluster::*;
@@ -42,7 +40,7 @@ fn bench_set<T: Simulator>(mut cluster: Cluster<T>, value_size: usize) -> BenchS
 
     bench!{
             let (k, v) = kvs.next().unwrap();
-            cluster.put(&k, &v)
+            cluster.must_put(&k, &v)
     }
 }
 
@@ -72,7 +70,7 @@ fn bench_seek<T: Simulator>(mut cluster: Cluster<T>) -> BenchSamples {
 
     bench!{
             let k = keys.next().unwrap();
-            cluster.seek(&k)
+            cluster.must_seek(&k)
     }
 }
 
@@ -87,7 +85,7 @@ fn bench_delete<T: Simulator>(mut cluster: Cluster<T>) -> BenchSamples {
 
     bench!{
             let k = keys.next().unwrap();
-            cluster.delete(&k)
+            cluster.must_delete(&k)
     }
 }
 

--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -361,7 +361,7 @@ impl<T: Simulator> Cluster<T> {
         }
     }
 
-    pub fn put(&mut self, key: &[u8], value: &[u8]) {
+    pub fn must_put(&mut self, key: &[u8], value: &[u8]) {
         let resp = self.request(key, vec![new_put_cmd(key, value)], Duration::from_secs(3));
         if resp.get_header().has_error() {
             panic!("response {:?} has error", resp);
@@ -370,7 +370,7 @@ impl<T: Simulator> Cluster<T> {
         assert_eq!(resp.get_responses()[0].get_cmd_type(), CmdType::Put);
     }
 
-    pub fn seek(&mut self, key: &[u8]) -> Option<(Vec<u8>, Vec<u8>)> {
+    pub fn must_seek(&mut self, key: &[u8]) -> Option<(Vec<u8>, Vec<u8>)> {
         let resp = self.request(key, vec![new_seek_cmd(key)], Duration::from_secs(3));
         if resp.get_header().has_error() {
             panic!("response {:?} has error", resp);
@@ -385,7 +385,7 @@ impl<T: Simulator> Cluster<T> {
         }
     }
 
-    pub fn delete(&mut self, key: &[u8]) {
+    pub fn must_delete(&mut self, key: &[u8]) {
         let resp = self.request(key, vec![new_delete_cmd(key)], Duration::from_secs(3));
         if resp.get_header().has_error() {
             panic!("response {:?} has error", resp);

--- a/tests/raftstore/test_compact_log.rs
+++ b/tests/raftstore/test_compact_log.rs
@@ -42,7 +42,7 @@ fn test_compact_log<T: Simulator>(cluster: &mut Cluster<T>) {
         let (k, v) = (format!("key{}", i), format!("value{}", i));
         let key = k.as_bytes();
         let value = v.as_bytes();
-        cluster.put(key, value);
+        cluster.must_put(key, value);
         let v = cluster.get(key);
         assert_eq!(v, Some(value.to_vec()));
     }
@@ -73,7 +73,7 @@ fn test_compact_limit<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.bootstrap_region().expect("");
     cluster.start();
 
-    cluster.put(b"a1", b"v1");
+    cluster.must_put(b"a1", b"v1");
 
     let mut before_states = HashMap::new();
 
@@ -91,7 +91,7 @@ fn test_compact_limit<T: Simulator>(cluster: &mut Cluster<T>) {
     for i in 1..300 {
         let k = i.to_string().into_bytes();
         let v = k.clone();
-        cluster.put(&k, &v);
+        cluster.must_put(&k, &v);
         let v2 = cluster.get(&k);
         assert_eq!(v2, Some(v));
     }
@@ -113,7 +113,7 @@ fn test_compact_limit<T: Simulator>(cluster: &mut Cluster<T>) {
     for i in 300..600 {
         let k = i.to_string().into_bytes();
         let v = k.clone();
-        cluster.put(&k, &v);
+        cluster.must_put(&k, &v);
         let v2 = cluster.get(&k);
         assert_eq!(v2, Some(v));
     }

--- a/tests/raftstore/test_conf_change.rs
+++ b/tests/raftstore/test_conf_change.rs
@@ -36,7 +36,7 @@ fn test_simple_conf_change<T: Simulator>(cluster: &mut Cluster<T>) {
     // Now region 1 only has peer (1, 1, 1);
     let (key, value) = (b"a1", b"v1");
 
-    cluster.put(key, value);
+    cluster.must_put(key, value);
     assert_eq!(cluster.get(key), Some(value.to_vec()));
 
     let engine_2 = cluster.get_engine(2);
@@ -45,7 +45,7 @@ fn test_simple_conf_change<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.change_peer(r1, ConfChangeType::AddNode, new_peer(2, 2));
 
     let (key, value) = (b"a2", b"v2");
-    cluster.put(key, value);
+    cluster.must_put(key, value);
     assert_eq!(cluster.get(key), Some(value.to_vec()));
 
     // now peer 2 must have v1 and v2;
@@ -92,7 +92,7 @@ fn test_simple_conf_change<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.change_peer(r1, ConfChangeType::RemoveNode, new_peer(2, 2));
 
     let (key, value) = (b"a3", b"v3");
-    cluster.put(key, value);
+    cluster.must_put(key, value);
     assert_eq!(cluster.get(key), Some(value.to_vec()));
     // now peer 3 must have v1, v2 and v3
     let engine_3 = cluster.get_engine(3);
@@ -134,7 +134,7 @@ fn test_simple_conf_change<T: Simulator>(cluster: &mut Cluster<T>) {
 
     // Force update a2 to check whether peer 2 added ok and received the snapshot.
     let (key, value) = (b"a2", b"v2");
-    cluster.put(key, value);
+    cluster.must_put(key, value);
     assert_eq!(cluster.get(key), Some(value.to_vec()));
 
     let engine_2 = cluster.get_engine(2);
@@ -152,7 +152,7 @@ fn test_simple_conf_change<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.change_peer(r1, ConfChangeType::RemoveNode, new_peer(3, 3));
 
     let (key, value) = (b"a4", b"v4");
-    cluster.put(key, value);
+    cluster.must_put(key, value);
     assert_eq!(cluster.get(key), Some(value.to_vec()));
     // now peer 4 in store 2 must have v1, v2, v3, v4, we check v1 and v4 here.
     let engine_2 = cluster.get_engine(2);
@@ -196,7 +196,7 @@ fn test_pd_conf_change<T: Simulator>(cluster: &mut Cluster<T>) {
     // Now the first store has first region. others have none.
 
     let (key, value) = (b"a1", b"v1");
-    cluster.put(key, value);
+    cluster.must_put(key, value);
     assert_eq!(cluster.get(key), Some(value.to_vec()));
 
     let peer2 = new_conf_change_peer(&stores[1], &pd_client);
@@ -206,7 +206,7 @@ fn test_pd_conf_change<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.change_peer(region_id, ConfChangeType::AddNode, peer2.clone());
 
     let (key, value) = (b"a2", b"v2");
-    cluster.put(key, value);
+    cluster.must_put(key, value);
     assert_eq!(cluster.get(key), Some(value.to_vec()));
 
     // now peer 2 must have v1 and v2;
@@ -220,7 +220,7 @@ fn test_pd_conf_change<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.change_peer(region_id, ConfChangeType::RemoveNode, peer2.clone());
 
     let (key, value) = (b"a3", b"v3");
-    cluster.put(key, value);
+    cluster.must_put(key, value);
     assert_eq!(cluster.get(key), Some(value.to_vec()));
     // now peer 3 must have v1, v2 and v3
     let engine_3 = cluster.get_engine(peer3.get_store_id());
@@ -238,7 +238,7 @@ fn test_pd_conf_change<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.change_peer(region_id, ConfChangeType::RemoveNode, peer3.clone());
 
     let (key, value) = (b"a4", b"v4");
-    cluster.put(key, value);
+    cluster.must_put(key, value);
     assert_eq!(cluster.get(key), Some(value.to_vec()));
     // now peer4 must have v1, v2, v3, v4, we check v1 and v4 here.
     let engine_2 = cluster.get_engine(peer4.get_store_id());
@@ -315,7 +315,7 @@ fn test_auto_adjust_replica<T: Simulator>(cluster: &mut Cluster<T>) {
     wait_till_reach_count(pd_client.clone(), cluster_id, region_id, 5);
 
     let (key, value) = (b"a1", b"v1");
-    cluster.put(key, value);
+    cluster.must_put(key, value);
     assert_eq!(cluster.get(key), Some(value.to_vec()));
 
     region = pd_client.rl().get_region_by_id(cluster_id, region_id).unwrap();

--- a/tests/raftstore/test_multi.rs
+++ b/tests/raftstore/test_multi.rs
@@ -38,7 +38,7 @@ fn test_multi_with_transport_strategy<T: Simulator>(cluster: &mut Cluster<T>,
 
     let (key, value) = (b"a1", b"v1");
 
-    cluster.put(key, value);
+    cluster.must_put(key, value);
     assert_eq!(cluster.get(key), Some(value.to_vec()));
 
     let check_res = cluster.check_quorum(|engine| {
@@ -49,7 +49,7 @@ fn test_multi_with_transport_strategy<T: Simulator>(cluster: &mut Cluster<T>,
     });
     assert!(check_res);
 
-    cluster.delete(key);
+    cluster.must_delete(key);
     assert_eq!(cluster.get(key), None);
 
     let check_res = cluster.check_quorum(|engine| {
@@ -66,7 +66,7 @@ fn test_multi_leader_crash<T: Simulator>(cluster: &mut Cluster<T>) {
 
     let (key1, value1) = (b"a1", b"v1");
 
-    cluster.put(key1, value1);
+    cluster.must_put(key1, value1);
 
     let last_leader = cluster.leader_of_region(1).unwrap();
     cluster.stop_node(last_leader.get_store_id());
@@ -80,8 +80,8 @@ fn test_multi_leader_crash<T: Simulator>(cluster: &mut Cluster<T>) {
 
     let (key2, value2) = (b"a2", b"v2");
 
-    cluster.put(key2, value2);
-    cluster.delete(key1);
+    cluster.must_put(key2, value2);
+    cluster.must_delete(key1);
     must_get_none(&cluster.engines[&last_leader.get_store_id()], key2);
     must_get_equal(&cluster.engines[&last_leader.get_store_id()], key1, value1);
 
@@ -100,7 +100,7 @@ fn test_multi_cluster_restart<T: Simulator>(cluster: &mut Cluster<T>) {
     let (key, value) = (b"a1", b"v1");
 
     assert_eq!(cluster.get(key), None);
-    cluster.put(key, value);
+    cluster.must_put(key, value);
 
     assert_eq!(cluster.get(key), Some(value.to_vec()));
 
@@ -139,7 +139,7 @@ fn test_multi_random_restart<T: Simulator>(cluster: &mut Cluster<T>,
     let (key, value) = (b"a1", b"v1");
 
     assert_eq!(cluster.get(key), None);
-    cluster.put(key, value);
+    cluster.must_put(key, value);
     assert_eq!(cluster.get(key), Some(value.to_vec()));
 
     let mut rng = rand::thread_rng();
@@ -155,9 +155,9 @@ fn test_multi_random_restart<T: Simulator>(cluster: &mut Cluster<T>,
 
         let (k, v) = (b"a2", b"v2");
         // assert_eq!(cluster.get(k), None);
-        cluster.put(k, v);
+        cluster.must_put(k, v);
         assert_eq!(cluster.get(k), Some(v.to_vec()));
-        cluster.delete(k);
+        cluster.must_delete(k);
         assert_eq!(cluster.get(k), None);
     }
 }

--- a/tests/raftstore/test_single.rs
+++ b/tests/raftstore/test_single.rs
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 use super::cluster::{Cluster, Simulator};
-use tikv::raftstore::store::*;
 use super::node::new_node_cluster;
 use super::server::new_server_cluster;
 
@@ -26,7 +25,7 @@ fn test_put<T: Simulator>(cluster: &mut Cluster<T>) {
         let (k, v) = (format!("key{}", i), format!("value{}", i));
         let key = k.as_bytes();
         let value = v.as_bytes();
-        cluster.put(key, value);
+        cluster.must_put(key, value);
         let v = cluster.get(key);
         assert_eq!(v, Some(value.to_vec()));
     }
@@ -35,7 +34,7 @@ fn test_put<T: Simulator>(cluster: &mut Cluster<T>) {
         let (k, v) = (format!("key{}", i), format!("value{}", i + 1));
         let key = k.as_bytes();
         let value = v.as_bytes();
-        cluster.put(key, value);
+        cluster.must_put(key, value);
         let v = cluster.get(key);
         assert_eq!(v, Some(value.to_vec()));
     }
@@ -49,7 +48,7 @@ fn test_delete<T: Simulator>(cluster: &mut Cluster<T>) {
         let (k, v) = (format!("key{}", i), format!("value{}", i));
         let key = k.as_bytes();
         let value = v.as_bytes();
-        cluster.put(key, value);
+        cluster.must_put(key, value);
         let v = cluster.get(key);
         assert_eq!(v, Some(value.to_vec()));
     }
@@ -57,7 +56,7 @@ fn test_delete<T: Simulator>(cluster: &mut Cluster<T>) {
     for i in 1..1000 {
         let k = format!("key{}", i);
         let key = k.as_bytes();
-        cluster.delete(key);
+        cluster.must_delete(key);
         assert!(cluster.get(key).is_none());
     }
 }
@@ -70,13 +69,13 @@ fn test_seek<T: Simulator>(cluster: &mut Cluster<T>) {
         let (k, v) = (format!("key{}", i), format!("value{}", i));
         let key = k.as_bytes();
         let value = v.as_bytes();
-        cluster.put(key, value);
+        cluster.must_put(key, value);
     }
 
     for i in 0..100 {
         let k = format!("key{:03}", i);
         let key = k.as_bytes();
-        let (k, v) = cluster.seek(key).unwrap();
+        let (k, v) = cluster.must_seek(key).unwrap();
         assert_eq!(k, b"key100");
         assert_eq!(v, b"value100");
     }
@@ -85,7 +84,7 @@ fn test_seek<T: Simulator>(cluster: &mut Cluster<T>) {
         let (k, v) = (format!("key{}", i), format!("value{}", i));
         let key = k.as_bytes();
         let value = v.as_bytes();
-        let (sk, sv) = cluster.seek(key).unwrap();
+        let (sk, sv) = cluster.must_seek(key).unwrap();
         assert_eq!(sk, key);
         assert_eq!(sv, value);
     }
@@ -93,10 +92,10 @@ fn test_seek<T: Simulator>(cluster: &mut Cluster<T>) {
     for i in 200..300 {
         let k = format!("key{}", i);
         let key = k.as_bytes();
-        assert!(cluster.seek(key).is_none());
+        assert!(cluster.must_seek(key).is_none());
     }
 
-    assert!(cluster.seek(b"key2").is_none(),
+    assert!(cluster.must_seek(b"key2").is_none(),
             "seek should follow binary order");
 }
 

--- a/tests/raftstore/test_split_region.rs
+++ b/tests/raftstore/test_split_region.rs
@@ -40,12 +40,12 @@ fn test_base_split_region<T: Simulator>(cluster: &mut Cluster<T>) {
     let region = pd_client.rl().get_region(cluster_id, b"").unwrap();
 
     let a1 = b"a1";
-    cluster.put(a1, b"v1");
+    cluster.must_put(a1, b"v1");
 
     let a2 = b"a2";
 
     let a3 = b"a3";
-    cluster.put(a3, b"v3");
+    cluster.must_put(a3, b"v3");
 
     // Split with a2, so a1 must in left, and a3 in right.
     cluster.split_region(region.get_id(), Some(a2.to_vec()));
@@ -58,10 +58,10 @@ fn test_base_split_region<T: Simulator>(cluster: &mut Cluster<T>) {
     assert_eq!(left.get_end_key(), right.get_start_key());
     assert_eq!(region.get_end_key(), right.get_end_key());
 
-    cluster.put(a1, b"vv1");
+    cluster.must_put(a1, b"vv1");
     assert_eq!(cluster.get(a1).unwrap(), b"vv1".to_vec());
 
-    cluster.put(a3, b"vv3");
+    cluster.must_put(a3, b"vv3");
     assert_eq!(cluster.get(a3).unwrap(), b"vv3".to_vec());
 
     let epoch = left.get_region_epoch().clone();
@@ -98,7 +98,7 @@ fn put_till_size<T: Simulator>(cluster: &mut Cluster<T>,
         let key = range.next().unwrap().to_string().into_bytes();
         let mut value = vec![0; 64];
         rng.fill_bytes(&mut value);
-        cluster.put(&key, &value);
+        cluster.must_put(&key, &value);
         // plus 1 for the extra encoding prefix
         len += key.len() as u64 + 1;
         len += value.len() as u64;
@@ -204,10 +204,10 @@ fn test_delay_split_region<T: Simulator>(cluster: &mut Cluster<T>) {
     let region = pd_client.rl().get_region(cluster_id, b"").unwrap();
 
     let a1 = b"a1";
-    cluster.put(a1, b"v1");
+    cluster.must_put(a1, b"v1");
 
     let a3 = b"a3";
-    cluster.put(a3, b"v3");
+    cluster.must_put(a3, b"v3");
 
     // check all nodes apply the logs.
     for i in 0..3 {
@@ -235,7 +235,7 @@ fn test_delay_split_region<T: Simulator>(cluster: &mut Cluster<T>) {
     util::sleep_ms(3000);
 
     let a4 = b"a4";
-    cluster.put(a4, b"v4");
+    cluster.must_put(a4, b"v4");
 
     assert_eq!(cluster.get(a4).unwrap(), b"v4".to_vec());
 

--- a/tests/raftstore/test_tombstone.rs
+++ b/tests/raftstore/test_tombstone.rs
@@ -33,7 +33,7 @@ fn test_tombstone<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.change_peer(r1, ConfChangeType::AddNode, new_peer(2, 2));
 
     let (key, value) = (b"a1", b"v1");
-    cluster.put(key, value);
+    cluster.must_put(key, value);
     assert_eq!(cluster.get(key), Some(value.to_vec()));
 
     let engine_2 = cluster.get_engine(2);
@@ -51,7 +51,7 @@ fn test_tombstone<T: Simulator>(cluster: &mut Cluster<T>) {
     // After new leader is elected, the change peer must be finished.
     cluster.leader_of_region(1).unwrap();
     let (key, value) = (b"a3", b"v3");
-    cluster.put(key, value);
+    cluster.must_put(key, value);
     assert_eq!(cluster.get(key), Some(value.to_vec()));
 
     let engine_2 = cluster.get_engine(2);


### PR DESCRIPTION
error is usual in a distribute system. if we panic on error, we name
the api must_xxx, so caller won't get a surprise on that behavior.