### PR TITLE
*: use shutdown to close snapshot conn gracefully.

### DIFF
--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -61,6 +61,10 @@ fn try_read_data<T: TryRead, B: MutBuf>(r: &mut T, buf: &mut B) -> Result<()> {
     unsafe {
         // header is not full read, we will try read more.
         if let Some(n) = try!(r.try_read(buf.mut_bytes())) {
+            if n == 0 {
+                // 0 means remote has closed the socket.
+                return Err(box_err!("remote has closed the connection"));
+            }
             buf.advance(n)
         }
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -119,10 +119,6 @@ pub enum Msg {
         sock_addr: SocketAddr,
         data: ConnData,
     },
-    SnapToken {
-        store_id: u64,
-        token: Token,
-    },
 }
 
 #[derive(Debug)]

--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -110,10 +110,9 @@ impl<T: Simulator> Cluster<T> {
     }
 
     pub fn start_with_strategy(&mut self, strategy: Vec<Strategy>) {
+        let mut sim = self.sim.wl();
         for engine in &self.dbs {
-            let node_id = self.sim
-                              .wl()
-                              .run_node(0, self.cfg.clone(), engine.clone(), strategy.clone());
+            let node_id = sim.run_node(0, self.cfg.clone(), engine.clone(), strategy.clone());
             self.engines.insert(node_id, engine.clone());
         }
     }
@@ -413,8 +412,8 @@ impl<T: Simulator> Cluster<T> {
                                             new_change_peer_cmd(change_type, peer));
         let resp = self.call_command_on_leader(region_id, change_peer, Duration::from_secs(3))
                        .unwrap();
-        assert_eq!(resp.get_admin_response().get_cmd_type(),
-                   AdminCmdType::ChangePeer);
+        assert!(resp.get_admin_response().get_cmd_type() == AdminCmdType::ChangePeer,
+                format!("{:?}", resp));
 
         let region = resp.get_admin_response().get_change_peer().get_region();
         self.pd_client.wl().change_peer(self.id(), region.clone()).unwrap();


### PR DESCRIPTION
We can use shutdown write first after receiving the whole snapshot, see http://www.gnu.org/software/libc/manual/html_node/Closing-a-Socket.html .

@ngaut @BusyJay @disksing @tiancaiamao 


