### PR TITLE
raftstore: fix possiblely calling the wrong callback

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -344,7 +344,10 @@ impl Peer {
             return cmd.cb.call_box((err_resp,));
         }
 
-        debug!("propose command with uuid {:?}", cmd.uuid);
+        debug!("[{}] {} propose command with uuid {:?}",
+               self.region_id,
+               self.peer_id(),
+               cmd.uuid);
         metric_incr!("raftstore.propose");
 
         if let Err(e) = self.check_epoch(&req) {
@@ -395,6 +398,10 @@ impl Peer {
         let leader = self.get_peer_from_cache(self.leader_id());
         let not_leader = Error::NotLeader(self.region_id, leader);
         let resp = cmd_resp::err_resp(not_leader, cmd.uuid, self.term());
+        warn!("[{}] {:?} {} is stale, skip",
+              self.region_id,
+              self.peer,
+              cmd.uuid);
         if let Err(e) = cmd.cb.call_box((resp,)) {
             error!("failed to clean stale callback of {}: {:?}", cmd.uuid, e);
         }
@@ -686,7 +693,10 @@ impl Peer {
             (cmd_resp::new_error(e), None)
         });
 
-        debug!("command with uuid {:?} is applied", uuid);
+        debug!("[{}] {} command with uuid {:?} is applied",
+               self.region_id,
+               self.peer_id(),
+               uuid);
 
         if cb.is_none() {
             return Ok(exec_result);

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -592,7 +592,8 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             Some(peer) => peer,
         };
 
-        bind_term(&mut resp, peer.term());
+        let term = peer.term();
+        bind_term(&mut resp, term);
 
         if !peer.is_leader() {
             bind_error(&mut resp,
@@ -619,6 +620,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
 
         let pending_cmd = PendingCmd {
             uuid: uuid,
+            term: term,
             cb: cb,
         };
         try!(peer.propose(pending_cmd, msg, resp));

--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -52,7 +52,7 @@ pub trait Simulator {
     fn send_raft_msg(&self, msg: RaftMessage) -> Result<()>;
     fn get_store_sendch(&self, node_id: u64) -> Option<SendCh>;
     fn add_filter(&self, node_id: u64, filter: Box<Filter>);
-    fn clear_filter(&self, node_id: u64);
+    fn clear_filters(&self, node_id: u64);
 }
 
 pub struct Cluster<T: Simulator> {
@@ -136,16 +136,12 @@ impl<T: Simulator> Cluster<T> {
     }
 
     pub fn run_node(&mut self, node_id: u64) {
-        debug!("starting node {}", node_id);
         let engine = self.engines.get(&node_id).unwrap();
         self.sim.wl().run_node(node_id, self.cfg.clone(), engine.clone());
-        debug!("node {} started", node_id);
     }
 
     pub fn stop_node(&mut self, node_id: u64) {
-        debug!("stopping node {}", node_id);
         self.sim.wl().stop_node(node_id);
-        debug!("node {} stopped", node_id);
     }
 
     pub fn get_engine(&self, node_id: u64) -> Arc<DB> {
@@ -519,10 +515,10 @@ impl<T: Simulator> Cluster<T> {
         }
     }
 
-    pub fn clear_filter(&mut self) {
+    pub fn clear_filters(&mut self) {
         let sim = self.sim.wl();
         for node_id in sim.get_node_ids() {
-            sim.clear_filter(node_id);
+            sim.clear_filters(node_id);
         }
     }
 

--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -51,7 +51,8 @@ pub trait Simulator {
     fn call_command(&self, request: RaftCmdRequest, timeout: Duration) -> Result<RaftCmdResponse>;
     fn send_raft_msg(&self, msg: RaftMessage) -> Result<()>;
     fn get_store_sendch(&self, node_id: u64) -> Option<SendCh>;
-    fn hook_transport(&self, node_id: u64, filters: Vec<Box<Filter>>);
+    fn add_filter(&self, node_id: u64, filters: Box<Filter>);
+    fn clear_filter(&self, node_id: u64);
 }
 
 pub struct Cluster<T: Simulator> {
@@ -135,12 +136,16 @@ impl<T: Simulator> Cluster<T> {
     }
 
     pub fn run_node(&mut self, node_id: u64) {
+        debug!("starting node {}", node_id);
         let engine = self.engines.get(&node_id).unwrap();
         self.sim.wl().run_node(node_id, self.cfg.clone(), engine.clone());
+        debug!("node {} started", node_id);
     }
 
     pub fn stop_node(&mut self, node_id: u64) {
+        debug!("stopping node {}", node_id);
         self.sim.wl().stop_node(node_id);
+        debug!("node {} stopped", node_id);
     }
 
     pub fn get_engine(&self, node_id: u64) -> Arc<DB> {
@@ -479,11 +484,12 @@ impl<T: Simulator> Cluster<T> {
         status_resp.take_region_detail()
     }
 
-    pub fn hook_transport<F: FilterFactory>(&self, factory: F) {
+    pub fn add_filter<F: FilterFactory>(&self, factory: F) {
         let sim = self.sim.wl();
         for node_id in sim.get_node_ids() {
-            let filter = factory.generate(node_id);
-            sim.hook_transport(node_id, filter);
+            for filter in factory.generate(node_id) {
+                sim.add_filter(node_id, filter);
+            }
         }
     }
 
@@ -513,10 +519,10 @@ impl<T: Simulator> Cluster<T> {
         }
     }
 
-    pub fn reset_transport_hooks(&mut self) {
+    pub fn clear_filter(&mut self) {
         let sim = self.sim.wl();
         for node_id in sim.get_node_ids() {
-            sim.hook_transport(node_id, vec![]);
+            sim.clear_filter(node_id);
         }
     }
 
@@ -558,7 +564,7 @@ impl<T: Simulator> Cluster<T> {
 
     // it's so common that we provide an API for it
     pub fn partition(&self, s1: Vec<u64>, s2: Vec<u64>) {
-        self.hook_transport(Partition::new(s1, s2));
+        self.add_filter(Partition::new(s1, s2));
     }
 }
 

--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -51,7 +51,7 @@ pub trait Simulator {
     fn call_command(&self, request: RaftCmdRequest, timeout: Duration) -> Result<RaftCmdResponse>;
     fn send_raft_msg(&self, msg: RaftMessage) -> Result<()>;
     fn get_store_sendch(&self, node_id: u64) -> Option<SendCh>;
-    fn add_filter(&self, node_id: u64, filters: Box<Filter>);
+    fn add_filter(&self, node_id: u64, filter: Box<Filter>);
     fn clear_filter(&self, node_id: u64);
 }
 

--- a/tests/raftstore/node.rs
+++ b/tests/raftstore/node.rs
@@ -177,9 +177,9 @@ impl Simulator for NodeCluster {
         self.trans.rl().send(msg)
     }
 
-    fn add_filter(&self, node_id: u64, filters: Box<Filter>) {
+    fn add_filter(&self, node_id: u64, filter: Box<Filter>) {
         let trans = self.simulate_trans.get(&node_id).unwrap();
-        trans.wl().add_filters(filters);
+        trans.wl().add_filters(filter);
     }
 
     fn clear_filter(&self, node_id: u64) {

--- a/tests/raftstore/node.rs
+++ b/tests/raftstore/node.rs
@@ -179,7 +179,7 @@ impl Simulator for NodeCluster {
 
     fn add_filter(&self, node_id: u64, filter: Box<Filter>) {
         let trans = self.simulate_trans.get(&node_id).unwrap();
-        trans.wl().add_filters(filter);
+        trans.wl().add_filter(filter);
     }
 
     fn clear_filter(&self, node_id: u64) {

--- a/tests/raftstore/node.rs
+++ b/tests/raftstore/node.rs
@@ -182,9 +182,9 @@ impl Simulator for NodeCluster {
         trans.wl().add_filter(filter);
     }
 
-    fn clear_filter(&self, node_id: u64) {
+    fn clear_filters(&self, node_id: u64) {
         let trans = self.simulate_trans.get(&node_id).unwrap();
-        trans.wl().clear_filter();
+        trans.wl().clear_filters();
     }
 
     fn get_store_sendch(&self, node_id: u64) -> Option<SendCh> {

--- a/tests/raftstore/node.rs
+++ b/tests/raftstore/node.rs
@@ -177,9 +177,14 @@ impl Simulator for NodeCluster {
         self.trans.rl().send(msg)
     }
 
-    fn hook_transport(&self, node_id: u64, filters: Vec<Box<Filter>>) {
+    fn add_filter(&self, node_id: u64, filters: Box<Filter>) {
         let trans = self.simulate_trans.get(&node_id).unwrap();
-        trans.wl().set_filters(filters);
+        trans.wl().add_filters(filters);
+    }
+
+    fn clear_filter(&self, node_id: u64) {
+        let trans = self.simulate_trans.get(&node_id).unwrap();
+        trans.wl().clear_filter();
     }
 
     fn get_store_sendch(&self, node_id: u64) -> Option<SendCh> {

--- a/tests/raftstore/server.rs
+++ b/tests/raftstore/server.rs
@@ -255,9 +255,9 @@ impl Simulator for ServerCluster {
         trans.wl().add_filter(filter);
     }
 
-    fn clear_filter(&self, node_id: u64) {
+    fn clear_filters(&self, node_id: u64) {
         let trans = self.sim_trans.get(&node_id).unwrap();
-        trans.wl().clear_filter();
+        trans.wl().clear_filters();
     }
 
     fn get_store_sendch(&self, node_id: u64) -> Option<StoreSendCh> {

--- a/tests/raftstore/server.rs
+++ b/tests/raftstore/server.rs
@@ -252,7 +252,7 @@ impl Simulator for ServerCluster {
 
     fn add_filter(&self, node_id: u64, filter: Box<Filter>) {
         let trans = self.sim_trans.get(&node_id).unwrap();
-        trans.wl().add_filters(filter);
+        trans.wl().add_filter(filter);
     }
 
     fn clear_filter(&self, node_id: u64) {

--- a/tests/raftstore/server.rs
+++ b/tests/raftstore/server.rs
@@ -250,9 +250,9 @@ impl Simulator for ServerCluster {
         Ok(())
     }
 
-    fn add_filter(&self, node_id: u64, filters: Box<Filter>) {
+    fn add_filter(&self, node_id: u64, filter: Box<Filter>) {
         let trans = self.sim_trans.get(&node_id).unwrap();
-        trans.wl().add_filters(filters);
+        trans.wl().add_filters(filter);
     }
 
     fn clear_filter(&self, node_id: u64) {

--- a/tests/raftstore/server.rs
+++ b/tests/raftstore/server.rs
@@ -250,9 +250,14 @@ impl Simulator for ServerCluster {
         Ok(())
     }
 
-    fn hook_transport(&self, node_id: u64, filters: Vec<Box<Filter>>) {
+    fn add_filter(&self, node_id: u64, filters: Box<Filter>) {
         let trans = self.sim_trans.get(&node_id).unwrap();
-        trans.wl().set_filters(filters);
+        trans.wl().add_filters(filters);
+    }
+
+    fn clear_filter(&self, node_id: u64) {
+        let trans = self.sim_trans.get(&node_id).unwrap();
+        trans.wl().clear_filter();
     }
 
     fn get_store_sendch(&self, node_id: u64) -> Option<StoreSendCh> {

--- a/tests/raftstore/test_conf_change.rs
+++ b/tests/raftstore/test_conf_change.rs
@@ -420,7 +420,7 @@ fn test_split_brain<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.must_put(b"k2", b"v2");
 
     // when network recovers, 1 will send request vote to [2,3]
-    cluster.clear_filter();
+    cluster.clear_filters();
     cluster.partition(vec![1, 2, 3], vec![4, 5, 6]);
 
     // refresh region info, maybe no need

--- a/tests/raftstore/test_conf_change.rs
+++ b/tests/raftstore/test_conf_change.rs
@@ -404,7 +404,7 @@ fn test_split_brain<T: Simulator>(cluster: &mut Cluster<T>) {
 
     // leader isolation
     cluster.must_transfer_leader(r1, new_peer(1, 1));
-    cluster.hook_transport(Isolate::new(1));
+    cluster.add_filter(Isolate::new(1));
 
     // refresh region info, maybe no need
     cluster.must_put(b"k1", b"v1");
@@ -420,7 +420,7 @@ fn test_split_brain<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.must_put(b"k2", b"v2");
 
     // when network recovers, 1 will send request vote to [2,3]
-    cluster.reset_transport_hooks();
+    cluster.clear_filter();
     cluster.partition(vec![1, 2, 3], vec![4, 5, 6]);
 
     // refresh region info, maybe no need

--- a/tests/raftstore/test_multi.rs
+++ b/tests/raftstore/test_multi.rs
@@ -18,8 +18,7 @@ use super::util::*;
 use super::cluster::{Cluster, Simulator};
 use super::node::new_node_cluster;
 use super::server::new_server_cluster;
-use super::transport_simulate::{Delay, DropPacket};
-use super::transport_simulate::IsolateRegionStore;
+use super::transport_simulate::*;
 
 use rand;
 use rand::Rng;
@@ -271,16 +270,19 @@ fn test_multi_server_random_restart() {
 }
 
 fn test_leader_change_with_uncommitted_log<T: Simulator>(cluster: &mut Cluster<T>) {
+    cluster.cfg.store_cfg.raft_election_timeout_ticks = 50;
     // We use three nodes([1, 2, 3]) for this test.
     cluster.run();
+
+    sleep_ms(500);
 
     // guarantee node 1 is leader
     cluster.must_transfer_leader(1, new_peer(1, 1));
     cluster.must_put(b"k0", b"v0");
     assert_eq!(cluster.leader_of_region(1), Some(new_peer(1, 1)));
 
-    // isolate node 3 for region 1.
-    cluster.add_filter(IsolateRegionStore::new(Some(MessageType::MsgAppend), 1, 3, 3, 0));
+    // So node 3 won't replicate any message of the region but still can vote.
+    cluster.add_filter(IsolateRegionStore::new(1, 3).msg_type(MessageType::MsgAppend));
     cluster.must_put(b"k1", b"v1");
 
     // node 1 and node 2 must have k2, but node 3 must not.
@@ -293,13 +295,26 @@ fn test_leader_change_with_uncommitted_log<T: Simulator>(cluster: &mut Cluster<T
     must_get_none(&engine3, b"k1");
 
     // now only 1 and 2 can step to leader.
-    cluster.add_filter(IsolateRegionStore::new(Some(MessageType::MsgAppend), 1, 1, 2, 0));
+
     // hack: first append will append log, second append will set commit,
-    // so only allow first append.
-    cluster.add_filter(IsolateRegionStore::new(Some(MessageType::MsgAppend), 1, 2, 2, 1));
-    cluster.add_filter(IsolateRegionStore::new(
-        Some(MessageType::MsgHeartbeatResponse), 1, 1, 1, 0));
-    cluster.add_filter(IsolateRegionStore::new(Some(MessageType::MsgHeartbeat), 1, 2, 2, 0));
+    // So only allowing first append to make 2 have uncommitted entries.
+    cluster.add_filter(IsolateRegionStore::new(1, 2)
+        .msg_type(MessageType::MsgAppend)
+        .direction(Direction::Recv)
+        .allow(1));
+    // Make 2 have no way to know the uncommitted entries can be applied when it becomes leader.
+    cluster.add_filter(IsolateRegionStore::new(1, 1)
+        .msg_type(MessageType::MsgHeartbeatResponse)
+        .direction(Direction::Send));
+    // Make 2's msg won't be replicated when it becomes leader,
+    // so the uncommitted entries won't be applied immediatly.
+    cluster.add_filter(IsolateRegionStore::new(1, 1)
+        .msg_type(MessageType::MsgAppend)
+        .direction(Direction::Recv));
+    // Make 2 have no way to know the uncommitted entries can be applied when it's still follower.
+    cluster.add_filter(IsolateRegionStore::new(1, 2)
+        .msg_type(MessageType::MsgHeartbeat)
+        .direction(Direction::Recv));
     cluster.must_put(b"k2", b"v2");
 
     // 1 must commit, but 2 is not.
@@ -314,13 +329,6 @@ fn test_leader_change_with_uncommitted_log<T: Simulator>(cluster: &mut Cluster<T
     let mut put = new_request(region.get_id(), region.get_region_epoch().clone(), reqs);
     debug!("requesting: {:?}", put);
     put.mut_header().set_peer(new_peer(2, 2));
-    let resp = cluster.call_command(put, Duration::from_secs(3));
-    assert!(resp.is_err());
-
-    let reqs = vec![new_put_cmd(b"k4", b"v4")];
-    let mut put = new_request(region.get_id(), region.get_region_epoch().clone(), reqs);
-    debug!("requesting: {:?}", put);
-    put.mut_header().set_peer(new_peer(2, 2));
     cluster.clear_filter();
     let resp = cluster.call_command(put, Duration::from_secs(5)).unwrap();
     assert!(!resp.get_header().has_error(), format!("{:?}", resp));
@@ -328,7 +336,6 @@ fn test_leader_change_with_uncommitted_log<T: Simulator>(cluster: &mut Cluster<T
     for i in 1..4 {
         must_get_equal(&cluster.get_engine(i), b"k2", b"v2");
         must_get_equal(&cluster.get_engine(i), b"k3", b"v3");
-        must_get_equal(&cluster.get_engine(i), b"k4", b"v4");
     }
 }
 

--- a/tests/raftstore/test_multi.rs
+++ b/tests/raftstore/test_multi.rs
@@ -297,7 +297,8 @@ fn test_leader_change_with_uncommitted_log<T: Simulator>(cluster: &mut Cluster<T
     // hack: first append will append log, second append will set commit,
     // so only allow first append.
     cluster.add_filter(IsolateRegionStore::new(Some(MessageType::MsgAppend), 1, 2, 2, 1));
-    cluster.add_filter(IsolateRegionStore::new(Some(MessageType::MsgHeartbeatResponse), 1, 1, 1, 0));
+    cluster.add_filter(IsolateRegionStore::new(
+        Some(MessageType::MsgHeartbeatResponse), 1, 1, 1, 0));
     cluster.add_filter(IsolateRegionStore::new(Some(MessageType::MsgHeartbeat), 1, 2, 2, 0));
     cluster.must_put(b"k2", b"v2");
 

--- a/tests/raftstore/test_split_region.rs
+++ b/tests/raftstore/test_split_region.rs
@@ -278,7 +278,7 @@ fn test_split_overlap_snapshot<T: Simulator>(cluster: &mut Cluster<T>) {
     let engine3 = cluster.get_engine(3);
     util::must_get_none(&engine3, b"k2");
 
-    cluster.clear_filter();
+    cluster.clear_filters();
     cluster.must_put(b"k3", b"v3");
 
     util::sleep_ms(3000);
@@ -338,7 +338,7 @@ fn test_apply_new_version_snapshot<T: Simulator>(cluster: &mut Cluster<T>) {
         cluster.get(b"k2").unwrap();
     }
 
-    cluster.clear_filter();
+    cluster.clear_filters();
 
     util::sleep_ms(3000);
     // node 3 must have k1, k2.

--- a/tests/raftstore/test_split_region.rs
+++ b/tests/raftstore/test_split_region.rs
@@ -259,7 +259,7 @@ fn test_split_overlap_snapshot<T: Simulator>(cluster: &mut Cluster<T>) {
     let pd_client = cluster.pd_client.clone();
 
     // isolate node 3 for region 1.
-    cluster.add_filter(IsolateRegionStore::new(None, 1, 3, 3, 0));
+    cluster.add_filter(IsolateRegionStore::new(1, 3));
     cluster.must_put(b"k1", b"v1");
 
     let region = pd_client.get_region(b"").unwrap();
@@ -314,7 +314,7 @@ fn test_apply_new_version_snapshot<T: Simulator>(cluster: &mut Cluster<T>) {
     let pd_client = cluster.pd_client.clone();
 
     // isolate node 3 for region 1.
-    cluster.add_filter(IsolateRegionStore::new(None, 1, 3, 3, 0));
+    cluster.add_filter(IsolateRegionStore::new(1, 3));
     cluster.must_put(b"k1", b"v1");
 
     let region = pd_client.get_region(b"").unwrap();

--- a/tests/raftstore/test_split_region.rs
+++ b/tests/raftstore/test_split_region.rs
@@ -259,7 +259,7 @@ fn test_split_overlap_snapshot<T: Simulator>(cluster: &mut Cluster<T>) {
     let pd_client = cluster.pd_client.clone();
 
     // isolate node 3 for region 1.
-    cluster.hook_transport(IsolateRegionStore::new(1, 3));
+    cluster.add_filter(IsolateRegionStore::new(None, 1, 3, 3, 0));
     cluster.must_put(b"k1", b"v1");
 
     let region = pd_client.get_region(b"").unwrap();
@@ -278,7 +278,7 @@ fn test_split_overlap_snapshot<T: Simulator>(cluster: &mut Cluster<T>) {
     let engine3 = cluster.get_engine(3);
     util::must_get_none(&engine3, b"k2");
 
-    cluster.reset_transport_hooks();
+    cluster.clear_filter();
     cluster.must_put(b"k3", b"v3");
 
     util::sleep_ms(3000);
@@ -314,7 +314,7 @@ fn test_apply_new_version_snapshot<T: Simulator>(cluster: &mut Cluster<T>) {
     let pd_client = cluster.pd_client.clone();
 
     // isolate node 3 for region 1.
-    cluster.hook_transport(IsolateRegionStore::new(1, 3));
+    cluster.add_filter(IsolateRegionStore::new(None, 1, 3, 3, 0));
     cluster.must_put(b"k1", b"v1");
 
     let region = pd_client.get_region(b"").unwrap();
@@ -338,7 +338,7 @@ fn test_apply_new_version_snapshot<T: Simulator>(cluster: &mut Cluster<T>) {
         cluster.get(b"k2").unwrap();
     }
 
-    cluster.reset_transport_hooks();
+    cluster.clear_filter();
 
     util::sleep_ms(3000);
     // node 3 must have k1, k2.

--- a/tests/raftstore/test_stats.rs
+++ b/tests/raftstore/test_stats.rs
@@ -122,7 +122,7 @@ fn test_server_store_snap_stats() {
 
     must_detect_snap(&pd_client);
 
-    cluster.clear_filter();
+    cluster.clear_filters();
     // wait snapshot finish.
     sleep_ms(100);
 

--- a/tests/raftstore/test_stats.rs
+++ b/tests/raftstore/test_stats.rs
@@ -117,12 +117,12 @@ fn test_server_store_snap_stats() {
     cluster.must_put(b"k1", b"v1");
 
     // delay snapshot sending, so that we can detect this.
-    cluster.hook_transport(DelaySnapshot::new(Duration::from_millis(50)));
+    cluster.add_filter(DelaySnapshot::new(Duration::from_millis(50)));
     pd_client.must_add_peer(r1, new_peer(2, 2));
 
     must_detect_snap(&pd_client);
 
-    cluster.reset_transport_hooks();
+    cluster.clear_filter();
     // wait snapshot finish.
     sleep_ms(100);
 

--- a/tests/raftstore/test_transport.rs
+++ b/tests/raftstore/test_transport.rs
@@ -33,14 +33,14 @@ fn test_partition_write<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.must_put(key, value);
     assert_eq!(cluster.get(key), Some(value.to_vec()));
     assert_eq!(cluster.leader_of_region(region_id), Some(new_peer(1, 1)));
-    cluster.reset_transport_hooks();
+    cluster.clear_filter();
 
     // leader in minority, new leader should be elected
     cluster.partition(vec![1, 2], vec![3, 4, 5]);
     assert_eq!(cluster.get(key), Some(value.to_vec()));
     assert!(cluster.leader_of_region(region_id).unwrap().get_id() != 1);
     cluster.must_put(key, b"changed");
-    cluster.reset_transport_hooks();
+    cluster.clear_filter();
 
     // when network recover, old leader should sync data
     cluster.reset_leader_of_region(region_id);

--- a/tests/raftstore/test_transport.rs
+++ b/tests/raftstore/test_transport.rs
@@ -33,14 +33,14 @@ fn test_partition_write<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.must_put(key, value);
     assert_eq!(cluster.get(key), Some(value.to_vec()));
     assert_eq!(cluster.leader_of_region(region_id), Some(new_peer(1, 1)));
-    cluster.clear_filter();
+    cluster.clear_filters();
 
     // leader in minority, new leader should be elected
     cluster.partition(vec![1, 2], vec![3, 4, 5]);
     assert_eq!(cluster.get(key), Some(value.to_vec()));
     assert!(cluster.leader_of_region(region_id).unwrap().get_id() != 1);
     cluster.must_put(key, b"changed");
-    cluster.clear_filter();
+    cluster.clear_filters();
 
     // when network recover, old leader should sync data
     cluster.reset_leader_of_region(region_id);

--- a/tests/raftstore/transport_simulate.rs
+++ b/tests/raftstore/transport_simulate.rs
@@ -83,7 +83,7 @@ impl<T: Transport> SimulateTransport<T> {
         self.filters.clear();
     }
 
-    pub fn add_filters(&mut self, filter: Box<Filter>) {
+    pub fn add_filter(&mut self, filter: Box<Filter>) {
         self.filters.push(filter);
     }
 }

--- a/tests/raftstore/transport_simulate.rs
+++ b/tests/raftstore/transport_simulate.rs
@@ -79,7 +79,7 @@ impl<T: Transport> SimulateTransport<T> {
         }
     }
 
-    pub fn clear_filter(&mut self) {
+    pub fn clear_filters(&mut self) {
         self.filters.clear();
     }
 


### PR DESCRIPTION
When a follower with uncommitted log becomes leader and then propose a message immediately, the callback of the message will be considered as stale callback, which apparently is not.

This pr will take term into consideration, and hold the callback queue when applied entry's term is less than the callback's term.

@ngaut @siddontang @disksing PTAL