### PR TITLE
[DNM] *: remove lifetime of snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
  "protobuf 1.0.20 (git+https://github.com/stepancheg/rust-protobuf.git)",
  "quick-error 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocksdb 0.3.0 (git+https://github.com/ngaut/rust-rocksdb.git)",
+ "rocksdb 0.3.0 (git+https://github.com/busyjay/rust-rocksdb.git?branch=busyjay/introduce-unsafe-snap)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -145,7 +145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/ngaut/rust-rocksdb.git#c78df78c386a8818285353f79eb0665122331d26"
+source = "git+https://github.com/busyjay/rust-rocksdb.git?branch=busyjay/introduce-unsafe-snap#8c3aa4103c9b8ad3ba8bb1c26f6ca7644034c73e"
 dependencies = [
  "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -311,10 +311,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/ngaut/rust-rocksdb.git#c78df78c386a8818285353f79eb0665122331d26"
+source = "git+https://github.com/busyjay/rust-rocksdb.git?branch=busyjay/introduce-unsafe-snap#8c3aa4103c9b8ad3ba8bb1c26f6ca7644034c73e"
 dependencies = [
  "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "librocksdb_sys 0.1.0 (git+https://github.com/ngaut/rust-rocksdb.git)",
+ "librocksdb_sys 0.1.0 (git+https://github.com/busyjay/rust-rocksdb.git?branch=busyjay/introduce-unsafe-snap)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
  "protobuf 1.0.20 (git+https://github.com/stepancheg/rust-protobuf.git)",
  "quick-error 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocksdb 0.3.0 (git+https://github.com/busyjay/rust-rocksdb.git?branch=busyjay/introduce-unsafe-snap)",
+ "rocksdb 0.3.0 (git+https://github.com/ngaut/rust-rocksdb.git)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -145,7 +145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/busyjay/rust-rocksdb.git?branch=busyjay/introduce-unsafe-snap#8c3aa4103c9b8ad3ba8bb1c26f6ca7644034c73e"
+source = "git+https://github.com/ngaut/rust-rocksdb.git#7de3c903eb21325f3c5eb648676c7d8f073266c0"
 dependencies = [
  "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -311,10 +311,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/busyjay/rust-rocksdb.git?branch=busyjay/introduce-unsafe-snap#8c3aa4103c9b8ad3ba8bb1c26f6ca7644034c73e"
+source = "git+https://github.com/ngaut/rust-rocksdb.git#7de3c903eb21325f3c5eb648676c7d8f073266c0"
 dependencies = [
  "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "librocksdb_sys 0.1.0 (git+https://github.com/busyjay/rust-rocksdb.git?branch=busyjay/introduce-unsafe-snap)",
+ "librocksdb_sys 0.1.0 (git+https://github.com/ngaut/rust-rocksdb.git)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,7 @@ clippy = {version = "*", optional = true}
 git = "https://github.com/rust-lang-nursery/getopts"
 
 [dependencies.rocksdb]
-git = "https://github.com/busyjay/rust-rocksdb.git"
-branch = "busyjay/introduce-unsafe-snap"
+git = "https://github.com/ngaut/rust-rocksdb.git"
 
 [dependencies.protobuf]
 git = "https://github.com/stepancheg/rust-protobuf.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,8 @@ clippy = {version = "*", optional = true}
 git = "https://github.com/rust-lang-nursery/getopts"
 
 [dependencies.rocksdb]
-git = "https://github.com/ngaut/rust-rocksdb.git"
+git = "https://github.com/busyjay/rust-rocksdb.git"
+branch = "busyjay/introduce-unsafe-snap"
 
 [dependencies.protobuf]
 git = "https://github.com/stepancheg/rust-protobuf.git"

--- a/src/raftstore/coprocessor/dispatcher.rs
+++ b/src/raftstore/coprocessor/dispatcher.rs
@@ -214,7 +214,7 @@ mod test {
 
     fn new_peer_storage(path: &TempDir) -> PeerStorage {
         let engine = new_engine(path.path().to_str().unwrap()).unwrap();
-        PeerStorage::new(Arc::new(engine), &Region::new(), store::new_snap_mgr("")).unwrap()
+        PeerStorage::new(engine, &Region::new(), store::new_snap_mgr("")).unwrap()
     }
 
     fn share<T>(t: T) -> Arc<RwLock<T>> {

--- a/src/raftstore/coprocessor/mod.rs
+++ b/src/raftstore/coprocessor/mod.rs
@@ -34,15 +34,15 @@ pub trait Coprocessor {
 }
 
 /// Context of request.
-pub struct ObserverContext<'a> {
+pub struct ObserverContext {
     /// A snapshot of requested region.
-    pub snap: RegionSnapshot<'a>,
+    pub snap: RegionSnapshot,
     /// Whether to bypass following observer hook.
     pub bypass: bool,
 }
 
-impl<'a> ObserverContext<'a> {
-    pub fn new(peer: &'a PeerStorage) -> ObserverContext<'a> {
+impl ObserverContext {
+    pub fn new(peer: &PeerStorage) -> ObserverContext {
         ObserverContext {
             snap: RegionSnapshot::new(peer),
             bypass: false,

--- a/src/raftstore/coprocessor/region_snapshot.rs
+++ b/src/raftstore/coprocessor/region_snapshot.rs
@@ -218,8 +218,7 @@ mod tests {
     type DataSet = Vec<(Vec<u8>, Vec<u8>)>;
 
     fn new_temp_engine(path: &TempDir) -> Arc<DB> {
-        let engine = new_engine(path.path().to_str().unwrap()).unwrap();
-        Arc::new(engine)
+        new_engine(path.path().to_str().unwrap()).unwrap()
     }
 
     fn new_peer_storage(engine: Arc<DB>, r: &Region) -> PeerStorage {

--- a/src/raftstore/coprocessor/region_snapshot.rs
+++ b/src/raftstore/coprocessor/region_snapshot.rs
@@ -11,11 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
 use rocksdb::{DB, SeekKey, DBVector, DBIterator};
-use rocksdb::rocksdb::Snapshot;
 use kvproto::metapb::Region;
 
-use raftstore::store::engine::Peekable;
+use raftstore::store::engine::{Snapshot, Peekable, Iterable};
 use raftstore::store::{keys, util, PeerStorage};
 use raftstore::{Error, Result};
 
@@ -25,22 +25,22 @@ type Kv<'a> = (&'a [u8], &'a [u8]);
 /// Snapshot of a region.
 ///
 /// Only data within a region can be accessed.
-pub struct RegionSnapshot<'a> {
-    snap: Snapshot<'a>,
+pub struct RegionSnapshot {
+    snap: Snapshot,
     region: Region,
 }
 
-impl<'a> RegionSnapshot<'a> {
-    pub fn new(ps: &'a PeerStorage) -> RegionSnapshot<'a> {
+impl RegionSnapshot {
+    pub fn new(ps: &PeerStorage) -> RegionSnapshot {
         RegionSnapshot {
             snap: ps.raw_snapshot(),
             region: ps.get_region().clone(),
         }
     }
 
-    pub fn from_raw(db: &'a DB, region: Region) -> RegionSnapshot<'a> {
+    pub fn from_raw(db: Arc<DB>, region: Region) -> RegionSnapshot {
         RegionSnapshot {
-            snap: db.snapshot(),
+            snap: Snapshot::new(db),
             region: region,
         }
     }
@@ -50,7 +50,7 @@ impl<'a> RegionSnapshot<'a> {
     }
 
     pub fn iter(&self) -> RegionIterator {
-        RegionIterator::new(self.snap.iter(), self.region.clone())
+        RegionIterator::new(self.snap.new_iterator(), self.region.clone())
     }
 
     // scan scans database using an iterator in range [start_key, end_key), calls function f for
@@ -86,7 +86,7 @@ impl<'a> RegionSnapshot<'a> {
     }
 }
 
-impl<'a> Peekable for RegionSnapshot<'a> {
+impl Peekable for RegionSnapshot {
     fn get_value(&self, key: &[u8]) -> Result<Option<DBVector>> {
         try!(util::check_key_in_region(key, &self.region));
         let data_key = keys::data_key(key);

--- a/src/raftstore/coprocessor/split_observer.rs
+++ b/src/raftstore/coprocessor/split_observer.rs
@@ -106,7 +106,6 @@ impl RegionObserver for SplitObserver {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::sync::Arc;
     use tempdir::TempDir;
     use raftstore::store::engine::*;
     use raftstore::store::{self, PeerStorage};
@@ -121,7 +120,7 @@ mod test {
 
     fn new_peer_storage(path: &TempDir) -> PeerStorage {
         let engine = new_engine(path.path().to_str().unwrap()).unwrap();
-        PeerStorage::new(Arc::new(engine), &Region::new(), store::new_snap_mgr("")).unwrap()
+        PeerStorage::new(engine, &Region::new(), store::new_snap_mgr("")).unwrap()
     }
 
     fn new_split_request(key: &[u8]) -> AdminRequest {
@@ -163,7 +162,7 @@ mod test {
         r.set_id(10);
         r.set_start_key(region_start_key);
 
-        let ps = PeerStorage::new(Arc::new(engine), &r, store::new_snap_mgr("")).unwrap();
+        let ps = PeerStorage::new(engine, &r, store::new_snap_mgr("")).unwrap();
         let mut ctx = ObserverContext::new(&ps);
         let mut observer = SplitObserver;
 

--- a/src/raftstore/store/engine.rs
+++ b/src/raftstore/store/engine.rs
@@ -50,10 +50,10 @@ impl Drop for Snapshot {
     }
 }
 
-pub fn new_engine(path: &str) -> Result<DB> {
+pub fn new_engine(path: &str) -> Result<Arc<DB>> {
     // TODO: set proper options here,
     let db = try!(DB::open_default(path));
-    Ok(db)
+    Ok(Arc::new(db))
 }
 
 // TODO: refactor this trait into rocksdb trait.
@@ -199,7 +199,6 @@ impl Mutable for WriteBatch {}
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
     use tempdir::TempDir;
     use rocksdb::Writable;
 
@@ -209,7 +208,7 @@ mod tests {
     #[test]
     fn test_base() {
         let path = TempDir::new("var").unwrap();
-        let engine = Arc::new(new_engine(path.path().to_str().unwrap()).unwrap());
+        let engine = new_engine(path.path().to_str().unwrap()).unwrap();
 
         let mut r = Region::new();
         r.set_id(10);
@@ -250,7 +249,7 @@ mod tests {
     #[test]
     fn test_scan() {
         let path = TempDir::new("var").unwrap();
-        let engine = Arc::new(new_engine(path.path().to_str().unwrap()).unwrap());
+        let engine = new_engine(path.path().to_str().unwrap()).unwrap();
 
         engine.put(b"a1", b"v1").unwrap();
         engine.put(b"a2", b"v2").unwrap();

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -17,7 +17,6 @@ use std::vec::Vec;
 use std::default::Default;
 
 use rocksdb::{DB, WriteBatch, Writable};
-use rocksdb::rocksdb::Snapshot;
 use protobuf::{self, Message};
 use uuid::Uuid;
 
@@ -40,7 +39,7 @@ use super::msg::Callback;
 use super::cmd_resp;
 use super::transport::Transport;
 use super::keys;
-use super::engine::{Peekable, Iterable, Mutable};
+use super::engine::{Snapshot, Peekable, Iterable, Mutable};
 
 pub struct PendingCmd {
     pub uuid: Uuid,
@@ -731,7 +730,7 @@ impl Peer {
         let (mut resp, exec_result) = {
             let engine = self.engine.clone();
             let ctx = ExecContext {
-                snap: engine.snapshot(),
+                snap: Snapshot::new(engine),
                 wb: &wb,
                 req: req,
             };
@@ -804,7 +803,7 @@ fn get_change_peer_cmd(msg: &RaftCmdRequest) -> Option<&ChangePeerRequest> {
 }
 
 struct ExecContext<'a> {
-    pub snap: Snapshot<'a>,
+    pub snap: Snapshot,
     pub wb: &'a WriteBatch,
     pub req: &'a RaftCmdRequest,
 }

--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -150,6 +150,7 @@ impl SnapFile {
     }
 
     pub fn try_delete(&self) -> io::Result<()> {
+        debug!("deleting {}", self.path().display());
         fs::remove_file(self.path())
     }
 
@@ -191,6 +192,7 @@ impl Write for SnapFile {
 impl Drop for SnapFile {
     fn drop(&mut self) {
         if let Some((_, path)) = self.tmp_file.take() {
+            debug!("deleteing {}", path);
             if let Err(e) = fs::remove_file(&path) {
                 warn!("failed to delete temporary file {}: {:?}", path, e);
             }
@@ -242,6 +244,7 @@ impl SnapManagerCore {
             if !try!(p.file_type()).is_file() {
                 continue;
             }
+            debug!("deleting {}", p.path().display());
             try!(fs::remove_file(p.path()));
             // TODO: resume applying when suitable
         }

--- a/src/raftstore/store/worker/snap.rs
+++ b/src/raftstore/store/worker/snap.rs
@@ -60,14 +60,13 @@ impl Runner {
 
     fn generate_snap(&self, task: &Task) -> Result<(), Error> {
         // do we need to check leader here?
-        let db = task.storage.rl().get_engine();
         let raw_snap;
         let ranges;
         let key;
 
         {
             let storage = task.storage.rl();
-            raw_snap = db.snapshot();
+            raw_snap = storage.raw_snapshot();
             ranges = storage.region_key_ranges();
             let applied_idx = box_try!(storage.load_applied_index(&raw_snap));
             let term = box_try!(storage.term(applied_idx));

--- a/src/storage/engine/raftkv.rs
+++ b/src/storage/engine/raftkv.rs
@@ -104,14 +104,18 @@ enum CmdRes {
     Snap(RegionSnapshot),
 }
 
-fn on_result(mut resp: RaftCmdResponse, l: usize, uuid: &[u8], db: Arc<DB>) -> Result<CmdRes> {
+fn on_result(mut resp: RaftCmdResponse,
+             resp_cnt: usize,
+             uuid: &[u8],
+             db: Arc<DB>)
+             -> Result<CmdRes> {
     if resp.get_header().get_uuid() != uuid {
         return Err(Error::InvalidResponse("response is not correct!!!".to_owned()));
     }
     if resp.get_header().has_error() {
         return Err(Error::RequestFailed(resp.take_header().take_error()));
     }
-    if l != resp.get_responses().len() {
+    if resp_cnt != resp.get_responses().len() {
         return Err(Error::InvalidResponse("response count is not equal to requests, \
                                             something must go wrong."
             .to_owned()));

--- a/src/storage/engine/raftkv.rs
+++ b/src/storage/engine/raftkv.rs
@@ -15,9 +15,9 @@
 
 use server::Node;
 use server::transport::{ServerRaftStoreRouter, RaftStoreRouter};
-use raftstore::store::Peekable;
 use raftstore::errors::Error as RaftServerError;
 use raftstore::coprocessor::{RegionSnapshot, RegionIterator};
+use raftstore::store::engine::Peekable;
 use util::HandyRwLock;
 use kvproto::raft_cmdpb::{RaftCmdRequest, RaftCmdResponse, RaftRequestHeader, Request, Response,
                           CmdType, DeleteRequest, PutRequest};
@@ -99,6 +99,31 @@ pub struct RaftKv<C: PdClient + 'static> {
     router: Arc<RwLock<ServerRaftStoreRouter>>,
 }
 
+enum CmdRes {
+    Resp(Vec<Response>),
+    Snap(RegionSnapshot),
+}
+
+fn on_result(mut resp: RaftCmdResponse, l: usize, uuid: &[u8], db: Arc<DB>) -> Result<CmdRes> {
+    if resp.get_header().get_uuid() != uuid {
+        return Err(Error::InvalidResponse("response is not correct!!!".to_owned()));
+    }
+    if resp.get_header().has_error() {
+        return Err(Error::RequestFailed(resp.take_header().take_error()));
+    }
+    if l != resp.get_responses().len() {
+        return Err(Error::InvalidResponse("response count is not equal to requests, \
+                                            something must go wrong."
+            .to_owned()));
+    }
+    let mut resps = resp.take_responses();
+    if resps.len() != 1 || resps[0].get_cmd_type() != CmdType::Snap {
+        return Ok(CmdRes::Resp(resps.into_vec()));
+    }
+    let snap = RegionSnapshot::from_raw(db, resps[0].take_snap().take_region());
+    Ok(CmdRes::Snap(snap))
+}
+
 impl<C: PdClient> RaftKv<C> {
     /// Create a RaftKv using specified configuration.
     pub fn new(node: Node<C>, db: Arc<DB>) -> RaftKv<C> {
@@ -110,48 +135,26 @@ impl<C: PdClient> RaftKv<C> {
         }
     }
 
-    pub fn call_command(&self, request: RaftCmdRequest) -> Result<Event<RaftCmdResponse>> {
+    fn call_command(&self, req: RaftCmdRequest) -> Result<CmdRes> {
+        let uuid = req.get_header().get_uuid().to_vec();
+        let l = req.get_requests().len();
+        let db = self.db.clone();
         let finished = Event::new();
         let finished2 = finished.clone();
         let timeout = Duration::from_secs(DEFAULT_TIMEOUT_SECS);
 
-        try!(self.router.rl().send_command(request,
+        try!(self.router.rl().send_command(req,
                                            box move |resp| {
-            finished2.set(resp);
-            // Wait for response to be consumed or `finished` is
-            // dropped.
-            finished2.wait_clear(None);
-            Ok(())
-        }));
+                                               let res = on_result(resp, l, &uuid, db);
+                                               finished2.set(res);
+                                               Ok(())
+                                           }));
 
         if finished.wait_timeout(Some(timeout)) {
-            return Ok(finished);
+            return finished.take().unwrap();
         }
 
         Err(Error::Timeout(timeout))
-    }
-
-    fn exec_cmd_request(&self, req: RaftCmdRequest) -> Result<Event<RaftCmdResponse>> {
-        let uuid = req.get_header().get_uuid().to_vec();
-        let l = req.get_requests().len();
-
-        let resp = try!(self.call_command(req));
-        try!(resp.apply(|resp| {
-                if resp.get_header().get_uuid() != &*uuid {
-                    return Err(Error::InvalidResponse("response is not correct!!!".to_owned()));
-                }
-                if resp.get_header().has_error() {
-                    return Err(Error::RequestFailed(resp.take_header().take_error()));
-                }
-                if l != resp.get_responses().len() {
-                    return Err(Error::InvalidResponse("response count is not equal to requests, \
-                                                       something must go wrong."
-                        .to_owned()));
-                }
-                Ok(())
-            })
-            .unwrap());
-        Ok(resp)
     }
 
     fn new_request_header(&self, ctx: &Context) -> RaftRequestHeader {
@@ -163,41 +166,21 @@ impl<C: PdClient> RaftKv<C> {
         header
     }
 
-    fn exec_requests(&self, ctx: &Context, reqs: Vec<Request>) -> Result<Vec<Response>> {
+    fn exec_requests(&self, ctx: &Context, reqs: Vec<Request>) -> Result<CmdRes> {
         let header = self.new_request_header(ctx);
         let mut cmd = RaftCmdRequest::new();
         cmd.set_header(header);
         cmd.set_requests(RepeatedField::from_vec(reqs));
-        let resp = try!(self.exec_cmd_request(cmd));
-        // notice: raft thread will be woken up after the take method is called.
-        Ok(resp.take().unwrap().take_responses().to_vec())
-    }
-
-    fn exec_request(&self, ctx: &Context, req: Request) -> Result<Response> {
-        let resps = self.exec_requests(ctx, vec![req]);
-        resps.map(|mut v| v.remove(0))
+        self.call_command(cmd)
     }
 
     fn raw_snapshot(&self, ctx: &Context) -> Result<RegionSnapshot> {
         let mut req = Request::new();
         req.set_cmd_type(CmdType::Snap);
-
-        let header = self.new_request_header(ctx);
-        let mut cmd = RaftCmdRequest::new();
-        cmd.set_header(header);
-        cmd.mut_requests().push(req);
-
-        // notice: the raft thread will be woken up after resp is dropped
-        let resp = try!(self.exec_cmd_request(cmd));
-        let region = try!(resp.apply(|resp| {
-                let mut resp = resp.take_responses().remove(0);
-                if resp.get_cmd_type() != CmdType::Snap {
-                    return Err(invalid_resp_type(CmdType::Snap, resp.get_cmd_type()));
-                }
-                Ok(resp.take_snap().take_region())
-            })
-            .unwrap());
-        Ok(RegionSnapshot::from_raw(self.db.as_ref(), region))
+        match try!(self.exec_requests(ctx, vec![req])) {
+            CmdRes::Resp(rs) => Err(invalid_resp_type(CmdType::Snap, rs[0].get_cmd_type()).into()),
+            CmdRes::Snap(s) => Ok(s),
+        }
     }
 }
 
@@ -247,8 +230,10 @@ impl<C: PdClient> Engine for RaftKv<C> {
             }
             reqs.push(req);
         }
-        try!(self.exec_requests(ctx, reqs));
-        Ok(())
+        match try!(self.exec_requests(ctx, reqs)) {
+            CmdRes::Resp(_) => Ok(()),
+            CmdRes::Snap(_) => Err(box_err!("unexpect snapshot, should mutate instead.")),
+        }
     }
 
     fn snapshot<'a>(&'a self, ctx: &Context) -> engine::Result<Box<Snapshot + 'a>> {
@@ -257,7 +242,7 @@ impl<C: PdClient> Engine for RaftKv<C> {
     }
 }
 
-impl<'a> Snapshot for RegionSnapshot<'a> {
+impl Snapshot for RegionSnapshot {
     fn get(&self, key: &Key) -> engine::Result<Option<Value>> {
         let v = box_try!(self.get_value(key.encoded()));
         Ok(v.map(|v| v.to_vec()))

--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -63,7 +63,7 @@ pub struct Cluster<T: Simulator> {
     // node id -> db engine.
     pub engines: HashMap<u64, Arc<DB>>,
 
-    sim: Arc<RwLock<T>>,
+    pub sim: Arc<RwLock<T>>,
     pub pd_client: Arc<TestPdClient>,
 }
 

--- a/tests/raftstore/mod.rs
+++ b/tests/raftstore/mod.rs
@@ -14,7 +14,7 @@
 pub mod util;
 pub mod cluster;
 mod node;
-mod server;
+pub mod server;
 pub mod pd;
 pub mod transport_simulate;
 

--- a/tests/storage/mod.rs
+++ b/tests/storage/mod.rs
@@ -1,0 +1,1 @@
+mod test_raftkv;

--- a/tests/storage/test_raftkv.rs
+++ b/tests/storage/test_raftkv.rs
@@ -13,7 +13,7 @@ fn test_raftkv() {
     let mut cluster = new_server_cluster(0, count);
     cluster.run();
 
-    // make sure leader have elected.
+    // make sure leader has been elected.
     assert_eq!(cluster.get(b"k1"), None);
 
     let region = cluster.get_region(b"");

--- a/tests/storage/test_raftkv.rs
+++ b/tests/storage/test_raftkv.rs
@@ -1,0 +1,125 @@
+use tikv::util::HandyRwLock;
+use tikv::storage::engine::*;
+use tikv::storage::Key;
+use tikv::util::codec::bytes;
+use tikv::util::escape;
+use kvproto::kvrpcpb::Context;
+
+use raftstore::server::new_server_cluster;
+
+#[test]
+fn test_raftkv() {
+    let count = 1;
+    let mut cluster = new_server_cluster(0, count);
+    cluster.run();
+
+    // make sure leader have elected.
+    assert_eq!(cluster.get(b"k1"), None);
+
+    let region = cluster.get_region(b"");
+    let leader_id = cluster.leader_of_region(region.get_id()).unwrap();
+    let storage = cluster.sim.rl().storages.get(&leader_id.get_id()).unwrap().clone();
+
+    let mut ctx = Context::new();
+    ctx.set_region_id(region.get_id());
+    ctx.set_region_epoch(region.get_region_epoch().clone());
+    ctx.set_peer(region.get_peers()[0].clone());
+
+    get_put(&ctx, storage.as_ref().as_ref());
+    batch(&ctx, storage.as_ref().as_ref());
+    seek(&ctx, storage.as_ref().as_ref());
+    near_seek(&ctx, storage.as_ref().as_ref());
+    // TODO: test multiple node
+}
+
+pub fn make_key(k: &[u8]) -> Key {
+    Key::from_raw(k)
+}
+
+fn must_put(ctx: &Context, engine: &Engine, key: &[u8], value: &[u8]) {
+    engine.put(ctx, make_key(key), value.to_vec()).unwrap();
+}
+
+fn must_delete(ctx: &Context, engine: &Engine, key: &[u8]) {
+    engine.delete(ctx, make_key(key)).unwrap();
+}
+
+fn assert_has(ctx: &Context, engine: &Engine, key: &[u8], value: &[u8]) {
+    assert_eq!(engine.get(ctx, &make_key(key)).unwrap().unwrap(), value);
+}
+
+fn assert_none(ctx: &Context, engine: &Engine, key: &[u8]) {
+    assert_eq!(engine.get(ctx, &make_key(key)).unwrap(), None);
+}
+
+fn assert_seek(ctx: &Context, engine: &Engine, key: &[u8], pair: (&[u8], &[u8])) {
+    let mut iter = engine.iter(ctx).unwrap();
+    iter.seek(&make_key(key)).unwrap();
+    assert_eq!((iter.key(), iter.value()),
+               (&*bytes::encode_bytes(pair.0), pair.1));
+}
+
+fn assert_near_seek(cursor: &mut Cursor, key: &[u8], pair: (&[u8], &[u8])) {
+    assert!(cursor.near_seek(&make_key(key)).unwrap(), escape(key));
+    assert_eq!((cursor.key(), cursor.value()),
+               (&*bytes::encode_bytes(pair.0), pair.1));
+}
+
+fn assert_near_reverse_seek(cursor: &mut Cursor, key: &[u8], pair: (&[u8], &[u8])) {
+    assert!(cursor.near_reverse_seek(&make_key(key)).unwrap(),
+            escape(key));
+    assert_eq!((cursor.key(), cursor.value()),
+               (&*bytes::encode_bytes(pair.0), pair.1));
+}
+
+fn get_put(ctx: &Context, engine: &Engine) {
+    assert_none(ctx, engine, b"x");
+    must_put(ctx, engine, b"x", b"1");
+    assert_has(ctx, engine, b"x", b"1");
+    must_put(ctx, engine, b"x", b"2");
+    assert_has(ctx, engine, b"x", b"2");
+}
+
+fn batch(ctx: &Context, engine: &Engine) {
+    engine.write(ctx,
+               vec![Modify::Put((make_key(b"x"), b"1".to_vec())),
+                    Modify::Put((make_key(b"y"), b"2".to_vec()))])
+        .unwrap();
+    assert_has(ctx, engine, b"x", b"1");
+    assert_has(ctx, engine, b"y", b"2");
+
+    engine.write(ctx,
+               vec![Modify::Delete(make_key(b"x")), Modify::Delete(make_key(b"y"))])
+        .unwrap();
+    assert_none(ctx, engine, b"y");
+    assert_none(ctx, engine, b"y");
+}
+
+fn seek(ctx: &Context, engine: &Engine) {
+    must_put(ctx, engine, b"x", b"1");
+    assert_seek(ctx, engine, b"x", (b"x", b"1"));
+    assert_seek(ctx, engine, b"a", (b"x", b"1"));
+    must_put(ctx, engine, b"z", b"2");
+    assert_seek(ctx, engine, b"y", (b"z", b"2"));
+    assert_seek(ctx, engine, b"x\x00", (b"z", b"2"));
+    let mut iter = engine.iter(ctx).unwrap();
+    assert!(!iter.seek(&make_key(b"z\x00")).unwrap());
+    must_delete(ctx, engine, b"x");
+    must_delete(ctx, engine, b"z");
+}
+
+fn near_seek(ctx: &Context, engine: &Engine) {
+    must_put(ctx, engine, b"x", b"1");
+    must_put(ctx, engine, b"z", b"2");
+    let mut cursor = engine.iter(ctx).unwrap();
+    let cursor_mut = cursor.as_mut();
+    assert_near_seek(cursor_mut, b"x", (b"x", b"1"));
+    assert_near_seek(cursor_mut, b"a", (b"x", b"1"));
+    assert_near_reverse_seek(cursor_mut, b"z1", (b"z", b"2"));
+    assert_near_reverse_seek(cursor_mut, b"x1", (b"x", b"1"));
+    assert_near_seek(cursor_mut, b"y", (b"z", b"2"));
+    assert_near_seek(cursor_mut, b"x\x00", (b"z", b"2"));
+    assert!(!cursor_mut.near_seek(&make_key(b"z\x00")).unwrap());
+    must_delete(ctx, engine, b"x");
+    must_delete(ctx, engine, b"z");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -41,6 +41,7 @@ mod test_raft_flow_control;
 mod test_raw_node;
 mod raftstore;
 mod coprocessor;
+mod storage;
 mod util;
 
 #[test]


### PR DESCRIPTION
Remove lifetime of snapshot to make code more clean and make it easy to merge snapshot generation into snapshot manager later.

@ngaut @siddontang @disksing PTAL