### PR TITLE
tests/raftstore: add a retry argument for call_command_on_leader

### DIFF
--- a/tests/raftstore/test_conf_change.rs
+++ b/tests/raftstore/test_conf_change.rs
@@ -66,7 +66,7 @@ fn test_simple_conf_change<T: Simulator>(cluster: &mut Cluster<T>) {
                                         &epoch,
                                         new_change_peer_cmd(ConfChangeType::AddNode,
                                                             new_peer(2, 2)));
-    let resp = cluster.call_command_on_leader(1, change_peer, Duration::from_secs(3)).unwrap();
+    let resp = cluster.call_command_on_leader(1, change_peer, Duration::from_secs(3), 300).unwrap();
     assert!(resp.get_header().has_error(),
             "we can't add same peer twice");
 
@@ -78,7 +78,7 @@ fn test_simple_conf_change<T: Simulator>(cluster: &mut Cluster<T>) {
                                         &stale_epoch,
                                         new_change_peer_cmd(ConfChangeType::AddNode,
                                                             new_peer(5, 5)));
-    let resp = cluster.call_command_on_leader(1, change_peer, Duration::from_secs(3)).unwrap();
+    let resp = cluster.call_command_on_leader(1, change_peer, Duration::from_secs(3), 300).unwrap();
     assert!(resp.get_header().has_error(),
             "We can't change peer with stale epoch");
 
@@ -114,7 +114,7 @@ fn test_simple_conf_change<T: Simulator>(cluster: &mut Cluster<T>) {
                                         &epoch,
                                         new_change_peer_cmd(ConfChangeType::RemoveNode,
                                                             new_peer(2, 2)));
-    let resp = cluster.call_command_on_leader(1, change_peer, Duration::from_secs(3)).unwrap();
+    let resp = cluster.call_command_on_leader(1, change_peer, Duration::from_secs(3), 300).unwrap();
     assert!(resp.get_header().has_error(),
             "we can't remove same peer twice");
 
@@ -122,7 +122,7 @@ fn test_simple_conf_change<T: Simulator>(cluster: &mut Cluster<T>) {
                                         &stale_epoch,
                                         new_change_peer_cmd(ConfChangeType::RemoveNode,
                                                             new_peer(3, 3)));
-    let resp = cluster.call_command_on_leader(1, change_peer, Duration::from_secs(3)).unwrap();
+    let resp = cluster.call_command_on_leader(1, change_peer, Duration::from_secs(3), 300).unwrap();
     assert!(resp.get_header().has_error(),
             "We can't change peer with stale epoch");
 

--- a/tests/raftstore/test_split_region.rs
+++ b/tests/raftstore/test_split_region.rs
@@ -67,7 +67,7 @@ fn test_base_split_region<T: Simulator>(cluster: &mut Cluster<T>) {
     let epoch = left.get_region_epoch().clone();
     let get = util::new_request(left.get_id(), epoch, vec![util::new_get_cmd(a3)]);
     let region_id = left.get_id();
-    let resp = cluster.call_command_on_leader(region_id, get, Duration::from_secs(3)).unwrap();
+    let resp = cluster.call_command_on_leader(region_id, get, Duration::from_secs(3), 300).unwrap();
     assert!(resp.get_header().has_error());
     assert!(resp.get_header().get_error().has_key_not_in_region());
 }
@@ -174,7 +174,7 @@ fn test_auto_split_region<T: Simulator>(cluster: &mut Cluster<T>) {
     let epoch = left.get_region_epoch().clone();
     let get = util::new_request(left.get_id(), epoch, vec![util::new_get_cmd(&max_key)]);
     let region_id = left.get_id();
-    let resp = cluster.call_command_on_leader(region_id, get, Duration::from_secs(3)).unwrap();
+    let resp = cluster.call_command_on_leader(region_id, get, Duration::from_secs(3), 300).unwrap();
     assert!(resp.get_header().has_error());
     assert!(resp.get_header().get_error().has_key_not_in_region());
 }


### PR DESCRIPTION
call_command_on_leader actually has two step:
1. get leader
2.call command on leader
with retry_cnt we can control actions of step1