### PR TITLE
docker: upgrade rocksdb version to 4.5.1, and add lz4 support

### DIFF
--- a/docker/rust_dockerfile
+++ b/docker/rust_dockerfile
@@ -10,17 +10,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     checkinstall \
     libgflags-dev \
     libsnappy-dev \
+    liblz4-dev \
     zlib1g-dev \
     libbz2-dev \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/* && apt-get clean
 
 RUN cd / && \
-    curl -L https://github.com/facebook/rocksdb/archive/v4.3.1.tar.gz | tar xz && \
-    cd rocksdb-4.3.1 && \
+    curl -L https://github.com/facebook/rocksdb/archive/v4.5.1.tar.gz | tar xz && \
+    cd rocksdb-4.5.1 && \
     make shared_lib && \
     make install && \
     cd / && \
-    rm -rf /rocksdb-4.3.1
+    rm -rf /rocksdb-4.5.1
 
 RUN curl -sSf https://static.rust-lang.org/rustup.sh |  sh -s  -- --disable-sudo -y --channel=nightly


### PR DESCRIPTION
Modified Dockerfile to support rocksdb options tuning of [#597](https://github.com/pingcap/tikv/pull/597)