### PR TITLE
server: report status after snap is scheduling to store

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -161,6 +161,9 @@ pub enum Msg {
         sock_addr: Result<SocketAddr>,
         data: ConnData,
     },
+    CloseConn {
+        token: Token,
+    },
 }
 
 #[derive(Debug)]

--- a/src/server/snap.rs
+++ b/src/server/snap.rs
@@ -47,7 +47,6 @@ const DEFAULT_SENDER_POOL_SIZE: usize = 3;
 /// `Discard` discard all the unsaved changes made to snapshot file;
 /// `SendTo` send the snapshot file to specified address.
 pub enum Task {
-    // bool indicate whether the initialization succeed.
     Register(Token, RaftMessage),
     Write(Token, ByteBuf),
     Close(Token),


### PR DESCRIPTION
Currently snap status is reported when all data is received by the follower. But this may lead to generate snapshot multiple times. So we should report status after snapshot is scheduling to store. This will make sure further append message is handled after snapshot is applied.

@ngaut @siddontang @disksing PTAL