### PR TITLE
raft: remove arc

### DIFF
--- a/src/raft/raft.rs
+++ b/src/raft/raft.rs
@@ -35,7 +35,6 @@ use raft::progress::{Progress, Inflights, ProgressState};
 use raft::errors::{Result, Error, StorageError};
 use std::collections::HashMap;
 use raft::raft_log::{self, RaftLog};
-use std::sync::Arc;
 
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -213,7 +212,7 @@ fn new_message(to: u64, field_type: MessageType, from: Option<u64>) -> Message {
 }
 
 impl<T: Storage> Raft<T> {
-    pub fn new(c: &Config, store: Arc<T>) -> Raft<T> {
+    pub fn new(c: &Config, store: T) -> Raft<T> {
         c.validate().expect("configuration is invalid");
         let rs = store.initial_state().expect("");
         let raft_log = RaftLog::new(store);
@@ -274,7 +273,8 @@ impl<T: Storage> Raft<T> {
         r
     }
 
-    pub fn get_store(&self) -> Arc<T> {
+    #[inline]
+    pub fn get_store(&self) -> &T {
         self.raft_log.get_store()
     }
 

--- a/src/raft/raw_node.rs
+++ b/src/raft/raw_node.rs
@@ -33,7 +33,6 @@ use kvproto::raftpb::{HardState, Entry, EntryType, Message, Snapshot, MessageTyp
                       ConfChangeType, ConfState};
 use raft::raft::{Config, Raft, SoftState, INVALID_ID};
 use raft::Status;
-use std::sync::Arc;
 
 #[derive(Debug, Default)]
 pub struct Peer {
@@ -140,7 +139,7 @@ pub struct RawNode<T: Storage> {
 
 impl<T: Storage> RawNode<T> {
     // NewRawNode returns a new RawNode given configuration and a list of raft peers.
-    pub fn new(config: &Config, store: Arc<T>, peers: &[Peer]) -> Result<RawNode<T>> {
+    pub fn new(config: &Config, store: T, peers: &[Peer]) -> Result<RawNode<T>> {
         assert!(config.id != 0, "config.id must not be zero");
         let r = Raft::new(config, store);
         let mut rn = RawNode {

--- a/src/raft/storage.rs
+++ b/src/raft/storage.rs
@@ -26,11 +26,10 @@
 // limitations under the License.
 
 
-#![allow(dead_code)]
-#![allow(deprecated)]
+use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
 use kvproto::raftpb::{HardState, ConfState, Entry, Snapshot};
 use raft::errors::{Result, Error, StorageError};
-use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use util::{self, HandyRwLock};
 
 #[derive(Debug, Clone)]
@@ -162,8 +161,9 @@ impl MemStorageCore {
     }
 }
 
+#[derive(Clone, Default)]
 pub struct MemStorage {
-    core: RwLock<MemStorageCore>,
+    core: Arc<RwLock<MemStorageCore>>,
 }
 
 /// A thread-safe in-memory storage implementation.
@@ -179,12 +179,6 @@ impl MemStorage {
 
     pub fn wl(&self) -> RwLockWriteGuard<MemStorageCore> {
         self.core.wl()
-    }
-}
-
-impl Default for MemStorage {
-    fn default() -> MemStorage {
-        MemStorage { core: RwLock::new(MemStorageCore::default()) }
     }
 }
 

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -121,7 +121,7 @@ pub struct Peer {
     pub peer: metapb::Peer,
     region_id: u64,
     pub raft_group: RawNode<RaftStorage>,
-    pub storage: Arc<RaftStorage>,
+    pub storage: RaftStorage,
     pending_cmds: PendingCmdQueue,
     peer_cache: Arc<RwLock<HashMap<u64, metapb::Peer>>>,
     coprocessor_host: CoprocessorHost,
@@ -195,7 +195,7 @@ impl Peer {
         let store_id = store.store_id();
         let ps = try!(PeerStorage::new(store.engine(), &region, cfg.snap_dir.clone()));
         let applied_index = ps.applied_index();
-        let storage = Arc::new(RaftStorage::new(ps));
+        let storage = RaftStorage::new(ps);
 
         let raft_cfg = raft::Config {
             id: peer_id,

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -821,19 +821,22 @@ pub fn save_last_index<T: Mutable>(w: &T, region_id: u64, last_index: u64) -> Re
     w.put_u64(&keys::raft_last_index_key(region_id), last_index)
 }
 
+#[derive(Clone)]
 pub struct RaftStorage {
-    store: RwLock<PeerStorage>,
+    store: Arc<RwLock<PeerStorage>>,
 }
 
 impl RaftStorage {
     pub fn new(store: PeerStorage) -> RaftStorage {
-        RaftStorage { store: RwLock::new(store) }
+        RaftStorage { store: Arc::new(RwLock::new(store)) }
     }
 
+    #[inline]
     pub fn rl(&self) -> RwLockReadGuard<PeerStorage> {
         self.store.rl()
     }
 
+    #[inline]
     pub fn wl(&self) -> RwLockWriteGuard<PeerStorage> {
         self.store.wl()
     }

--- a/src/raftstore/store/worker/snap.rs
+++ b/src/raftstore/store/worker/snap.rs
@@ -13,7 +13,6 @@
 
 use raftstore::store::{self, RaftStorage, SnapState};
 
-use std::sync::Arc;
 use std::fmt::{self, Formatter, Display};
 use std::error;
 use std::time::Instant;
@@ -23,11 +22,11 @@ use util::worker::Runnable;
 
 /// Snapshot generating task.
 pub struct Task {
-    storage: Arc<RaftStorage>,
+    storage: RaftStorage,
 }
 
 impl Task {
-    pub fn new(storage: Arc<RaftStorage>) -> Task {
+    pub fn new(storage: RaftStorage) -> Task {
         Task { storage: storage }
     }
 }

--- a/tests/test_raw_node.rs
+++ b/tests/test_raw_node.rs
@@ -29,7 +29,6 @@ use kvproto::raftpb::*;
 use protobuf::{self, ProtobufEnum};
 use tikv::raft::*;
 use tikv::raft::storage::MemStorage;
-use std::sync::Arc;
 use test_raft::*;
 use test_raft_paper::*;
 
@@ -80,7 +79,7 @@ fn new_raw_node(id: u64,
                 peers: Vec<u64>,
                 election: usize,
                 heartbeat: usize,
-                storage: Arc<MemStorage>,
+                storage: MemStorage,
                 peer_nodes: Vec<Peer>)
                 -> RawNode<MemStorage> {
     RawNode::new(&new_test_config(id, peers, election, heartbeat),


### PR DESCRIPTION
Arc is an unnecessary constraint, so remove it.

And after this pr, RaftStorage becomes clone-able, which will be handy when doing snapshot.

@ngaut @siddontang @disksing PTAL