### PR TITLE
raftstore: let mgr schedule snapshot production

### DIFF
--- a/src/raftstore/store/mod.rs
+++ b/src/raftstore/store/mod.rs
@@ -33,5 +33,5 @@ pub use self::transport::Transport;
 pub use self::peer::Peer;
 pub use self::bootstrap::{bootstrap_store, bootstrap_region, write_region, clear_region};
 pub use self::engine::{Peekable, Iterable, Mutable};
-pub use self::peer_storage::{PeerStorage, do_snapshot, SnapState, RaftStorage};
-pub use self::snap::{SnapFile, SnapKey, SnapManager, new_snap_mgr};
+pub use self::peer_storage::{PeerStorage, do_snapshot, Range, RaftStorage};
+pub use self::snap::{SnapFile, SnapKey, SnapState, SnapManager, new_snap_mgr};

--- a/src/raftstore/store/mod.rs
+++ b/src/raftstore/store/mod.rs
@@ -34,4 +34,4 @@ pub use self::peer::Peer;
 pub use self::bootstrap::{bootstrap_store, bootstrap_region, write_region, clear_region};
 pub use self::engine::{Peekable, Iterable, Mutable};
 pub use self::peer_storage::{PeerStorage, do_snapshot, Range, RaftStorage};
-pub use self::snap::{SnapFile, SnapKey, SnapState, SnapManager, new_snap_mgr};
+pub use self::snap::{SnapFile, SnapKey, SnapState, SnapManager, new_snap_mgr, GenericSendCh};

--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 use mio;
 
 use raftstore::{Result, send_msg, Error};
+use raftstore::store::SnapKey;
 use kvproto::raft_serverpb::RaftMessage;
 use kvproto::raft_cmdpb::{RaftCmdRequest, RaftCmdResponse};
 use kvproto::metapb::RegionEpoch;
@@ -62,6 +63,10 @@ pub enum Msg {
         region_id: u64,
         to_peer_id: u64,
     },
+
+    SnapshotGenerated {
+        key: SnapKey,
+    },
 }
 
 impl fmt::Debug for Msg {
@@ -84,6 +89,7 @@ impl fmt::Debug for Msg {
                        to_peer_id,
                        region_id)
             }
