### PR TITLE
Add rocksdb configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ dependencies = [
  "bytes 0.3.0 (git+https://github.com/carllerche/bytes)",
  "cadence 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getopts 0.2.14 (git+https://github.com/rust-lang-nursery/getopts)",
  "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.5.0 (git+https://github.com/carllerche/mio.git)",
@@ -71,7 +71,7 @@ dependencies = [
 [[package]]
 name = "getopts"
 version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/rust-lang-nursery/getopts#4dfc197aa8253e7b0961fa05a594adbf8276209b"
 
 [[package]]
 name = "kernel32-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ byteorder = "0.5"
 rand = "0.3"
 quick-error = "0.2"
 tempdir = "0.3"
-getopts = "0.2"
 uuid = "0.1"
 time = "0.1"
 threadpool = "1.0.0"
@@ -41,6 +40,10 @@ toml = "0.1"
 num = "0.1"
 cadence = "0.5.0"
 clippy = {version = "*", optional = true}
+
+# The getopts in crate.io is outdated, use the latest getopts instead.
+[dependencies.getopts]
+git = "https://github.com/rust-lang-nursery/getopts"
 
 [dependencies.rocksdb]
 git = "https://github.com/ngaut/rust-rocksdb.git"

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -32,13 +32,13 @@ prefix = "tikv"
 # For detailed explanation please refer to https://github.com/facebook/rocksdb/blob/master/include/rocksdb/options.h
 [rocksdb]
 # compression method (if any) is used to compress a block.
-#   kNoCompression
-#   kSnappyCompression
-#   kZlibCompression
-#   kBZip2Compression
-#   kLZ4Compression
-#   kLZ4HCCompression
-compression = "kLZ4Compression"
+#   no: kNoCompression
+#   snappy: kSnappyCompression
+#   zlib: kZlibCompression
+#   bzip2: kBZip2Compression
+#   lz4: kLZ4Compression
+#   lz4hc: kLZ4HCCompression
+compression = "lz4"
 
 # Amount of data to build up in memory (backed by an unsorted log
 # on disk) before converting to a sorted on-disk file.

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -28,3 +28,50 @@ prefix = "tikv"
 #cluster-id = 1
 # set pd address, host:port
 #pd = 
+
+# For detailed explanation please refer to https://github.com/facebook/rocksdb/blob/master/include/rocksdb/options.h
+[rocksdb]
+# compression method (if any) is used to compress a block.
+#   kNoCompression
+#   kSnappyCompression
+#   kZlibCompression
+#   kBZip2Compression
+#   kLZ4Compression
+#   kLZ4HCCompression
+compression = "kLZ4Compression"
+
+# Amount of data to build up in memory (backed by an unsorted log
+# on disk) before converting to a sorted on-disk file.
+write-buffer-size = 67108864 # 64 * 1024 * 1024
+
+# The maximum number of write buffers that are built up in memory.
+max-write-buffer-number = 5
+
+# The minimum number of write buffers that will be merged together
+# before writing to storage.
+min-write-buffer-number-to-merge = 2
+
+# Maximum number of concurrent background compaction jobs, submitted to
+# the default LOW priority thread pool.
+max-background-compactions = 3
+
+# Control maximum total data size for a level.
+max-bytes-for-level-base = 67108864 # 64 * 1024 * 1024
+
+# Target file size for compaction.
+target-file-size-base = 67108864 # 64 * 1024 * 1024
+
+# If true, the database will be created if it is missing.
+create-if-missing = true
+
+# Soft limit on number of level-0 files. We start slowing down writes at this point.
+level0-slowdown-writes-trigger = 12
+
+# Maximum number of level-0 files.  We stop writes at this point.
+level0-stop-writes-trigger = 24
+
+# For detailed explanation please refer to https://github.com/facebook/rocksdb/blob/master/include/rocksdb/table.h
+[rocksdb.block-based-table]
+# Approximate size of user data packed per block.  Note that the 
+# block size specified here corresponds to uncompressed data.
+block-size = 65536 # 64 * 1024

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -173,7 +173,7 @@ fn get_rocksdb_option(matches: &Matches, config: &toml::Value) -> RocksdbOptions
                               "rocksdb.compression",
                               matches,
                               config,
-                              Some("kLZ4Compression".to_owned()),
+                              Some("lz4".to_owned()),
                               |v| v.as_str().map(|s| s.to_owned()));
     let compression = util::rocksdb_option::get_compression_by_string(&tp);
     opts.compression(compression);

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -36,6 +36,7 @@ pub mod worker;
 pub mod codec;
 pub mod xeval;
 pub mod event;
+pub mod rocksdb_option;
 
 pub fn init_log(level: LogLevelFilter) -> Result<(), SetLoggerError> {
     log::set_logger(|filter| {

--- a/src/util/rocksdb_option.rs
+++ b/src/util/rocksdb_option.rs
@@ -1,0 +1,26 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocksdb::DBCompressionType;
+
+pub fn get_compression_by_string(tp: &str) -> DBCompressionType {
+    match &*tp.to_owned() {
+        "kNoCompression" => DBCompressionType::DBNo,
+        "kSnappyCompression" => DBCompressionType::DBSnappy,
+        "kZlibCompression" => DBCompressionType::DBZlib,
+        "kBZip2Compression" => DBCompressionType::DBBz2,
+        "kLZ4Compression" => DBCompressionType::DBLz4,
+        "kLZ4HCCompression" => DBCompressionType::DBLz4hc,
+        _ => DBCompressionType::DBNo,
+    }
+}

--- a/src/util/rocksdb_option.rs
+++ b/src/util/rocksdb_option.rs
@@ -14,13 +14,13 @@
 use rocksdb::DBCompressionType;
 
 pub fn get_compression_by_string(tp: &str) -> DBCompressionType {
-    match &*tp.to_owned() {
-        "kNoCompression" => DBCompressionType::DBNo,
-        "kSnappyCompression" => DBCompressionType::DBSnappy,
-        "kZlibCompression" => DBCompressionType::DBZlib,
-        "kBZip2Compression" => DBCompressionType::DBBz2,
-        "kLZ4Compression" => DBCompressionType::DBLz4,
-        "kLZ4HCCompression" => DBCompressionType::DBLz4hc,
+    match &*tp.to_owned().to_lowercase() {
+        "no" => DBCompressionType::DBNo,
+        "snappy" => DBCompressionType::DBSnappy,
+        "zlib" => DBCompressionType::DBZlib,
+        "bzip2" => DBCompressionType::DBBz2,
+        "lz4" => DBCompressionType::DBLz4,
+        "lz4hc" => DBCompressionType::DBLz4hc,
         _ => DBCompressionType::DBNo,
     }
 }


### PR DESCRIPTION
#601 

-----
The getopts in crate.io is outdated, use the latest getopts instead. In the old version getopts, It seems like there is no way to avoid panic if short is not defined.