### PR TITLE
server: drop messages and report failed when resolving store address

### DIFF
--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -54,6 +54,11 @@ pub enum Msg {
         to_peer_id: u64,
         status: SnapshotStatus,
     },
+
+    ReportUnreachable {
+        region_id: u64,
+        to_peer_id: u64,
+    },
 }
 
 impl fmt::Debug for Msg {
@@ -69,6 +74,12 @@ impl fmt::Debug for Msg {
                        to_peer_id,
                        region_id,
                        status)
+            }
+            Msg::ReportUnreachable { ref region_id, ref to_peer_id } => {
+                write!(fmt,
+                       "peer {} for region {} is unreachable",
+                       to_peer_id,
+                       region_id)
             }
         }
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -113,11 +113,13 @@ pub enum Msg {
         store_id: u64,
         data: ConnData,
     },
-    // Send data to remote peer with parsed socket address.
-    SendStoreSock {
+    // Resolve store address result.
+    // The data is not None only for sending snapshot data,
+    // other message data is be kept in pending send list.
+    ResolveResult {
         store_id: u64,
-        sock_addr: SocketAddr,
-        data: ConnData,
+        sock_addr: Result<SocketAddr>,
+        data: Option<ConnData>,
     },
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -14,14 +14,15 @@
 use std::thread;
 use std::time::Duration;
 use std::net::SocketAddr;
+use std::fmt::{self, Formatter, Display};
 
 use bytes::ByteBuf;
 use mio::{self, Token, NotifyError};
 use protobuf::Message;
 
-use kvproto::msgpb;
+use kvproto::msgpb::{self, MessageType};
 use util::codec::rpc;
-use kvproto::raftpb::MessageType;
+use kvproto::raftpb::MessageType as RaftMessageType;
 
 pub mod config;
 pub mod errors;
@@ -96,7 +97,42 @@ impl ConnData {
             return false;
         }
 
-        self.msg.get_raft().get_message().get_msg_type() == MessageType::MsgSnapshot
+        self.msg.get_raft().get_message().get_msg_type() == RaftMessageType::MsgSnapshot
+    }
+}
+
+impl Display for ConnData {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self.msg.get_msg_type() {
+            MessageType::Cmd => write!(f, "[{}] raft command request", self.msg_id),
+            MessageType::CmdResp => write!(f, "[{}] raft command response", self.msg_id),
+            MessageType::Raft => {
+                let from_peer = self.msg.get_raft().get_from_peer();
+                let to_peer = self.msg.get_raft().get_to_peer();
+                let msg_type = self.msg.get_raft().get_message().get_msg_type();
+                write!(f,
+                       "[{}] raft {:?} from {:?} to {:?}",
+                       self.msg_id,
+                       msg_type,
+                       from_peer.get_id(),
+                       to_peer.get_id())
+            }
+            MessageType::KvReq => {
+                write!(f,
+                       "[{}] kv command request {:?}",
+                       self.msg_id,
+                       self.msg.get_kv_req().get_field_type())
+            }
+            MessageType::KvResp => {
+                write!(f,
+                       "[{}] kv command resposne {:?}",
+                       self.msg_id,
+                       self.msg.get_kv_resp().get_field_type())
+            }
+            MessageType::CopReq => write!(f, "[{}] coprocessor request", self.msg_id),
+            MessageType::CopResp => write!(f, "[{}] coprocessor response", self.msg_id),
+            MessageType::None => write!(f, "[{}] invalid message", self.msg_id),
+        }
     }
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -114,12 +114,10 @@ pub enum Msg {
         data: ConnData,
     },
     // Resolve store address result.
