### PR TITLE
*: fix a bug in call_command_on_leader

### DIFF
--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -157,7 +157,7 @@ impl<T: Simulator> Cluster<T> {
             }
             sleep_ms(10);
         }
-        Err(Error::Timeout("can't get leader of region after retry 200 times".to_string()))
+        Err(Error::Other(box_err!("can't get leader of region after retry 200 times")))
     }
 
     pub fn leader_of_region(&mut self, region_id: u64) -> Option<metapb::Peer> {


### PR DESCRIPTION
when it can't get leader of region, it should not return timeout,
otherwise we can't distinguish it with timout error from call_command
the following retry stratage based on timeout error may goes wrong