### PR TITLE
*: support metric.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,7 @@ version = "0.0.1"
 dependencies = [
  "byteorder 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.3.0 (git+https://github.com/carllerche/bytes)",
+ "cadence 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto)",
@@ -40,6 +41,14 @@ source = "git+https://github.com/carllerche/bytes#12dfc417ce3de87ca0ae867636fcb9
 name = "bytes"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cadence"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cfg-if"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ uuid = "0.1"
 time = "0.1"
 threadpool = "1.0.0"
 toml = "0.1"
+cadence = "0.5.0"
 clippy = {version = "*", optional = true}
 
 [dependencies.rocksdb]

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -10,6 +10,12 @@ store = "/tmp/tikv/store"
 # log level: trace, debug, info, warn, error, off.
 log-level = "info"
 
+[server.metric]
+# metric log level: trace, debug, info, warn, error, off.
+level = "info"
+# metric prefix: trace, debug, info, warn, error, off.
+prefix = "tikv"
+
 [raft]
 # set cluster id, must greater than 0.
 #cluster-id = 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@
 extern crate log;
 #[macro_use]
 extern crate quick_error;
+extern crate cadence;
 extern crate test;
 extern crate protobuf;
 extern crate bytes;

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -81,7 +81,7 @@ pub struct Server<T: RaftStoreRouter + 'static, S: StoreAddrResolver> {
 
     // TODO: remove `#[allow(dead_code)]`
     #[allow(dead_code)]
-    metric: Metric,
+    metric: Arc<Metric>,
 }
 
 impl<T: RaftStoreRouter, S: StoreAddrResolver> Server<T, S> {
@@ -106,6 +106,7 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver> Server<T, S> {
         let engine = storage.get_engine();
         let store_handler = StoreHandler::new(storage);
         let end_point = EndPointHost::new(engine);
+        let metric = Arc::new(metric);
 
         let svr = Server {
             listener: listener,

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -28,6 +28,7 @@ use super::{Msg, SendCh, ConnData};
 use super::conn::{Conn, OnWriteComplete};
 use super::{Result, OnResponse};
 use util::HandyRwLock;
+use util::metric::Metric;
 use storage::Storage;
 use super::kv::StoreHandler;
 use super::coprocessor::EndPointHost;
@@ -77,6 +78,10 @@ pub struct Server<T: RaftStoreRouter + 'static, S: StoreAddrResolver> {
     end_point: EndPointHost,
 
     resolver: S,
+
+    // TODO: remove `#[allow(dead_code)]`
+    #[allow(dead_code)]
+    metric: Metric,
 }
 
 impl<T: RaftStoreRouter, S: StoreAddrResolver> Server<T, S> {
@@ -89,7 +94,8 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver> Server<T, S> {
                listener: TcpListener,
                storage: Storage,
                raft_router: Arc<RwLock<T>>,
-               resolver: S)
+               resolver: S,
+               metric: Metric)
                -> Result<Server<T, S>> {
         try!(event_loop.register(&listener,
                                  SERVER_TOKEN,
@@ -112,6 +118,7 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver> Server<T, S> {
             store: store_handler,
             end_point: end_point,
             resolver: resolver,
+            metric: metric,
         };
 
         Ok(svr)

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -624,6 +624,7 @@ mod tests {
     use std::net::SocketAddr;
 
     use mio::tcp::TcpListener;
+    use log::LogLevel;
 
     use super::*;
     use super::super::{Msg, ConnData, Result};
@@ -637,6 +638,7 @@ mod tests {
     use kvproto::raft_cmdpb::RaftCmdRequest;
     use raft::SnapshotStatus;
     use storage::engine::TEMP_DIR;
+    use util::metric::Metric;
 
     struct MockResolver {
         addr: SocketAddr,
@@ -680,6 +682,8 @@ mod tests {
 
         let resolver = MockResolver { addr: listener.local_addr().unwrap() };
 
+        let metric = Metric::new("tikv", LogLevel::Info);
+
         let mut event_loop = create_event_loop().unwrap();
         let (tx, rx) = mpsc::channel();
         let mut server = Server::new(&mut event_loop,
@@ -688,7 +692,8 @@ mod tests {
                                      Arc::new(RwLock::new(TestRaftStoreRouter {
                                          tx: Mutex::new(tx),
                                      })),
-                                     resolver)
+                                     resolver,
+                                     metric)
                              .unwrap();
 
         let ch = server.get_sendch();

--- a/src/util/metric.rs
+++ b/src/util/metric.rs
@@ -1,0 +1,89 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use log::LogLevel;
+use cadence::prelude::{Counted, Timed, Gauged, Metered};
+use cadence::{StatsdClient, LoggingMetricSink};
+
+pub struct Metric {
+    inner: StatsdClient<LoggingMetricSink>,
+}
+
+impl Metric {
+    pub fn new(prefix: &str, level: LogLevel) -> Metric {
+        let sink = LoggingMetricSink::new(level);
+        Metric { inner: StatsdClient::from_sink(prefix, sink) }
+    }
+
+    // Increment the counter by `1`
+    pub fn incr(&self, key: &str) {
+        let r = self.inner.incr(key);
+        match r {
+            Err(e) => warn!("{}", e),
+            _ => {}
+        }
+    }
+
+    // Decrement the counter by `1`
+    pub fn decr(&self, key: &str) {
+        let r = self.inner.decr(key);
+        match r {
+            Err(e) => warn!("{}", e),
+            _ => {}
+        }
+    }
+
+    // Increment or decrement the counter by the given amount
+    pub fn count(&self, key: &str, count: i64) {
+        let r = self.inner.count(key, count);
+        match r {
+            Err(e) => warn!("{}", e),
+            _ => {}
+        }
+    }
+
+    // Record a  timing in milliseconds with the given key
+    pub fn time(&self, key: &str, time: u64) {
+        let r = self.inner.time(key, time);
+        match r {
+            Err(e) => warn!("{}", e),
+            _ => {}
+        }
+    }
+
+    // Record a gauge value with the given key
+    pub fn gauge(&self, key: &str, value: u64) {
+        let r = self.inner.gauge(key, value);
+        match r {
+            Err(e) => warn!("{}", e),
+            _ => {}
+        }
+    }
+
+    // Record a single metered event with the given key
+    pub fn mark(&self, key: &str) {
+        let r = self.inner.mark(key);
+        match r {
+            Err(e) => warn!("{}", e),
+            _ => {}
+        }
+    }
+
+    // Record a meter value with the given key
+    pub fn meter(&self, key: &str, value: u64) {
+        let r = self.inner.meter(key, value);
+        match r {
+            Err(e) => warn!("{}", e),
+            _ => {}
+        }
+    }
+}

--- a/src/util/metric.rs
+++ b/src/util/metric.rs
@@ -26,64 +26,50 @@ impl Metric {
 
     // Increment the counter by `1`
     pub fn incr(&self, key: &str) {
-        let r = self.inner.incr(key);
-        match r {
-            Err(e) => warn!("{}", e),
-            _ => {}
+        if let Err(e) = self.inner.incr(key) {
+            warn!("{}", e);
         }
     }
 
     // Decrement the counter by `1`
     pub fn decr(&self, key: &str) {
-        let r = self.inner.decr(key);
-        match r {
-            Err(e) => warn!("{}", e),
-            _ => {}
+        if let Err(e) = self.inner.decr(key) {
+            warn!("{}", e);
         }
     }
 
     // Increment or decrement the counter by the given amount
     pub fn count(&self, key: &str, count: i64) {
-        let r = self.inner.count(key, count);
-        match r {
-            Err(e) => warn!("{}", e),
-            _ => {}
+        if let Err(e) = self.inner.count(key, count) {
+            warn!("{}", e);
         }
     }
 
     // Record a  timing in milliseconds with the given key
     pub fn time(&self, key: &str, time: u64) {
-        let r = self.inner.time(key, time);
-        match r {
-            Err(e) => warn!("{}", e),
-            _ => {}
+        if let Err(e) = self.inner.time(key, time) {
+            warn!("{}", e);
         }
     }
 
     // Record a gauge value with the given key
     pub fn gauge(&self, key: &str, value: u64) {
-        let r = self.inner.gauge(key, value);
-        match r {
-            Err(e) => warn!("{}", e),
-            _ => {}
+        if let Err(e) = self.inner.gauge(key, value) {
+            warn!("{}", e);
         }
     }
 
     // Record a single metered event with the given key
     pub fn mark(&self, key: &str) {
-        let r = self.inner.mark(key);
-        match r {
-            Err(e) => warn!("{}", e),
-            _ => {}
+        if let Err(e) = self.inner.mark(key) {
+            warn!("{}", e);
         }
     }
 
     // Record a meter value with the given key
     pub fn meter(&self, key: &str, value: u64) {
-        let r = self.inner.meter(key, value);
-        match r {
-            Err(e) => warn!("{}", e),
-            _ => {}
+        if let Err(e) = self.inner.meter(key, value) {
+            warn!("{}", e);
         }
     }
 }

--- a/src/util/metric.rs
+++ b/src/util/metric.rs
@@ -10,6 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 use log::LogLevel;
 use cadence::prelude::{Counted, Timed, Gauged, Metered};
 use cadence::{StatsdClient, LoggingMetricSink};

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -34,6 +34,7 @@ pub mod worker;
 pub mod codec;
 pub mod xeval;
 pub mod event;
+pub mod metric;
 
 pub fn init_log(level: LogLevelFilter) -> Result<(), SetLoggerError> {
     log::set_logger(|filter| {


### PR DESCRIPTION
Issue: #566 

Plan b: 
 - A new field `metric` in `struct Server`.
 - `metric` wraps `cadence`, provides a statsd client.