### PR TITLE
[DNM] remove snapshot connection after timeout.

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -125,6 +125,12 @@ pub enum Msg {
     },
 }
 
+pub enum Tick {
+    GcConn {
+        token: Token,
+    },
+}
+
 #[derive(Debug)]
 pub struct SendCh {
     ch: mio::Sender<Msg>,


### PR DESCRIPTION
After #467 

We can't close snapshot connection directly after sending OK, because the data may not be sent to remote now, even when using flush.

I tried to close the socket after receiving the snapshot, but still can't pass CI in linux. Strangely, I will see it later.

So now I use a gc timeout simply, after sending OK, wait sometime and then remove the snapshot connection, this may pass CI(maybe). But I think this is not a good way, I will improve it later. 

@ngaut @BusyJay @disksing @qiuyesuifeng @tiancaiamao 