### PR TITLE
lib: allow define more errors.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 #![feature(iter_arith)]
 #![cfg_attr(feature = "dev", plugin(clippy))]
 #![cfg_attr(not(feature = "dev"), allow(unknown_lints))]
+#![recursion_limit="100"]
 
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
https://github.com/tailhook/quick-error/issues/22