### PR TITLE
*: add tag for logging and debugging

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -197,6 +197,7 @@ impl Peer {
             max_inflight_msgs: cfg.raft_max_inflight_msgs,
             applied: applied_index,
             check_quorum: true,
+            tag: format!("[region {}]", region.get_id()),
         };
 
         let raft_group = try!(RawNode::new(&raft_cfg, storage.clone(), &[]));


### PR DESCRIPTION
Currently, the log inside of raft module has no relationship with region. It's hard to find out which region that the raft belongs to. We need a simply way to handle this problem without change the implementation of raft.