### PR TITLE
storage: encode keys from client

### DIFF
--- a/benches/bin/mvcc.rs
+++ b/benches/bin/mvcc.rs
@@ -35,24 +35,24 @@ fn bench_tombstone_scan(dsn: Dsn) -> BenchSamples {
     for (k, v) in kvs.take(100000) {
         let mut ts = ts_generator.next().unwrap();
         store.prewrite(Context::new(),
-                       vec![Mutation::Put((Key::from_raw(k.clone()), v))],
+                       vec![Mutation::Put((Key::from_raw(&k), v))],
                        k.clone(),
                        ts)
              .expect("");
         store.commit(Context::new(),
-                     vec![Key::from_raw(k.clone())],
+                     vec![Key::from_raw(&k)],
                      ts,
                      ts_generator.next().unwrap())
              .expect("");
 
         ts = ts_generator.next().unwrap();
         store.prewrite(Context::new(),
-                       vec![Mutation::Delete(Key::from_raw(k.clone()))],
+                       vec![Mutation::Delete(Key::from_raw(&k))],
                        k.clone(),
                        ts)
              .expect("");
         store.commit(Context::new(),
-                     vec![Key::from_raw(k.clone())],
+                     vec![Key::from_raw(&k)],
                      ts,
                      ts_generator.next().unwrap())
              .expect("");
@@ -62,7 +62,7 @@ fn bench_tombstone_scan(dsn: Dsn) -> BenchSamples {
     bench!{
         let (k, _) = kvs.next().unwrap();
         assert!(store.scan(Context::new(),
-                           Key::from_raw(k.clone()),
+                           Key::from_raw(&k),
                            1,
                            ts_generator.next().unwrap())
                      .unwrap()

--- a/src/server/coprocessor.rs
+++ b/src/server/coprocessor.rs
@@ -302,7 +302,7 @@ impl<'a> SelectContext<'a> {
     fn get_rows_from_range(&mut self, mut range: KeyRange) -> Result<Vec<Row>> {
         let mut rows = vec![];
         if is_point(&range) {
-            if let None = try!(self.snap.get(&Key::from_raw(range.get_start().to_vec()))) {
+            if let None = try!(self.snap.get(&Key::from_raw(range.get_start()))) {
                 return Ok(rows);
             }
             let h = box_try!(table::decode_handle(range.get_start()));
@@ -317,7 +317,7 @@ impl<'a> SelectContext<'a> {
             loop {
                 trace!("seek {}", escape(&seek_key));
                 let timer = Instant::now();
-                let mut res = try!(self.snap.scan(Key::from_raw(seek_key), 1));
+                let mut res = try!(self.snap.scan(Key::from_raw(&seek_key), 1));
                 trace!("scan takes {:?}", timer.elapsed());
                 if res.is_empty() {
                     debug!("no more data to scan.");
@@ -354,7 +354,7 @@ impl<'a> SelectContext<'a> {
                 self.eval.row.insert(col_id, Datum::I64(h));
             } else {
                 let key = table::encode_column_key(t_id, h, col_id);
-                let data = try!(self.snap.get(&Key::from_raw(key)));
+                let data = try!(self.snap.get(&Key::from_raw(&key)));
                 if data.is_none() {
                     return Err(box_err!("data is missing for [{}, {}, {}]", t_id, h, col_id));
                 }
@@ -383,7 +383,7 @@ impl<'a> SelectContext<'a> {
                     row.mut_data().extend(bytes);
                 } else {
                     let raw_key = table::encode_column_key(tid, h, col.get_column_id());
-                    let key = Key::from_raw(raw_key);
+                    let key = Key::from_raw(&raw_key);
                     match try!(self.snap.get(&key)) {
                         None => return Err(box_err!("key {} not exists", key)),
                         Some(bs) => row.mut_data().extend(bs),
@@ -411,7 +411,7 @@ impl<'a> SelectContext<'a> {
         loop {
             trace!("seek {}", escape(&seek_key));
             let timer = Instant::now();
-            let mut nk = try!(self.snap.scan(Key::from_raw(seek_key.clone()), 1));
+            let mut nk = try!(self.snap.scan(Key::from_raw(&seek_key), 1));
             trace!("scan takes {:?}", timer.elapsed());
             if nk.is_empty() {
                 debug!("no more data to scan");

--- a/src/server/kv.rs
+++ b/src/server/kv.rs
@@ -43,11 +43,11 @@ impl StoreHandler {
         if !msg.has_cmd_get_req() {
             return Err(box_err!("msg doesn't contain a CmdGetRequest"));
         }
-        let mut req = msg.take_cmd_get_req();
+        let req = msg.take_cmd_get_req();
         let ctx = msg.take_context();
         let cb = self.make_cb(StoreHandler::cmd_get_done, on_resp);
         self.store
-            .async_get(ctx, Key::from_raw(req.take_key()), req.get_version(), cb)
+            .async_get(ctx, Key::from_raw(req.get_key()), req.get_version(), cb)
             .map_err(Error::Storage)
     }
 
@@ -55,8 +55,8 @@ impl StoreHandler {
         if !msg.has_cmd_scan_req() {
             return Err(box_err!("msg doesn't contain a CmdScanRequest"));
         }
-        let mut req = msg.take_cmd_scan_req();
-        let start_key = req.take_start_key();
+        let req = msg.take_cmd_scan_req();
+        let start_key = req.get_start_key();
         debug!("start_key [{}]", escape(&start_key));
         let cb = self.make_cb(StoreHandler::cmd_scan_done, on_resp);
         self.store
@@ -78,10 +78,10 @@ impl StoreHandler {
                            .map(|mut x| {
                                match x.get_op() {
                                    Op::Put => {
-                                       Mutation::Put((Key::from_raw(x.take_key()), x.take_value()))
+                                       Mutation::Put((Key::from_raw(x.get_key()), x.take_value()))
                                    }
-                                   Op::Del => Mutation::Delete(Key::from_raw(x.take_key())),
-                                   Op::Lock => Mutation::Lock(Key::from_raw(x.take_key())),
+                                   Op::Del => Mutation::Delete(Key::from_raw(x.get_key())),
+                                   Op::Lock => Mutation::Lock(Key::from_raw(x.get_key())),
                                }
                            })
                            .collect();
@@ -99,11 +99,11 @@ impl StoreHandler {
         if !msg.has_cmd_commit_req() {
             return Err(box_err!("msg doesn't contain a CmdCommitRequest"));
         }
-        let mut req = msg.take_cmd_commit_req();
+        let req = msg.take_cmd_commit_req();
         let cb = self.make_cb(StoreHandler::cmd_commit_done, on_resp);
-        let keys = req.take_keys()
-                      .into_iter()
-                      .map(Key::from_raw)
+        let keys = req.get_keys()
+                      .iter()
+                      .map(|x| Key::from_raw(&x))
                       .collect();
         self.store
             .async_commit(msg.take_context(),
@@ -118,11 +118,11 @@ impl StoreHandler {
         if !msg.has_cmd_cleanup_req() {
             return Err(box_err!("msg doesn't contain a CmdCleanupRequest"));
         }
-        let mut req = msg.take_cmd_cleanup_req();
+        let req = msg.take_cmd_cleanup_req();
         let cb = self.make_cb(StoreHandler::cmd_cleanup_done, on_resp);
         self.store
             .async_cleanup(msg.take_context(),
-                           Key::from_raw(req.take_key()),
+                           Key::from_raw(req.get_key()),
                            req.get_start_version(),
                            cb)
             .map_err(Error::Storage)
@@ -133,10 +133,10 @@ impl StoreHandler {
             return Err(box_err!("msg doesn't contain a CmdCommitThenGetRequest"));
         }
         let cb = self.make_cb(StoreHandler::cmd_commit_get_done, on_resp);
-        let mut req = msg.take_cmd_commit_get_req();
+        let req = msg.take_cmd_commit_get_req();
         self.store
             .async_commit_then_get(msg.take_context(),
-                                   Key::from_raw(req.take_key()),
+                                   Key::from_raw(req.get_key()),
                                    req.get_lock_version(),
                                    req.get_commit_version(),
                                    req.get_get_version(),
@@ -148,11 +148,11 @@ impl StoreHandler {
         if !msg.has_cmd_rb_get_req() {
             return Err(box_err!("msg doesn't contain a CmdRollbackThenGetRequest"));
         }
-        let mut req = msg.take_cmd_rb_get_req();
+        let req = msg.take_cmd_rb_get_req();
         let cb = self.make_cb(StoreHandler::cmd_rollback_get_done, on_resp);
         self.store
             .async_rollback_then_get(msg.take_context(),
-                                     Key::from_raw(req.take_key()),
+                                     Key::from_raw(req.get_key()),
                                      req.get_lock_version(),
                                      cb)
             .map_err(Error::Storage)
@@ -162,11 +162,11 @@ impl StoreHandler {
         if !msg.has_cmd_batch_get_req() {
             return Err(box_err!("msg doesn't contain a CmdBatchGetRequest"));
         }
-        let mut req = msg.take_cmd_batch_get_req();
+        let req = msg.take_cmd_batch_get_req();
         let cb = self.make_cb(StoreHandler::cmd_batch_get_done, on_resp);
         self.store
             .async_batch_get(msg.take_context(),
-                             req.take_keys().into_iter().map(Key::from_raw).collect(),
+                             req.get_keys().into_iter().map(|x| Key::from_raw(&x)).collect(),
                              req.get_version(),
                              cb)
             .map_err(Error::Storage)

--- a/src/storage/engine/raftkv.rs
+++ b/src/storage/engine/raftkv.rs
@@ -204,13 +204,13 @@ impl<T: PdClient, Trans: Transport> Engine for RaftKv<T, Trans> {
             match m {
                 Modify::Delete(k) => {
                     let mut delete = DeleteRequest::new();
-                    delete.set_key(k.raw().clone());
+                    delete.set_key(k.encoded().to_owned());
                     req.set_cmd_type(CmdType::Delete);
                     req.set_delete(delete);
                 }
                 Modify::Put((k, v)) => {
                     let mut put = PutRequest::new();
-                    put.set_key(k.raw().clone());
+                    put.set_key(k.encoded().to_owned());
                     put.set_value(v);
                     req.set_cmd_type(CmdType::Put);
                     req.set_put(put);
@@ -250,17 +250,17 @@ impl<T: PdClient, Trans: Transport> Engine for RaftKv<T, Trans> {
 
 impl<'a> Snapshot for RegionSnapshot<'a> {
     fn get(&self, key: &Key) -> engine::Result<Option<Value>> {
-        let v = box_try!(self.get_value(key.raw()));
+        let v = box_try!(self.get_value(key.encoded()));
         Ok(v.map(|v| v.to_vec()))
     }
 
     fn seek(&self, key: &Key) -> engine::Result<Option<KvPair>> {
-        let pair = box_try!(self.seek(key.raw()));
+        let pair = box_try!(self.seek(key.encoded()));
         Ok(pair)
     }
 
     fn reverse_seek(&self, key: &Key) -> engine::Result<Option<KvPair>> {
-        let pair = box_try!(self.reverse_seek(key.raw()));
+        let pair = box_try!(self.reverse_seek(key.encoded()));
         Ok(pair)
     }
 }

--- a/src/storage/engine/rocksdb.rs
+++ b/src/storage/engine/rocksdb.rs
@@ -61,14 +61,14 @@ impl Engine for EngineRocksdb {
     fn get(&self, _: &Context, key: &Key) -> Result<Option<Value>> {
         trace!("EngineRocksdb: get {}", key);
         self.db
-            .get(key.raw())
+            .get(key.encoded())
             .map(|r| r.map(|v| v.to_vec()))
             .map_err(|e| RocksDBError::new(e).into_engine_error())
     }
 
     fn seek(&self, _: &Context, key: &Key) -> Result<Option<KvPair>> {
         trace!("EngineRocksdb: seek {}", key);
-        let mode = IteratorMode::From(key.raw(), Direction::Forward);
+        let mode = IteratorMode::From(key.encoded(), Direction::Forward);
         let pair = self.db.iterator(mode).next().map(|(k, v)| (k.to_vec(), v.to_vec()));
         Ok(pair)
     }
@@ -79,13 +79,13 @@ impl Engine for EngineRocksdb {
             match rev {
                 Modify::Delete(k) => {
                     trace!("EngineRocksdb: delete {}", k);
-                    if let Err(msg) = wb.delete(k.raw()) {
+                    if let Err(msg) = wb.delete(k.encoded()) {
                         return Err(RocksDBError::new(msg).into_engine_error());
                     }
                 }
                 Modify::Put((k, v)) => {
                     trace!("EngineRocksdb: put {},{}", k, escape(&v));
-                    if let Err(msg) = wb.put(k.raw(), &v) {
+                    if let Err(msg) = wb.put(k.encoded(), &v) {
                         return Err(RocksDBError::new(msg).into_engine_error());
                     }
                 }
@@ -106,27 +106,27 @@ impl Engine for EngineRocksdb {
 impl<'a> Snapshot for RocksSnapshot<'a> {
     fn get(&self, key: &Key) -> Result<Option<Value>> {
         trace!("RocksSnapshot: get {}", key);
-        self.get(key.raw())
+        self.get(key.encoded())
             .map(|r| r.map(|v| v.to_vec()))
             .map_err(|e| RocksDBError::new(e).into_engine_error())
     }
 
     fn seek(&self, key: &Key) -> Result<Option<KvPair>> {
         trace!("RocksSnapshot: seek {}", key);
-        let mode = IteratorMode::From(key.raw(), Direction::Forward);
+        let mode = IteratorMode::From(key.encoded(), Direction::Forward);
         let pair = self.iterator(mode).next().map(|(k, v)| (k.to_vec(), v.to_vec()));
         Ok(pair)
     }
 
     fn reverse_seek(&self, key: &Key) -> Result<Option<KvPair>> {
         trace!("RocksSnapshot: seek {}", key);
-        let mut iter = self.iterator(IteratorMode::From(key.raw(), Direction::Reverse));
+        let mut iter = self.iterator(IteratorMode::From(key.encoded(), Direction::Reverse));
         // iter will be positioned at `key` or the kv pair after it. If no such key exists, we need
         // locate it to the end.
         if !iter.valid() {
             iter = self.iterator(IteratorMode::End);
         }
-        let pair = iter.skip_while(|&(k, _)| k >= key.raw())
+        let pair = iter.skip_while(|&(k, _)| k >= key.encoded())
                        .next()
                        .map(|(k, v)| (k.to_vec(), v.to_vec()));
         Ok(pair)

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -419,7 +419,6 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 mod tests {
     use super::*;
     use kvproto::kvrpcpb::Context;
-    use util::codec::bytes;
 
     fn expect_get_none() -> Callback<Option<Value>> {
         Box::new(|x: Result<Option<Value>>| assert_eq!(x.unwrap(), None))
@@ -492,9 +491,9 @@ mod tests {
                            1000,
                            5,
                            expect_scan(vec![
-            Some((bytes::encode_bytes(b"a"), b"aa".to_vec())),
-            Some((bytes::encode_bytes(b"b"), b"bb".to_vec())),
-            Some((bytes::encode_bytes(b"c"), b"cc".to_vec())),
+            Some((b"a".to_vec(), b"aa".to_vec())),
+            Some((b"b".to_vec(), b"bb".to_vec())),
+            Some((b"c".to_vec(), b"cc".to_vec())),
             ]))
                .unwrap();
         storage.stop().unwrap();

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -37,7 +37,7 @@ impl Scheduler {
                         let mut res = vec![];
                         for (k, v) in keys.into_iter().zip(results.into_iter()) {
                             match v {
-                                Ok(Some(x)) => res.push(Ok((k.raw().to_owned(), x))),
+                                Ok(Some(x)) => res.push(Ok((k.raw().unwrap(), x))),
                                 Ok(None) => {}
                                 Err(e) => res.push(Err(::storage::Error::from(e))),
                             }

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -210,18 +210,18 @@ impl<'a> SnapshotStore<'a> {
         let txn = MvccSnapshot::new(self.snapshot.as_ref(), self.start_ts);
         while results.len() < limit {
             key = match try!(self.snapshot.seek(&key)) {
-                Some((k, _)) => try!(Key::from_raw(k).truncate_ts()),
+                Some((k, _)) => try!(Key::from_encoded(k).truncate_ts()),
                 None => break,
             };
             match txn.get(&key) {
-                Ok(Some(value)) => results.push(Ok((key.raw().to_owned(), value))),
+                Ok(Some(value)) => results.push(Ok((try!(key.raw()), value))),
                 Ok(None) => {}
                 e @ Err(MvccError::KeyIsLocked { .. }) => {
                     results.push(Err(Error::from(e.unwrap_err())))
                 }
                 Err(e) => return Err(e.into()),
             };
-            key = key.encode_ts(u64::max_value());
+            key = key.append_ts(u64::max_value());
         }
         Ok(results)
     }
@@ -232,11 +232,11 @@ impl<'a> SnapshotStore<'a> {
         let txn = MvccSnapshot::new(self.snapshot.as_ref(), self.start_ts);
         while results.len() < limit {
             key = match try!(self.snapshot.reverse_seek(&key)) {
-                Some((k, _)) => try!(Key::from_raw(k).truncate_ts()),
+                Some((k, _)) => try!(Key::from_encoded(k).truncate_ts()),
                 None => break,
             };
             match txn.get(&key) {
-                Ok(Some(value)) => results.push(Ok((key.raw().to_owned(), value))),
+                Ok(Some(value)) => results.push(Ok((try!(key.raw()), value))),
                 Ok(None) => {}
                 e @ Err(MvccError::KeyIsLocked { .. }) => {
                     results.push(Err(Error::from(e.unwrap_err())))
@@ -254,7 +254,6 @@ mod tests {
     use kvproto::kvrpcpb::Context;
     use storage::{Mutation, Key, KvPair, make_key};
     use storage::engine::{self, Dsn, TEMP_DIR};
-    use util::codec::bytes;
 
     trait TxnStoreAssert {
         fn get_none(&self, key: &[u8], ts: u64);
@@ -333,9 +332,7 @@ mod tests {
                                                     .collect();
             let expect: Vec<Option<KvPair>> = expect.into_iter()
                                                     .map(|x| {
-                                                        x.map(|(k, v)| {
-                                                            (bytes::encode_bytes(k), v.to_vec())
-                                                        })
+                                                        x.map(|(k, v)| (k.to_vec(), v.to_vec()))
                                                     })
                                                     .collect();
             assert_eq!(result, expect);
@@ -354,7 +351,7 @@ mod tests {
             let expect: Vec<Option<KvPair>> = expect.into_iter()
                                                     .map(|x| {
                                                         x.map(|(k, v)| {
-                                                            (bytes::encode_bytes(k), v.to_vec())
+                                                            (k.to_vec(), v.to_vec())
                                                         })
                                                     })
                                                     .collect();

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -16,6 +16,7 @@ use std::mem;
 use std::fmt::{self, Formatter, Display};
 use byteorder::{BigEndian, WriteBytesExt};
 use util::{escape, codec};
+use util::codec::bytes::BytesDecoder;
 
 pub type Value = Vec<u8>;
 pub type KvPair = (Vec<u8>, Value);
@@ -24,15 +25,23 @@ pub type KvPair = (Vec<u8>, Value);
 pub struct Key(Vec<u8>);
 
 impl Key {
-    pub fn from_raw(key: Vec<u8>) -> Key {
-        Key(key)
+    pub fn from_raw(key: &[u8]) -> Key {
+        Key(codec::bytes::encode_bytes(key))
     }
 
-    pub fn raw(&self) -> &Vec<u8> {
+    pub fn raw(&self) -> Result<Vec<u8>, codec::Error> {
+        self.0.as_slice().decode_bytes()
+    }
+
+    pub fn from_encoded(encoded_key: Vec<u8>) -> Key {
+        Key(encoded_key)
+    }
+
+    pub fn encoded(&self) -> &Vec<u8> {
         &self.0
     }
 
-    pub fn encode_ts(&self, ts: u64) -> Key {
+    pub fn append_ts(&self, ts: u64) -> Key {
         let mut encoded = self.0.clone();
         encoded.write_u64::<BigEndian>(ts).unwrap();
         Key(encoded)
@@ -43,13 +52,13 @@ impl Key {
         if len < mem::size_of::<u64>() {
             return Err(codec::Error::KeyLength);
         }
-        Ok(Key::from_raw(self.0[..len - mem::size_of::<u64>()].to_owned()))
+        Ok(Key::from_encoded(self.0[..len - mem::size_of::<u64>()].to_vec()))
     }
 }
 
 impl Hash for Key {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.raw().hash(state)
+        self.encoded().hash(state)
     }
 }
 
@@ -61,6 +70,5 @@ impl Display for Key {
 
 #[cfg(test)]
 pub fn make_key(k: &[u8]) -> Key {
-    use util::codec::bytes;
-    Key::from_raw(bytes::encode_bytes(k))
+    Key::from_raw(k)
 }

--- a/tests/coprocessor/test_select.rs
+++ b/tests/coprocessor/test_select.rs
@@ -86,12 +86,12 @@ impl Store {
     fn put(&mut self, mut kv: Vec<(Vec<u8>, Vec<u8>)>) {
         self.handles.extend(kv.iter().map(|&(ref k, _)| k.clone()));
         let pk = kv[0].0.clone();
-        let kv = kv.drain(..).map(|(k, v)| Mutation::Put((Key::from_raw(k), v))).collect();
+        let kv = kv.drain(..).map(|(k, v)| Mutation::Put((Key::from_raw(&k), v))).collect();
         self.store.prewrite(Context::new(), kv, pk, self.current_ts).unwrap();
     }
 
     fn commit(&mut self) {
-        let handles = self.handles.drain(..).map(Key::from_raw).collect();
+        let handles = self.handles.drain(..).map(|x| Key::from_raw(&x)).collect();
         self.store
             .commit(Context::new(), handles, self.current_ts, self.ts_g.gen())
             .unwrap();


### PR DESCRIPTION
Always encode keys from client, in order to guarantee that the key is memory-comparable and safe to append mvcc ts.

@BusyJay 