### PR TITLE
tests/raftstore: try to fix a not leader error case

### DIFF
--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -302,7 +302,8 @@ impl<T: Simulator> Cluster<T> {
 
         let err = err.get_not_leader();
         if !err.has_leader() {
-            return false;
+            self.reset_leader_of_region(region_id);
+            return true;
         }
         self.leaders.insert(region_id, err.get_leader().clone());
         true


### PR DESCRIPTION
cluster cache leader for regions.
request() will call_command_on_leader() which give priority to cached leader.
result in refresh_leader_if_needed() never cover some case.

for example, old leader partition with minority nodes, when I call
request(), the code goes to refresh_leader_if_needed() but never refresh anything