### PR TITLE
worker: support MPMC

### DIFF
--- a/src/util/worker/mod.rs
+++ b/src/util/worker/mod.rs
@@ -209,6 +209,7 @@ impl<T: Display + Send + 'static> WorkerPool<T> {
     pub fn stop(&mut self) -> thread::Result<()> {
         let handlers: Vec<_> = self.handles.drain(..).collect();
         for _ in 0..handlers.len() {
+            info!("stoping {}", self.name);
             // close sender explicitly so the background thread will exit.
             if let Err(e) = self.scheduler.sender.send(None) {
                 warn!("failed to stop worker thread: {:?}", e);


### PR DESCRIPTION
Support MPMC, we will use this for pd, snapshot or other workers which need MC mechanism. 

It is convenient that worker can wrap all. (SPSC, SPMC, MPSC, MPMC). 

@ngaut @BusyJay @disksing 