### PR TITLE
server: on new connection, handshake and dispatch to different type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ dependencies = [
  "cadence 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto)",
+ "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto?rev=769fe895401eb09007f71c43907c94a0fbce6bce)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.5.0 (git+https://github.com/carllerche/mio.git)",
  "num 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -85,7 +85,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto#3db71b3c57032f21532c1716a43524c117bf4e91"
+source = "git+https://github.com/pingcap/kvproto?rev=769fe895401eb09007f71c43907c94a0fbce6bce#769fe895401eb09007f71c43907c94a0fbce6bce"
 dependencies = [
  "protobuf 1.0.20 (git+https://github.com/stepancheg/rust-protobuf.git)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ git = "https://github.com/carllerche/bytes"
 
 [dependencies.kvproto]
 git = "https://github.com/pingcap/kvproto"
+rev = "769fe895401eb09007f71c43907c94a0fbce6bce"
 
 [dependencies.tipb]
 git = "https://github.com/pingcap/tipb.git"

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -148,7 +148,7 @@ impl Conn {
 
         let msg = msg_or_none.unwrap();
         match msg.get_msg_type() {
-            MessageType::None => {
+            MessageType::Snapshot => {
                 self.conn_type = ConnType::Snapshot;
                 self.read_snapshot(event_loop)
             }

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -170,7 +170,7 @@ impl Conn {
               S: StoreAddrResolver
     {
         // TODO
-        Ok(vec![])
+        unimplemented!()
     }
 
     fn read_one_message(&mut self) -> Result<Option<Message>> {

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -20,7 +20,7 @@ use mio::{Token, EventLoop, EventSet, PollOpt, TryRead, TryWrite};
 use mio::tcp::TcpStream;
 use bytes::{Buf, MutBuf, ByteBuf, MutByteBuf, alloc};
 
-use kvproto::msgpb::Message;
+use kvproto::msgpb::{Message, MessageType};
 use super::{Result, ConnData};
 use super::server::Server;
 use util::codec::rpc;
@@ -30,10 +30,18 @@ use super::resolve::StoreAddrResolver;
 pub type OnClose = Box<FnBox() + Send>;
 pub type OnWriteComplete = Box<FnBox() + Send>;
 
+enum ConnType {
+    HandShake,
+    Rpc,
+    Snapshot,
+}
+
 pub struct Conn {
     pub sock: TcpStream,
     pub token: Token,
     pub interest: EventSet,
+
+    conn_type: ConnType,
 
     // store id is for remote store, we only set this
     // when we connect to the remote store.
@@ -85,6 +93,7 @@ impl Conn {
             sock: sock,
             token: token,
             interest: EventSet::readable() | EventSet::hup(),
+            conn_type: ConnType::HandShake,
             header: create_mem_buf(rpc::MSG_HEADER_LEN),
             payload: None,
             res: VecDeque::new(),
@@ -114,7 +123,87 @@ impl Conn {
         Ok(())
     }
 
-    pub fn read<T, S>(&mut self, _: &mut EventLoop<Server<T, S>>) -> Result<Vec<ConnData>>
+
+    pub fn on_readable<T, S>(&mut self,
+                             event_loop: &mut EventLoop<Server<T, S>>)
+                             -> Result<Vec<ConnData>>
+        where T: RaftStoreRouter,
+              S: StoreAddrResolver
+    {
+        match self.conn_type {
+            ConnType::HandShake => self.handshake(event_loop),
+            ConnType::Rpc => self.read_rpc(event_loop),
+            ConnType::Snapshot => self.read_snapshot(event_loop),
+        }
+    }
+
+    fn handshake<T, S>(&mut self, event_loop: &mut EventLoop<Server<T, S>>) -> Result<Vec<ConnData>>
+        where T: RaftStoreRouter,
+              S: StoreAddrResolver
+    {
+        let msg_or_none = try!(self.read_one_message());
+        if msg_or_none.is_none() {
+            return Ok(vec![]);
+        }
+
+        let msg = msg_or_none.unwrap();
+        match msg.get_msg_type() {
+            MessageType::None => {
+                self.conn_type = ConnType::Snapshot;
+                self.read_snapshot(event_loop)
+            }
+            _ => {
+                self.conn_type = ConnType::Rpc;
+                let mut first = vec![ConnData {
+                                         msg_id: self.last_msg_id,
+                                         msg: msg,
+                                     }];
+                let mut rem = try!(self.read_rpc(event_loop));
+                first.append(&mut rem);
+                Ok(first)
+            }
+        }
+    }
+
+    fn read_snapshot<T, S>(&mut self, _: &mut EventLoop<Server<T, S>>) -> Result<Vec<ConnData>>
+        where T: RaftStoreRouter,
+              S: StoreAddrResolver
+    {
+        // TODO
+        Ok(vec![])
+    }
+
+    fn read_one_message(&mut self) -> Result<Option<Message>> {
+        if self.payload.is_none() {
+            try!(try_read_data(&mut self.sock, &mut self.header));
+            if self.header.remaining() > 0 {
+                // we need to read more data for header
+                return Ok(None);
+            }
+
+            // we have already read whole header, parse it and begin to read payload.
+            let (msg_id, payload_len) = try!(rpc::decode_msg_header(self.header
+                .bytes()));
+            self.last_msg_id = msg_id;
+            self.payload = Some(create_mem_buf(payload_len));
+        }
+
+        // payload here can't be None.
+        let mut payload = self.payload.take().unwrap();
+        try!(try_read_data(&mut self.sock, &mut payload));
+        if payload.remaining() > 0 {
+            // we need to read more data for payload
+            self.payload = Some(payload);
+            return Ok(None);
+        }
+
+        let mut msg = Message::new();
+        try!(rpc::decode_body(payload.bytes(), &mut msg));
+        self.header.clear();
+        Ok(Some(msg))
+    }
+
+    fn read_rpc<T, S>(&mut self, _: &mut EventLoop<Server<T, S>>) -> Result<Vec<ConnData>>
         where T: RaftStoreRouter,
               S: StoreAddrResolver
     {
@@ -122,37 +211,14 @@ impl Conn {
 
         loop {
             // Because we use the edge trigger, so here we must read whole data.
-            if self.payload.is_none() {
-                try!(try_read_data(&mut self.sock, &mut self.header));
-                if self.header.remaining() > 0 {
-                    // we need to read more data for header
-                    break;
-                }
-
-                // we have already read whole header, parse it and begin to read payload.
-                let (msg_id, payload_len) = try!(rpc::decode_msg_header(self.header
-                    .bytes()));
-                self.last_msg_id = msg_id;
-                self.payload = Some(create_mem_buf(payload_len));
-            }
-
-            // payload here can't be None.
-            let mut payload = self.payload.take().unwrap();
-            try!(try_read_data(&mut self.sock, &mut payload));
-            if payload.remaining() > 0 {
-                // we need to read more data for payload
-                self.payload = Some(payload);
+            let msg = try!(self.read_one_message());
+            if msg.is_none() {
                 break;
             }
-
-            let mut msg = Message::new();
-            try!(rpc::decode_body(payload.bytes(), &mut msg));
             bufs.push(ConnData {
                 msg_id: self.last_msg_id,
-                msg: msg,
-            });
-
-            self.header.clear();
+                msg: msg.unwrap(),
+            })
         }
 
         Ok(bufs)

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -136,7 +136,9 @@ impl Display for ConnData {
             MessageType::CopResp => write!(f, "[{}] coprocessor response", self.msg_id),
             MessageType::PdReq => write!(f, "[{}] pd request", self.msg_id),
             MessageType::PdResp => write!(f, "[{}] pd response", self.msg_id),
-            MessageType::None => write!(f, "[{}] invalid message", self.msg_id),
+            MessageType::None | MessageType::Snapshot => {
+                write!(f, "[{}] invalid message", self.msg_id)
+            }
         }
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -136,9 +136,8 @@ impl Display for ConnData {
             MessageType::CopResp => write!(f, "[{}] coprocessor response", self.msg_id),
             MessageType::PdReq => write!(f, "[{}] pd request", self.msg_id),
             MessageType::PdResp => write!(f, "[{}] pd response", self.msg_id),
-            MessageType::None | MessageType::Snapshot => {
-                write!(f, "[{}] invalid message", self.msg_id)
-            }
+            MessageType::Snapshot => write!(f, "[{}] pd snapshot", self.msg_id),
+            MessageType::None => write!(f, "[{}] invalid message", self.msg_id),
         }
     }
 }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -185,7 +185,7 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver> Server<T, S> {
                 warn!("missing conn for token {:?}", token);
                 return Ok(());
             }
-            Some(conn) => conn.read(event_loop),
+            Some(conn) => conn.on_readable(event_loop),
         });
 
         if msgs.is_empty() {


### PR DESCRIPTION
there is trick that the first Message is used as handshake packet
that's not good but compatible, we can refact it later.

we'll have connections for snapshot, which begin with MessageTypeNone
followed by raw data