### PR TITLE
*: use duration for metric time.

### DIFF
--- a/src/util/metric/macros.rs
+++ b/src/util/metric/macros.rs
@@ -47,8 +47,9 @@ macro_rules! metric_decr {
 #[macro_export]
 macro_rules! metric_time {
     ($key:expr, $time:expr) => {
+        use $crate::util::duration_to_ms;
         if let Some(client) = $crate::util::metric::client() {
-            if let Err(e) = client.time($key, $time) {
+            if let Err(e) = client.time($key, duration_to_ms($time)) {
                 warn!("{}", e);
             }
         }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -250,8 +250,7 @@ impl<'a, T: 'a, V: 'a, E> TryInsertWith<'a, V, E> for Entry<'a, T, V> {
 pub fn duration_to_ms(d: Duration) -> u64 {
     let nanos = d.subsec_nanos() as u64;
     // Most of case, we can't have so large Duration, so here just panic if overflow now.
-    let ms = d.as_secs().checked_mul(1000).unwrap();
-    ms + (nanos / 1_000_000)
+    d.as_secs() * 1_000 + (nanos / 1_000_000)
 }
 
 #[cfg(test)]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -251,7 +251,7 @@ pub fn duration_to_ms(d: Duration) -> u64 {
     let nanos = d.subsec_nanos() as u64;
     // Most of case, we can't have so large Duration, so here just panic if overflow now.
     let ms = d.as_secs().checked_mul(1000).unwrap();
-    ms.checked_add(nanos / 1_000_000).unwrap()
+    ms + (nanos / 1_000_000)
 }
 
 #[cfg(test)]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -246,9 +246,16 @@ impl<'a, T: 'a, V: 'a, E> TryInsertWith<'a, V, E> for Entry<'a, T, V> {
     }
 }
 
+/// Convert Duration to milliseconds.
+pub fn duration_to_ms(d: Duration) -> u64 {
+    let nanos = d.subsec_nanos() as u64;
+    (1_000_000_000 * d.as_secs() + nanos) / (1_000_000)
+}
+
 #[cfg(test)]
 mod tests {
     use std::net::{SocketAddr, AddrParseError};
+    use std::time::Duration;
     use super::*;
 
     #[test]
@@ -273,6 +280,15 @@ mod tests {
         for (addr, ok) in tbls {
             let ret: Result<SocketAddr, AddrParseError> = addr.parse();
             assert_eq!(ret.is_ok(), ok);
+        }
+    }
+
+    #[test]
+    fn test_duration_to_ms() {
+        let tbl = vec![0, 100, 1_000, 5_000, 9999, 1_000_000, 1_000_000_000];
+        for ms in tbl {
+            let d = Duration::from_millis(ms);
+            assert_eq!(ms, duration_to_ms(d));
         }
     }
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -249,7 +249,9 @@ impl<'a, T: 'a, V: 'a, E> TryInsertWith<'a, V, E> for Entry<'a, T, V> {
 /// Convert Duration to milliseconds.
 pub fn duration_to_ms(d: Duration) -> u64 {
     let nanos = d.subsec_nanos() as u64;
-    (1_000_000_000 * d.as_secs() + nanos) / (1_000_000)
+    // Most of case, we can't have so large Duration, so here just panic if overflow now.
+    let ms = d.as_secs().checked_mul(1000).unwrap();
+    ms.checked_add(nanos / 1_000_000).unwrap()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Most of time, we will use time::Duration to timing.

@ngaut @BusyJay @disksing 