### PR TITLE
build portable version of rocksdb's shared library

### DIFF
--- a/docker/rust_dockerfile
+++ b/docker/rust_dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN cd / && \
     curl -L https://github.com/facebook/rocksdb/archive/v4.5.1.tar.gz | tar xz && \
     cd rocksdb-4.5.1 && \
-    make shared_lib && \
+    PORTABLE=1 make shared_lib && \
     make install && \
     cd / && \
     rm -rf /rocksdb-4.5.1


### PR DESCRIPTION
The current build of librocksdb.so is optimized for the host/kernel on which it is originally built; this can cause problems on a host that doesn't support the same CPU feature set, resulting in core dumps and messages like this in dmesg:
traps: tikv-server[16153] trap invalid opcode ip:7fe833fc9610 sp:7ffccbd12340 error:0 in librocksdb.so.4.5.1[7fe833e80000+373000]

The [official INSTALL.MD](https://github.com/facebook/rocksdb/blob/master/INSTALL.md) talks about this: 

> By default the binary we produce is optimized for the platform you're compiling on (-march=native or the equivalent). If you want to build a portable binary, add 'PORTABLE=1' before your make commands, like this: **PORTABLE=1** make static_lib