### PR TITLE
tests/raftstore: refact call_command_on_leader

### DIFF
--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -166,16 +166,16 @@ impl<T: Simulator> Cluster<T> {
         let mut retry_cnt = 0;
         loop {
             let result = self.call_command_on_leader_once(region_id, request.clone(), timeout);
-            if let Ok(resp) = result {
-                if self.refresh_leader_if_needed(&resp, region_id) && retry_cnt < 10 {
-                    retry_cnt += 1;
-                    warn!("seems leader changed, let's retry");
-                    continue;
-                }
-                return Ok(resp);
-            } else {
+            if result.is_err() {
                 return result;
             }
+            let resp = result.unwrap();
+            if self.refresh_leader_if_needed(&resp, region_id) && retry_cnt < 10 {
+                retry_cnt += 1;
+                warn!("seems leader changed, let's retry");
+                continue;
+            }
+            return Ok(resp);
         }
     }
 

--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -170,10 +170,10 @@ impl<T: Simulator> Cluster<T> {
                 if resp.get_header().has_error() && retry_cnt < 10 {
                     retry_cnt += 1;
                     if self.refresh_leader_if_needed(&resp, region_id) {
-                        println!("seems leader changed, let's retry");
+                        warn!("seems leader changed, let's retry");
                         continue;
                     } else if resp.get_header().get_error().has_stale_epoch() {
-                        println!("seems split, let's retry");
+                        warn!("seems split, let's retry");
                         continue;
                     }
                 }

--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -167,12 +167,10 @@ impl<T: Simulator> Cluster<T> {
         loop {
             let result = self.call_command_on_leader_once(region_id, request.clone(), timeout);
             if let Ok(resp) = result {
-                if resp.get_header().has_error() && retry_cnt < 10 {
+                if self.refresh_leader_if_needed(&resp, region_id) && retry_cnt < 10 {
                     retry_cnt += 1;
-                    if self.refresh_leader_if_needed(&resp, region_id) {
-                        warn!("seems leader changed, let's retry");
-                        continue;
-                    }
+                    warn!("seems leader changed, let's retry");
+                    continue;
                 }
                 return Ok(resp);
             } else {

--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -146,11 +146,11 @@ impl<T: Simulator> Cluster<T> {
         self.sim.rl().call_command(request, timeout)
     }
 
-    fn call_command_on_leader_directly(&mut self,
-                                       region_id: u64,
-                                       mut request: RaftCmdRequest,
-                                       timeout: Duration)
-                                       -> Result<RaftCmdResponse> {
+    fn call_command_on_leader_once(&mut self,
+                                   region_id: u64,
+                                   mut request: RaftCmdRequest,
+                                   timeout: Duration)
+                                   -> Result<RaftCmdResponse> {
         if let Some(leader) = self.leader_of_region(region_id) {
             request.mut_header().set_peer(leader);
             return self.call_command(request, timeout);
@@ -165,7 +165,7 @@ impl<T: Simulator> Cluster<T> {
                                   -> Result<RaftCmdResponse> {
         let mut retry_cnt = 0;
         loop {
-            let result = self.call_command_on_leader_directly(region_id, request.clone(), timeout);
+            let result = self.call_command_on_leader_once(region_id, request.clone(), timeout);
             if let Ok(resp) = result {
                 if resp.get_header().has_error() && retry_cnt < 10 {
                     retry_cnt += 1;


### PR DESCRIPTION
auto retry if response has error and the error is caused
by leader change or split