### PR TITLE
raftstore: enlarge default notify queue capacity

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -9,6 +9,8 @@ dsn = "rocksdb"
 store = "/tmp/tikv/store"
 # log level: trace, debug, info, warn, error, off.
 log-level = "info"
+# notify capacity, 40960 is suitable for about 7000 regions.
+notify-capacity = 40960
 
 # set store capacity, if no set, use unlimited or disk size later.
 # capacity = 0 # 0 is unlimited.
@@ -19,6 +21,10 @@ log-level = "info"
 addr = ""
 # metric prefix.
 prefix = "tikv"
+
+[raftstore]
+# notify capacity, 40960 is suitable for about 7000 regions.
+notify-capacity = 40960
 
 [raft]
 # set cluster id, must greater than 0.

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -30,6 +30,7 @@ const REGION_CHECK_DIFF: u64 = 8 * 1024 * 1024;
 const PD_HEARTBEAT_TICK_INTERVAL_MS: u64 = 5000;
 const PD_STORE_HEARTBEAT_TICK_INTERVAL_MS: u64 = 10000;
 const STORE_CAPACITY: u64 = u64::MAX;
+const DEFAULT_NOTIFY_CAPACITY: usize = 40960;
 
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -64,6 +65,7 @@ pub struct Config {
     pub region_check_size_diff: u64,
     pub pd_heartbeat_tick_interval: u64,
     pub pd_store_heartbeat_tick_interval: u64,
+    pub notify_capacity: usize,
 }
 
 impl Default for Config {
@@ -84,6 +86,7 @@ impl Default for Config {
             region_check_size_diff: REGION_CHECK_DIFF,
             pd_heartbeat_tick_interval: PD_HEARTBEAT_TICK_INTERVAL_MS,
             pd_store_heartbeat_tick_interval: PD_STORE_HEARTBEAT_TICK_INTERVAL_MS,
+            notify_capacity: DEFAULT_NOTIFY_CAPACITY,
         }
     }
 }

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -30,7 +30,7 @@ const REGION_CHECK_DIFF: u64 = 8 * 1024 * 1024;
 const PD_HEARTBEAT_TICK_INTERVAL_MS: u64 = 5000;
 const PD_STORE_HEARTBEAT_TICK_INTERVAL_MS: u64 = 10000;
 const STORE_CAPACITY: u64 = u64::MAX;
-const DEFAULT_NOTIFY_CAPACITY: usize = 40960;
+const DEFAULT_NOTIFY_CAPACITY: usize = 4096;
 
 #[derive(Debug, Clone)]
 pub struct Config {

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -89,6 +89,7 @@ pub fn create_event_loop<T, C>(cfg: &Config) -> Result<EventLoop<Store<T, C>>>
     // We use base raft tick as the event loop timer tick.
     let mut builder = EventLoopBuilder::new();
     builder.timer_tick(Duration::from_millis(cfg.raft_base_tick_interval));
+    builder.notify_capacity(cfg.notify_capacity);
     let event_loop = try!(builder.build());
     Ok(event_loop)
 }

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -17,6 +17,7 @@ use super::Result;
 const DEFAULT_CLUSTER_ID: u64 = 0;
 pub const DEFAULT_LISTENING_ADDR: &'static str = "127.0.0.1:20160";
 const DEFAULT_ADVERTISE_LISTENING_ADDR: &'static str = "";
+const DEFAULT_NOTIFY_CAPACITY: usize = 4096;
 
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -28,7 +29,7 @@ pub struct Config {
     // Server advertise listening address for outer communication.
     // If not set, we will use listening address instead.
     pub advertise_addr: String,
-
+    pub notify_capacity: usize,
     pub store_cfg: StoreConfig,
 }
 
@@ -38,6 +39,7 @@ impl Default for Config {
             cluster_id: DEFAULT_CLUSTER_ID,
             addr: DEFAULT_LISTENING_ADDR.to_owned(),
             advertise_addr: DEFAULT_ADVERTISE_LISTENING_ADDR.to_owned(),
+            notify_capacity: DEFAULT_NOTIFY_CAPACITY,
             store_cfg: StoreConfig::default(),
         }
     }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -18,7 +18,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::boxed::Box;
 use std::net::SocketAddr;
 
-use mio::{Token, Handler, EventLoop, EventSet, PollOpt};
+use mio::{Token, Handler, EventLoop, EventLoopBuilder, EventSet, PollOpt};
 use mio::tcp::{TcpListener, TcpStream};
 
 use kvproto::raft_cmdpb::RaftCmdRequest;
@@ -40,13 +40,16 @@ use raft::SnapshotStatus;
 const SERVER_TOKEN: Token = Token(1);
 const FIRST_CUSTOM_TOKEN: Token = Token(1024);
 const DEFAULT_COPROCESSOR_BATCH: usize = 50;
+const DEFAULT_NOTIFY_CAPACITY: usize = 40960;
 
 pub fn create_event_loop<T, S>() -> Result<EventLoop<Server<T, S>>>
     where T: RaftStoreRouter,
           S: StoreAddrResolver
 {
-    let event_loop = try!(EventLoop::new());
-    Ok(event_loop)
+    let mut builder = EventLoopBuilder::new();
+    builder.notify_capacity(DEFAULT_NOTIFY_CAPACITY);
+    let el = try!(builder.build());
+    Ok(el)
 }
 
 pub fn bind(addr: &str) -> Result<TcpListener> {

--- a/tests/raftstore/util.rs
+++ b/tests/raftstore/util.rs
@@ -77,6 +77,7 @@ pub fn new_store_cfg() -> Config {
         raft_log_gc_threshold: 1,
         pd_heartbeat_tick_interval: 20,
         region_check_size_diff: 10000,
+        notify_capacity: 4096,
         ..Config::default()
     }
 }

--- a/tests/raftstore/util.rs
+++ b/tests/raftstore/util.rs
@@ -77,7 +77,6 @@ pub fn new_store_cfg() -> Config {
         raft_log_gc_threshold: 1,
         pd_heartbeat_tick_interval: 20,
         region_check_size_diff: 10000,
-        notify_capacity: 4096,
         ..Config::default()
     }
 }


### PR DESCRIPTION
Default capacity for notify queue is 4096, which is small when region count increase to more than 7000.

@ngaut @siddontang @disksing PTAL