### PR TITLE
*: cleanup pd.

### DIFF
--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -83,7 +83,7 @@ fn build_raftkv(matches: &Matches,
                 ch: SendCh,
                 cluster_id: u64,
                 addr: String,
-                pd_client: Arc<RwLock<RpcClient>>)
+                pd_client: Arc<RpcClient>)
                 -> (Storage, Arc<RwLock<ServerRaftStoreRouter>>) {
     let trans = Arc::new(RwLock::new(ServerTransport::new(ch)));
 
@@ -176,7 +176,7 @@ fn run_raft_server(listener: TcpListener, matches: &Matches, config: &toml::Valu
                                    config,
                                    None,
                                    |v| v.as_str().map(|s| s.to_owned()));
-    let pd_client = Arc::new(RwLock::new(new_rpc_client(&pd_addr, cluster_id).unwrap()));
+    let pd_client = Arc::new(new_rpc_client(&pd_addr, cluster_id).unwrap());
     let resolver = PdStoreAddrResolver::new(pd_client.clone()).unwrap();
 
     let (store, raft_router) = build_raftkv(matches,

--- a/src/pd/mod.rs
+++ b/src/pd/mod.rs
@@ -44,7 +44,7 @@ pub trait PdClient: Send + Sync {
     // It may happen that multi nodes start at same time to try to
     // bootstrap, and only one can success, others will fail
     // and must remove their created local region data themselves.
-    fn bootstrap_cluster(&mut self, stores: metapb::Store, region: metapb::Region) -> Result<()>;
+    fn bootstrap_cluster(&self, stores: metapb::Store, region: metapb::Region) -> Result<()>;
 
     // Return whether the cluster is bootstrapped or not.
     // We must use the cluster after bootstrapped, so when the
@@ -53,11 +53,11 @@ pub trait PdClient: Send + Sync {
     fn is_cluster_bootstrapped(&self) -> Result<bool>;
 
     // Allocate a unique positive id.
-    fn alloc_id(&mut self) -> Result<u64>;
+    fn alloc_id(&self) -> Result<u64>;
 
     // When the store starts, or some store information changed, it
     // uses put_store to inform pd.
-    fn put_store(&mut self, store: metapb::Store) -> Result<()>;
+    fn put_store(&self, store: metapb::Store) -> Result<()>;
 
     // We don't need to support region and peer put/delete,
     // because pd knows all region and peers itself.

--- a/src/pd/protocol.rs
+++ b/src/pd/protocol.rs
@@ -16,7 +16,7 @@ use kvproto::{metapb, pdpb};
 use super::{Error, Result, RpcClient};
 
 impl super::PdClient for RpcClient {
-    fn bootstrap_cluster(&mut self, store: metapb::Store, region: metapb::Region) -> Result<()> {
+    fn bootstrap_cluster(&self, store: metapb::Store, region: metapb::Region) -> Result<()> {
         let mut bootstrap = pdpb::BootstrapRequest::new();
         bootstrap.set_store(store);
         bootstrap.set_region(region);
@@ -38,7 +38,7 @@ impl super::PdClient for RpcClient {
         Ok(resp.get_is_bootstrapped().get_bootstrapped())
     }
 
-    fn alloc_id(&mut self) -> Result<u64> {
+    fn alloc_id(&self) -> Result<u64> {
         let mut req = self.new_request(pdpb::CommandType::AllocId);
         req.set_alloc_id(pdpb::AllocIdRequest::new());
 
@@ -47,7 +47,7 @@ impl super::PdClient for RpcClient {
         Ok(resp.get_alloc_id().get_id())
     }
 
-    fn put_store(&mut self, store: metapb::Store) -> Result<()> {
+    fn put_store(&self, store: metapb::Store) -> Result<()> {
         let mut put_store = pdpb::PutStoreRequest::new();
         put_store.set_store(store);
 
@@ -66,18 +66,18 @@ impl super::PdClient for RpcClient {
         let mut req = self.new_request(pdpb::CommandType::GetStore);
         req.set_get_store(get_store);
 
-        let resp = try!(self.send(&req));
+        let mut resp = try!(self.send(&req));
         try!(check_resp(&resp));
-        Ok(resp.get_get_store().get_store().clone())
+        Ok(resp.take_get_store().take_store())
     }
 
     fn get_cluster_config(&self) -> Result<metapb::Cluster> {
         let mut req = self.new_request(pdpb::CommandType::GetClusterConfig);
         req.set_get_cluster_config(pdpb::GetClusterConfigRequest::new());
 
-        let resp = try!(self.send(&req));
+        let mut resp = try!(self.send(&req));
         try!(check_resp(&resp));
-        Ok(resp.get_get_cluster_config().get_cluster().clone())
+        Ok(resp.take_get_cluster_config().take_cluster())
     }
 
     fn get_region(&self, key: &[u8]) -> Result<metapb::Region> {
@@ -87,9 +87,9 @@ impl super::PdClient for RpcClient {
         let mut req = self.new_request(pdpb::CommandType::GetRegion);
         req.set_get_region(get_region);
 
-        let resp = try!(self.send(&req));
+        let mut resp = try!(self.send(&req));
         try!(check_resp(&resp));
-        Ok(resp.get_get_region().get_region().clone())
+        Ok(resp.take_get_region().take_region())
     }
 
     fn ask_change_peer(&self, region: metapb::Region, leader: metapb::Peer) -> Result<()> {

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -73,7 +73,7 @@ pub struct Store<T: Transport, C: PdClient + 'static> {
     stopped: Arc<RwLock<bool>>,
 
     trans: Arc<RwLock<T>>,
-    pd_client: Arc<RwLock<C>>,
+    pd_client: Arc<C>,
 
     peer_cache: Arc<RwLock<HashMap<u64, metapb::Peer>>>,
 }
@@ -96,7 +96,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                cfg: Config,
                engine: Arc<DB>,
                trans: Arc<RwLock<T>>,
-               pd_client: Arc<RwLock<C>>)
+               pd_client: Arc<C>)
                -> Result<Store<T, C>> {
         // TODO: we can get cluster meta regularly too later.
         try!(cfg.validate());

--- a/src/raftstore/store/worker/pd.rs
+++ b/src/raftstore/store/worker/pd.rs
@@ -11,13 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::fmt::{self, Formatter, Display};
 
 use kvproto::metapb;
 use kvproto::raftpb;
 
-use util::HandyRwLock;
 use util::worker::Runnable;
 use util::escape;
 use pd::PdClient;
@@ -58,11 +57,11 @@ impl Display for Task {
 }
 
 pub struct Runner<T: PdClient> {
-    pd_client: Arc<RwLock<T>>,
+    pd_client: Arc<T>,
 }
 
 impl<T: PdClient> Runner<T> {
-    pub fn new(pd_client: Arc<RwLock<T>>) -> Runner<T> {
+    pub fn new(pd_client: Arc<T>) -> Runner<T> {
         Runner { pd_client: pd_client }
     }
 }
@@ -74,14 +73,14 @@ impl<T: PdClient> Runnable<Task> for Runner<T> {
         let res = match task {
             Task::AskChangePeer { region, peer, .. } => {
                 // TODO: We may add change_type in pd protocol later.
-                self.pd_client.rl().ask_change_peer(region, peer)
+                self.pd_client.ask_change_peer(region, peer)
             }
             Task::AskSplit { region, split_key, peer } => {
-                self.pd_client.rl().ask_split(region, &split_key, peer)
+                self.pd_client.ask_split(region, &split_key, peer)
             }
             Task::Heartbeat { store } => {
                 // Now we use put store protocol for heartbeat.
-                self.pd_client.wl().put_store(store)
+                self.pd_client.put_store(store)
             }
         };
 

--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -67,7 +67,7 @@ pub struct Cluster<T: Simulator> {
     pub engines: HashMap<u64, Arc<DB>>,
 
     sim: Arc<RwLock<T>>,
-    pub pd_client: Arc<RwLock<TestPdClient>>,
+    pub pd_client: Arc<TestPdClient>,
 }
 
 impl<T: Simulator> Cluster<T> {
@@ -75,7 +75,7 @@ impl<T: Simulator> Cluster<T> {
     pub fn new(id: u64,
                count: usize,
                sim: Arc<RwLock<T>>,
-               pd_client: Arc<RwLock<TestPdClient>>)
+               pd_client: Arc<TestPdClient>)
                -> Cluster<T> {
         let mut c = Cluster {
             cfg: new_server_config(id),
@@ -195,7 +195,6 @@ impl<T: Simulator> Cluster<T> {
 
     fn store_ids_of_region(&self, region_id: u64) -> Vec<u64> {
         let peers = self.pd_client
-            .rl()
             .get_region_by_id(region_id)
             .unwrap()
             .take_peers();
@@ -315,13 +314,11 @@ impl<T: Simulator> Cluster<T> {
     // This is only for fixed id test.
     fn bootstrap_cluster(&mut self, region: metapb::Region) {
         self.pd_client
-            .write()
-            .unwrap()
             .bootstrap_cluster(new_store(1, "".to_owned()), region)
             .unwrap();
 
         for &id in self.engines.keys() {
-            self.pd_client.wl().put_store(new_store(id, "".to_owned())).unwrap();
+            self.pd_client.put_store(new_store(id, "".to_owned())).unwrap();
         }
     }
 
@@ -395,8 +392,6 @@ impl<T: Simulator> Cluster<T> {
 
     pub fn get_region(&self, key: &[u8]) -> metapb::Region {
         self.pd_client
-            .read()
-            .unwrap()
             .get_region(key)
             .unwrap()
     }
@@ -455,7 +450,6 @@ impl<T: Simulator> Cluster<T> {
 
     pub fn get_region_epoch(&self, region_id: u64) -> RegionEpoch {
         self.pd_client
-            .rl()
             .get_region_by_id(region_id)
             .unwrap()
             .get_region_epoch()
@@ -475,16 +469,16 @@ impl<T: Simulator> Cluster<T> {
                 format!("{:?}", resp));
 
         let region = resp.get_admin_response().get_change_peer().get_region();
-        self.pd_client.wl().change_peer(region.clone()).unwrap();
+        self.pd_client.change_peer(region.clone()).unwrap();
     }
 
     pub fn split_region(&mut self, region_id: u64, split_key: Option<Vec<u8>>) {
-        let new_region_id = self.pd_client.wl().alloc_id().unwrap();
-        let region = self.pd_client.rl().get_region_by_id(region_id).unwrap();
+        let new_region_id = self.pd_client.alloc_id().unwrap();
+        let region = self.pd_client.get_region_by_id(region_id).unwrap();
         let peer_count = region.get_peers().len();
         let mut peer_ids: Vec<u64> = vec![];
         for _ in 0..peer_count {
-            let peer_id = self.pd_client.wl().alloc_id().unwrap();
+            let peer_id = self.pd_client.alloc_id().unwrap();
             peer_ids.push(peer_id);
         }
 
@@ -500,7 +494,7 @@ impl<T: Simulator> Cluster<T> {
         let left = resp.get_admin_response().get_split().get_left();
         let right = resp.get_admin_response().get_split().get_right();
 
-        self.pd_client.wl().split_region(left.clone(), right.clone()).unwrap();
+        self.pd_client.split_region(left.clone(), right.clone()).unwrap();
     }
 
     pub fn region_detail(&mut self, region_id: u64, peer_id: u64) -> RegionDetailResponse {

--- a/tests/raftstore/node.rs
+++ b/tests/raftstore/node.rs
@@ -58,13 +58,13 @@ type SimulateChannelTransport = SimulateTransport<ChannelTransport>;
 pub struct NodeCluster {
     cluster_id: u64,
     trans: Arc<RwLock<ChannelTransport>>,
-    pd_client: Arc<RwLock<TestPdClient>>,
+    pd_client: Arc<TestPdClient>,
     nodes: HashMap<u64, Node<TestPdClient>>,
     simulate_trans: HashMap<u64, Arc<RwLock<SimulateChannelTransport>>>,
 }
 
 impl NodeCluster {
-    pub fn new(cluster_id: u64, pd_client: Arc<RwLock<TestPdClient>>) -> NodeCluster {
+    pub fn new(cluster_id: u64, pd_client: Arc<TestPdClient>) -> NodeCluster {
         NodeCluster {
             cluster_id: cluster_id,
             trans: ChannelTransport::new(),
@@ -134,7 +134,7 @@ impl Simulator for NodeCluster {
 
 pub fn new_node_cluster(id: u64, count: usize) -> Cluster<NodeCluster> {
     let (tx, rx) = mpsc::channel();
-    let pd_client = Arc::new(RwLock::new(TestPdClient::new(tx, id)));
+    let pd_client = Arc::new(TestPdClient::new(tx, id));
     let sim = Arc::new(RwLock::new(NodeCluster::new(id, pd_client.clone())));
     run_ask_loop(pd_client.clone(), sim.clone(), rx);
     Cluster::new(id, count, sim, pd_client)

--- a/tests/raftstore/server.rs
+++ b/tests/raftstore/server.rs
@@ -44,11 +44,11 @@ pub struct ServerCluster {
     sim_trans: HashMap<u64, Arc<RwLock<SimulateServerTransport>>>,
 
     msg_id: AtomicUsize,
-    pd_client: Arc<RwLock<TestPdClient>>,
+    pd_client: Arc<TestPdClient>,
 }
 
 impl ServerCluster {
-    pub fn new(pd_client: Arc<RwLock<TestPdClient>>) -> ServerCluster {
+    pub fn new(pd_client: Arc<TestPdClient>) -> ServerCluster {
         ServerCluster {
             senders: HashMap::new(),
             handles: HashMap::new(),
@@ -226,7 +226,7 @@ impl Simulator for ServerCluster {
 
 pub fn new_server_cluster(id: u64, count: usize) -> Cluster<ServerCluster> {
     let (tx, rx) = mpsc::channel();
-    let pd_client = Arc::new(RwLock::new(TestPdClient::new(tx, id)));
+    let pd_client = Arc::new(TestPdClient::new(tx, id));
     let sim = Arc::new(RwLock::new(ServerCluster::new(pd_client.clone())));
     run_ask_loop(pd_client.clone(), sim.clone(), rx);
     Cluster::new(id, count, sim, pd_client)

--- a/tests/raftstore/test_pd.rs
+++ b/tests/raftstore/test_pd.rs
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 use tikv::pd::PdClient;
-use tikv::util::HandyRwLock;
 use super::server::new_server_cluster;
 use super::util;
 
@@ -27,13 +26,13 @@ fn test_pd_heartbeat() {
     util::sleep_ms(100);
 
     let pd_client = cluster.pd_client.clone();
-    let store = pd_client.rl().get_store(1).unwrap();
+    let store = pd_client.get_store(1).unwrap();
     assert!(store.get_address().len() > 0);
 
     // force update a wrong store meta.
-    pd_client.wl().put_store(util::new_store(1, "".to_owned())).unwrap();
+    pd_client.put_store(util::new_store(1, "".to_owned())).unwrap();
 
     util::sleep_ms(500);
-    let store1 = pd_client.rl().get_store(1).unwrap();
+    let store1 = pd_client.get_store(1).unwrap();
     assert_eq!(store1.get_address(), store.get_address());
 }

--- a/tests/raftstore/test_split_region.rs
+++ b/tests/raftstore/test_split_region.rs
@@ -21,7 +21,6 @@ use super::node::new_node_cluster;
 use super::server::new_server_cluster;
 use super::util;
 use tikv::pd::PdClient;
-use tikv::util::HandyRwLock;
 use tikv::raftstore::store::keys::data_key;
 use tikv::raftstore::store::engine::Iterable;
 
@@ -36,7 +35,7 @@ fn test_base_split_region<T: Simulator>(cluster: &mut Cluster<T>) {
 
     let pd_client = cluster.pd_client.clone();
 
-    let region = pd_client.rl().get_region(b"").unwrap();
+    let region = pd_client.get_region(b"").unwrap();
 
     let a1 = b"a1";
     cluster.must_put(a1, b"v1");
@@ -49,8 +48,8 @@ fn test_base_split_region<T: Simulator>(cluster: &mut Cluster<T>) {
     // Split with a2, so a1 must in left, and a3 in right.
     cluster.split_region(region.get_id(), Some(a2.to_vec()));
 
-    let left = pd_client.rl().get_region(a1).unwrap();
-    let right = pd_client.rl().get_region(a3).unwrap();
+    let left = pd_client.get_region(a1).unwrap();
+    let right = pd_client.get_region(a3).unwrap();
 
     assert_eq!(region.get_id(), left.get_id());
     assert_eq!(region.get_start_key(), left.get_start_key());
@@ -120,14 +119,14 @@ fn test_auto_split_region<T: Simulator>(cluster: &mut Cluster<T>) {
 
     let pd_client = cluster.pd_client.clone();
 
-    let region = pd_client.rl().get_region(b"").unwrap();
+    let region = pd_client.get_region(b"").unwrap();
 
     let last_key = put_till_size(cluster, REGION_SPLIT_SIZE, &mut range);
 
     // it should be finished in millis if split.
     thread::sleep(Duration::from_secs(1));
 
-    let target = pd_client.rl().get_region(&last_key).unwrap();
+    let target = pd_client.get_region(&last_key).unwrap();
 
     assert_eq!(region, target);
 
@@ -138,16 +137,15 @@ fn test_auto_split_region<T: Simulator>(cluster: &mut Cluster<T>) {
 
     thread::sleep(Duration::from_secs(1));
 
-    let left = pd_client.rl().get_region(b"").unwrap();
-    let right = pd_client.rl().get_region(&max_key).unwrap();
+    let left = pd_client.get_region(b"").unwrap();
+    let right = pd_client.get_region(&max_key).unwrap();
 
     assert!(left != right);
     assert_eq!(region.get_start_key(), left.get_start_key());
     assert_eq!(right.get_start_key(), left.get_end_key());
     assert_eq!(region.get_end_key(), right.get_end_key());
-    assert_eq!(pd_client.rl().get_region(&max_key).unwrap(), right);
-    assert_eq!(pd_client.rl().get_region(left.get_end_key()).unwrap(),
-               right);
+    assert_eq!(pd_client.get_region(&max_key).unwrap(), right);
+    assert_eq!(pd_client.get_region(left.get_end_key()).unwrap(), right);
 
     let middle_key = left.get_end_key();
     let leader = cluster.leader_of_region(left.get_id()).unwrap();
@@ -195,7 +193,7 @@ fn test_delay_split_region<T: Simulator>(cluster: &mut Cluster<T>) {
 
     let pd_client = cluster.pd_client.clone();
 
-    let region = pd_client.rl().get_region(b"").unwrap();
+    let region = pd_client.get_region(b"").unwrap();
 
     let a1 = b"a1";
     cluster.must_put(a1, b"v1");

--- a/tests/raftstore/test_tombstone.rs
+++ b/tests/raftstore/test_tombstone.rs
@@ -15,7 +15,6 @@ use std::time::Duration;
 
 use kvproto::raftpb::ConfChangeType;
 use kvproto::raft_serverpb;
-use tikv::util::HandyRwLock;
 
 use super::cluster::{Cluster, Simulator};
 use super::node::new_node_cluster;
@@ -59,7 +58,6 @@ fn test_tombstone<T: Simulator>(cluster: &mut Cluster<T>) {
     must_get_none(&engine_2, b"a3");
 
     let epoch = cluster.pd_client
-        .rl()
         .get_region_by_id(1)
         .unwrap()
         .get_region_epoch()


### PR DESCRIPTION
Real RPC pd will handle mutability internally, no need `mut` in trait.

@ngaut @BusyJay @disksing @tiancaiamao 