+            Msg::SnapshotGenerated { ref key } => write!(fmt, "snapshot {} generated", key),
         }
     }
 }

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -14,7 +14,7 @@
 use std::sync::{self, Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::io::{Seek, SeekFrom};
 use std::fs::File;
-use std::{error, mem};
+use std::error;
 use std::time::Instant;
 
 use rocksdb::{DB, WriteBatch, Writable};
@@ -37,18 +37,8 @@ use super::{SnapFile, SnapKey, SnapManager};
 // so that we can force the follower peer to sync the snapshot first.
 pub const RAFT_INIT_LOG_TERM: u64 = 5;
 pub const RAFT_INIT_LOG_INDEX: u64 = 5;
-const MAX_SNAP_TRY_CNT: u8 = 5;
 
-pub type Ranges = Vec<(Vec<u8>, Vec<u8>)>;
-
-#[derive(PartialEq, Debug)]
-pub enum SnapState {
-    Relax,
-    Pending,
-    Generating,
-    Snap(Snapshot),
-    Failed,
-}
+pub type Range = (Vec<u8>, Vec<u8>);
 
 pub struct PeerStorage {
     engine: Arc<DB>,
@@ -60,9 +50,7 @@ pub struct PeerStorage {
     // 1, a truncated state preceded the first log entry.
     // 2, a dummy entry for the start point of the empty log.
     pub truncated_state: RaftTruncatedState,
-    pub snap_state: SnapState,
     snap_mgr: SnapManager,
-    snap_tried_cnt: u8,
 }
 
 fn storage_error<E>(error: E) -> raft::Error
@@ -103,8 +91,6 @@ impl PeerStorage {
             last_index: 0,
             applied_index: 0,
             truncated_state: RaftTruncatedState::new(),
-            snap_state: SnapState::Relax,
-            snap_tried_cnt: 0,
             snap_mgr: snap_mgr,
         };
 
@@ -242,29 +228,6 @@ impl PeerStorage {
 
     pub fn raw_snapshot(&self) -> DbSnapshot {
         DbSnapshot::new(self.engine.clone())
-    }
-
-    pub fn snapshot(&mut self) -> raft::Result<Snapshot> {
-        if let SnapState::Relax = self.snap_state {
-            info!("requesting snapshot on {}...", self.get_region_id());
-            self.snap_tried_cnt = 0;
-            self.snap_state = SnapState::Pending;
-        } else if let SnapState::Snap(_) = self.snap_state {
-            match mem::replace(&mut self.snap_state, SnapState::Relax) {
-                SnapState::Snap(s) => return Ok(s),
-                _ => unreachable!(),
-            }
-        } else if let SnapState::Failed = self.snap_state {
-            if self.snap_tried_cnt >= MAX_SNAP_TRY_CNT {
-                return Err(raft::Error::Store(box_err!("failed to get snapshot after {} times",
-                                                       self.snap_tried_cnt)));
-            }
-            self.snap_tried_cnt += 1;
-            warn!("snapshot generating failed, retry {} time",
-                  self.snap_tried_cnt);
-            self.snap_state = SnapState::Pending;
-        }
-        Err(raft::Error::Store(raft::StorageError::SnapshotTemporarilyUnavailable))
     }
 
     // Append the given entries to the raft log using previous last index or self.last_index.
@@ -475,7 +438,7 @@ impl PeerStorage {
     // [region raft start, region raft end) -> saving raft entries, applied index, etc.
     // [region meta start, region meta end) -> saving region meta information except raft.
     // [region data start, region data end) -> saving region data.
-    pub fn region_key_ranges(&self) -> Ranges {
+    pub fn region_key_ranges(&self) -> Vec<Range> {
         let (start_key, end_key) = (enc_start_key(self.get_region()),
                                     enc_end_key(self.get_region()));
 
@@ -543,13 +506,13 @@ impl PeerStorage {
 fn build_snap_file(f: &mut SnapFile,
                    snap: &DbSnapshot,
                    region_id: u64,
-                   ranges: Ranges)
+                   ranges: &[Range])
                    -> raft::Result<()> {
     // Scan everything except raft logs for this region.
     let log_prefix = keys::raft_log_prefix(region_id);
     let mut snap_size = 0;
     let mut snap_key_cnt = 0;
-    for (begin, end) in ranges {
+    for &(ref begin, ref end) in ranges {
         try!(snap.scan(&begin,
                        &end,
                        &mut |key, value| {
@@ -578,10 +541,10 @@ fn build_snap_file(f: &mut SnapFile,
     Ok(())
 }
 
-pub fn do_snapshot(mgr: SnapManager,
+pub fn do_snapshot(snap_file: &mut SnapFile,
                    snap: &DbSnapshot,
-                   key: SnapKey,
-                   ranges: Ranges)
+                   key: &SnapKey,
+                   ranges: &[Range])
                    -> raft::Result<Snapshot> {
     debug!("begin to generate a snapshot for region {}", key.region_id);
 
@@ -610,7 +573,6 @@ pub fn do_snapshot(mgr: SnapManager,
     let mut snap_data = RaftSnapshotData::new();
     snap_data.set_region(region);
 
-    let mut snap_file = try!(mgr.rl().get_snap_file(&key, true));
     if snap_file.exists() {
         if let Err(e) = snap_file.validate() {
             error!("file {} is invalid, will regenerate: {:?}",
@@ -618,10 +580,10 @@ pub fn do_snapshot(mgr: SnapManager,
                    e);
             try!(snap_file.try_delete());
             try!(snap_file.init());
-            try!(build_snap_file(&mut snap_file, snap, key.region_id, ranges));
+            try!(build_snap_file(snap_file, snap, key.region_id, ranges));
         }
     } else {
-        try!(build_snap_file(&mut snap_file, snap, key.region_id, ranges));
+        try!(build_snap_file(snap_file, snap, key.region_id, ranges));
     }
 
     let len = try!(snap_file.meta()).len();
@@ -696,21 +658,37 @@ impl Storage for RaftStorage {
     }
 
     fn snapshot(&self) -> raft::Result<Snapshot> {
-        self.wl().snapshot()
+        let inner = self.wl();
+        let mut snap_mgr = inner.snap_mgr.wl();
+        // TODO: check snapshot index and reject stale snapshot.
+        let (key, mut s) = try!(snap_mgr.gen_snap(&inner, false));
+        let first_index = inner.first_index();
+        if key.idx < first_index {
+            debug!("last snapshot is stale, so reschedule: {} < {}",
+                   key.idx,
+                   first_index);
+            s = try!(snap_mgr.gen_snap(&inner, true)).1;
+        }
+        match s {
+            None => Err(raft::Error::Store(raft::StorageError::SnapshotTemporarilyUnavailable)),
+            Some(s) => Ok(s),
+        }
     }
 }
 
 #[cfg(test)]
 mod test {
     use std::sync::*;
-    use std::io;
+    use std::{io, thread};
     use std::fs::File;
+    use std::time::Duration;
     use rocksdb::*;
     use kvproto::raftpb::{Entry, ConfState, Snapshot};
     use kvproto::raft_serverpb::RaftSnapshotData;
     use raft::{StorageError, Error as RaftError};
     use tempdir::*;
     use protobuf;
+    use raft::Storage;
     use raftstore::store::*;
     use util::codec::number::NumberEncoder;
     use util::HandyRwLock;
@@ -840,7 +818,8 @@ mod test {
         let applied_id = s.rl().load_applied_index(&raw_snap).unwrap();
         let term = s.rl().term(applied_id).unwrap();
         let key = SnapKey::new(s.rl().get_region_id(), term, applied_id);
-        do_snapshot(mgr, &raw_snap, key, key_ranges).unwrap()
+        let mut snap_file = mgr.wl().get_snap_file(&key, true).unwrap();
+        do_snapshot(&mut snap_file, &raw_snap, &key, &key_ranges).unwrap()
     }
 
     #[test]
@@ -852,15 +831,27 @@ mod test {
         let td = TempDir::new("tikv-store-test").unwrap();
         let snap_dir = TempDir::new("snap_dir").unwrap();
         let mgr = new_snap_mgr(snap_dir.path().to_str().unwrap());
+        mgr.wl().start().unwrap();
         let s = new_storage_from_ents(mgr, &td, &ents);
-        let snap = s.wl().snapshot();
+        let mut snap_res = s.snapshot();
         let unavailable = RaftError::Store(StorageError::SnapshotTemporarilyUnavailable);
-        assert_eq!(snap.unwrap_err(), unavailable);
-        assert_eq!(s.wl().snap_state, SnapState::Pending);
+        assert_eq!(snap_res.unwrap_err(), unavailable);
 
-        s.wl().snap_state = SnapState::Generating;
-        assert_eq!(s.wl().snapshot().unwrap_err(), unavailable);
-        assert_eq!(s.rl().snap_state, SnapState::Generating);
+        let mut try_cnt = 0;
+        loop {
+            snap_res = s.snapshot();
+            if snap_res.is_ok() {
+                break;
+            }
+
+            if try_cnt >= 100 {
+                panic!("failed to genenrate snapshot");
+            } else {
+                thread::sleep(Duration::from_millis(20));
+            }
+
+            try_cnt += 1;
+        }
 
         let snap_dir = TempDir::new("snap").unwrap();
         let snap = get_snap(&s, new_snap_mgr(snap_dir.path().to_str().unwrap()));
@@ -873,8 +864,7 @@ mod test {
         assert_eq!(data.get_region().get_id(), 1);
         assert_eq!(data.get_region().get_peers().len(), 1);
 
-        s.wl().snap_state = SnapState::Snap(snap.clone());
-        assert_eq!(s.wl().snapshot(), Ok(snap));
+        assert_eq!(snap_res, Ok(snap));
     }
 
     #[test]

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -37,14 +37,13 @@ use raftstore::{Result, Error};
 use kvproto::metapb;
 use util::worker::Worker;
 use util::get_disk_stat;
-use super::worker::{SplitCheckRunner, SplitCheckTask, SnapTask, SnapRunner, CompactTask,
-                    CompactRunner, PdRunner, PdTask};
+use super::worker::{SplitCheckRunner, SplitCheckTask, CompactTask, CompactRunner, PdRunner, PdTask};
 use super::{util, SendCh, Msg, Tick, SnapManager, SnapKey};
 use super::keys::{self, enc_start_key, enc_end_key};
 use super::engine::{Peekable, Iterable};
 use super::config::Config;
 use super::peer::{Peer, PendingCmd, ReadyResult, ExecResult};
-use super::peer_storage::{SnapState, ApplySnapResult};
+use super::peer_storage::ApplySnapResult;
 use super::msg::Callback;
 use super::cmd_resp::{bind_uuid, bind_term, bind_error};
 use super::transport::Transport;
@@ -67,7 +66,6 @@ pub struct Store<T: Transport, C: PdClient + 'static> {
     region_ranges: BTreeMap<Key, u64>,
 
     split_check_worker: Worker<SplitCheckTask>,
-    snap_worker: Worker<SnapTask>,
     compact_worker: Worker<CompactTask>,
     pd_worker: Worker<PdTask>,
 
@@ -118,7 +116,6 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             region_peers: HashMap::new(),
             pending_raft_groups: HashSet::new(),
             split_check_worker: Worker::new("split check worker"),
-            snap_worker: Worker::new("snapshot worker"),
             compact_worker: Worker::new("compact worker"),
             pd_worker: Worker::new("pd worker"),
             region_ranges: BTreeMap::new(),
@@ -160,7 +157,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
     pub fn run(&mut self, event_loop: &mut EventLoop<Self>) -> Result<()> {
         try!(self.prepare());
 
-        try!(self.snap_mgr.wl().try_recover());
+        box_try!(self.snap_mgr.wl().start());
 
         self.register_raft_base_tick(event_loop);
         self.register_raft_gc_log_tick(event_loop);
@@ -172,8 +169,6 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                                                        self.cfg.region_max_size,
                                                        self.cfg.region_split_size);
         box_try!(self.split_check_worker.start(split_check_runner));
-
-        box_try!(self.snap_worker.start(SnapRunner::new(self.snap_mgr.clone())));
 
         box_try!(self.compact_worker.start(CompactRunner));
 
@@ -221,17 +216,6 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         for (region_id, peer) in &mut self.region_peers {
             peer.raft_group.tick();
             self.pending_raft_groups.insert(*region_id);
-            // ALERT!!! patern matching won't release lock here.
-            if peer.is_leader() && SnapState::Pending == peer.storage.rl().snap_state {
-                debug!("handling snapshot for {}", region_id);
-                let task = SnapTask::new(peer.storage.clone());
-                debug!("task generated");
-                peer.storage.wl().snap_state = SnapState::Generating;
-                if let Err(e) = self.snap_worker.schedule(task) {
-                    error!("failed to schedule snap task {}", e);
-                    peer.storage.wl().snap_state = SnapState::Failed;
-                }
-            }
         }
 
         self.register_raft_base_tick(event_loop);
@@ -979,8 +963,8 @@ impl<T: Transport, C: PdClient> mio::Handler for Store<T, C> {
                 error!("failed to stop split scan thread: {:?}!!!", e);
             }
 
-            if let Err(e) = self.snap_worker.stop() {
-                error!("failed to stop snap thread: {:?}!!!", e);
+            if let Err(e) = self.snap_mgr.wl().stop() {
+                error!("failed to stop snap manager: {:?}", e);
             }
 
             if let Err(e) = self.compact_worker.stop() {


### PR DESCRIPTION
Let snapshot manager schedule snapshot production, which will speed up snapshot production and make stats collection more easy.

@ngaut @siddontang @disksing PTAL