-    // The data is not None only for sending snapshot data,
-    // other message data is be kept in pending send list.
     ResolveResult {
         store_id: u64,
         sock_addr: Result<SocketAddr>,
-        data: Option<ConnData>,
+        data: ConnData,
     },
 }
 

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -190,6 +190,7 @@ impl<T, Trans> Node<T, Trans>
     }
 
     fn start_store(&mut self, store_id: u64, engine: Arc<DB>) -> Result<()> {
+        info!("start raft store {} thread", store_id);
         let meta = try!(self.pd_client.rl().get_cluster_meta(self.cluster_id));
 
         if self.store_handle.is_some() {
@@ -220,6 +221,7 @@ impl<T, Trans> Node<T, Trans>
     }
 
     fn stop_store(&mut self, store_id: u64) -> Result<()> {
+        info!("stop raft store {} thread", store_id);
         match self.ch.take() {
             None => return Err(box_err!("stop invalid store with id {}", store_id)),
             Some(ch) => try!(ch.send(Msg::Quit)),

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -406,13 +406,14 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver> Server<T, S> {
         // No connection, try to resolve it.
         if self.store_resolving.contains(&store_id) {
             // If we are resolving the address, drop the message here.
-            warn!("store {} address is being resolved, drop msg {}",
-                  store_id,
-                  data);
+            debug!("store {} address is being resolved, drop msg {}",
+                   store_id,
+                   data);
             self.report_unreachable(data);
             return;
         }
 
+        info!("begin to resolve store {} address", store_id);
         self.store_resolving.insert(store_id);
         self.resolve_store(store_id, data);
     }
@@ -447,6 +448,8 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver> Server<T, S> {
         }
 
         let sock_addr = sock_addr.unwrap();
+        info!("resolve store {} address ok, addr {}", store_id, sock_addr);
+
         if data.is_snapshot() {
             return self.send_snapshot_sock(event_loop, store_id, sock_addr, data);
         }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -390,7 +390,9 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver> Server<T, S> {
         // No connection, try to resolve it.
         if self.store_resolving.contains(&store_id) {
             // If we are resolving the address, drop the message here.
-            warn!("store {} address is being resolved, drop msg", store_id);
+            warn!("store {} address is being resolved, drop msg {}",
+                  store_id,
+                  data);
             return;
         }
 

--- a/src/server/transport.rs
+++ b/src/server/transport.rs
@@ -35,6 +35,8 @@ pub trait RaftStoreRouter: Send + Sync {
                        to_peer_id: u64,
                        status: SnapshotStatus)
                        -> RaftStoreResult<()>;
+
+    fn report_unreachable(&self, region_id: u64, to_peer_id: u64) -> RaftStoreResult<()>;
 }
 
 pub struct ServerRaftStoreRouter {
@@ -91,6 +93,15 @@ impl RaftStoreRouter for ServerRaftStoreRouter {
 
         Ok(())
     }
+
+    fn report_unreachable(&self, region_id: u64, to_peer_id: u64) -> RaftStoreResult<()> {
+        try!(self.ch.send(StoreMsg::ReportUnreachable {
+            region_id: region_id,
+            to_peer_id: to_peer_id,
+        }));
+
+        Ok(())
+    }
 }
 
 pub struct ServerTransport {
@@ -143,6 +154,10 @@ impl RaftStoreRouter for MockRaftStoreRouter {
     }
 
     fn report_snapshot(&self, _: u64, _: u64, _: SnapshotStatus) -> RaftStoreResult<()> {
+        unimplemented!();
+    }
+
+    fn report_unreachable(&self, _: u64, _: u64) -> RaftStoreResult<()> {
         unimplemented!();
     }
 }


### PR DESCRIPTION
Old resolving mechanism may cause the message disorder, e.g, we send 1, 2, 3, and 4 to store a.

+ put 1, 2, 3 to resolve thread.
+ resolve store a address successfully for message 1 and notify server.
+ create the token for store a and then send 1.
+ now 4 comes and use token for a directly.
+ 2 and 3 resolve ok and notify server, send 2, 3.
 
As you see, 4 is sent before 2 and 3.
To solve this, we can introduce a pending list, if the token doesn't exist, we push the message to pending list and then resolve the store address, after resolving ok, we send all messages in pending list first, then following messages using the same token can have the correct order. 

@ngaut @BusyJay @disksing @tiancaiamao 