### PR TITLE
raftstore: use gc to delete snap files

### DIFF
--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -31,6 +31,8 @@ const PD_HEARTBEAT_TICK_INTERVAL_MS: u64 = 5000;
 const PD_STORE_HEARTBEAT_TICK_INTERVAL_MS: u64 = 10000;
 const STORE_CAPACITY: u64 = u64::MAX;
 const DEFAULT_NOTIFY_CAPACITY: usize = 4096;
+const DEFAULT_MGR_GC_TICK_INTERVAL_MS: u64 = 60000;
+const DEFAULT_SNAP_GC_TIMEOUT_SECS: u64 = 60 * 10;
 
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -66,6 +68,8 @@ pub struct Config {
     pub pd_heartbeat_tick_interval: u64,
     pub pd_store_heartbeat_tick_interval: u64,
     pub notify_capacity: usize,
+    pub snap_mgr_gc_tick_interval: u64,
+    pub snap_gc_timeout: u64,
 }
 
 impl Default for Config {
@@ -87,6 +91,8 @@ impl Default for Config {
             pd_heartbeat_tick_interval: PD_HEARTBEAT_TICK_INTERVAL_MS,
             pd_store_heartbeat_tick_interval: PD_STORE_HEARTBEAT_TICK_INTERVAL_MS,
             notify_capacity: DEFAULT_NOTIFY_CAPACITY,
+            snap_mgr_gc_tick_interval: DEFAULT_MGR_GC_TICK_INTERVAL_MS,
+            snap_gc_timeout: DEFAULT_SNAP_GC_TIMEOUT_SECS,
         }
     }
 }

--- a/src/raftstore/store/mod.rs
+++ b/src/raftstore/store/mod.rs
@@ -34,4 +34,4 @@ pub use self::peer::Peer;
 pub use self::bootstrap::{bootstrap_store, bootstrap_region, write_region, clear_region};
 pub use self::engine::{Peekable, Iterable, Mutable};
 pub use self::peer_storage::{PeerStorage, do_snapshot, SnapState, RaftStorage};
-pub use self::snap::{SnapFile, SnapKey, SnapManager, new_snap_mgr};
+pub use self::snap::{SnapFile, SnapKey, SnapManager, new_snap_mgr, SnapEntry};

--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -33,7 +33,7 @@ pub enum Tick {
     SplitRegionCheck,
     PdHeartbeat,
     PdStoreHeartbeat,
-    SnapMgrGc,
+    SnapGc,
 }
 
 pub enum Msg {

--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -33,6 +33,7 @@ pub enum Tick {
     SplitRegionCheck,
     PdHeartbeat,
     PdStoreHeartbeat,
+    SnapMgrGc,
 }
 
 pub enum Msg {

--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -158,6 +158,7 @@ impl SnapFile {
     ///
     /// Please note that this method can only be called once.
     pub fn save(&mut self) -> io::Result<()> {
+        debug!("saving to {}", self.file.as_path().display());
         if let Some((mut f, path)) = self.tmp_file.take() {
             try!(f.write_u32::<BigEndian>(self.digest.sum32()));
             try!(f.flush());
@@ -192,7 +193,7 @@ impl Write for SnapFile {
 impl Drop for SnapFile {
     fn drop(&mut self) {
         if let Some((_, path)) = self.tmp_file.take() {
-            debug!("deleteing {}", path);
+            debug!("deleting {}", path);
             if let Err(e) = fs::remove_file(&path) {
                 warn!("failed to delete temporary file {}: {:?}", path, e);
             }

--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -291,6 +291,11 @@ impl SnapManagerCore {
     }
 
     #[inline]
+    pub fn has_registered(&self, key: &SnapKey) -> bool {
+        self.registry.contains_key(key)
+    }
+
+    #[inline]
     pub fn get_snap_file(&self, key: &SnapKey, is_sending: bool) -> io::Result<SnapFile> {
         SnapFile::new(&self.base, is_sending, key)
     }

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -856,6 +856,9 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         snap_keys.sort();
         let (mut last_region_id, mut compacted_idx, mut compacted_term) = (0, u64::MAX, u64::MAX);
         for (key, is_sending) in snap_keys {
+            if self.snap_mgr.rl().has_registered(&key) {
+                continue;
+            }
             if last_region_id != key.region_id {
                 last_region_id = key.region_id;
                 match self.region_peers.get(&key.region_id) {

--- a/src/raftstore/store/worker/snap.rs
+++ b/src/raftstore/store/worker/snap.rs
@@ -18,7 +18,6 @@ use std::error;
 use std::time::Instant;
 
 use util::worker::Runnable;
-use util::HandyRwLock;
 
 /// Snapshot generating task.
 pub struct Task {
@@ -73,11 +72,9 @@ impl Runner {
             key = SnapKey::new(storage.get_region_id(), term, applied_idx);
         }
 
-        self.mgr.wl().register(key.clone(), true);
         match store::do_snapshot(self.mgr.clone(), &raw_snap, key.clone(), ranges) {
             Ok(snap) => task.storage.wl().snap_state = SnapState::Snap(snap),
             Err(e) => {
-                self.mgr.wl().deregister(&key, true);
                 return Err(Error::Other(box e));
             }
         }

--- a/src/server/snap.rs
+++ b/src/server/snap.rs
@@ -27,7 +27,7 @@ use protobuf::Message;
 
 use super::{Result, ConnData, SendCh, Msg};
 use super::transport::RaftStoreRouter;
-use raftstore::store::{SnapFile, SnapManager, SnapKey};
+use raftstore::store::{SnapFile, SnapManager, SnapKey, SnapEntry};
 use util::worker::Runnable;
 use util::codec::rpc;
 use util::codec::number::NumberEncoder;
@@ -80,8 +80,12 @@ fn send_snap(mgr: SnapManager, addr: SocketAddr, data: ConnData) -> Result<()> {
     let timer = Instant::now();
     let snap = data.msg.get_raft().get_message().get_snapshot();
     let key = try!(SnapKey::from_snap(&snap));
-    defer!(mgr.wl().deregister(&key, true));
+    mgr.wl().register(key.clone(), SnapEntry::Sending);
     let snap_file = box_try!(mgr.rl().get_snap_file(&key, true));
+    defer!({
+        snap_file.delete();
+        mgr.wl().deregister(&key, &SnapEntry::Sending);
+    });
     if !snap_file.exists() {
         return Err(box_err!("missing snap file: {:?}", snap_file.path()));
     }
@@ -141,12 +145,16 @@ impl<R: RaftStoreRouter + 'static> Runnable<Task> for Runner<R> {
                     .and_then(|key| mgr.rl().get_snap_file(&key, false).map(|r| (r, key))) {
                     Ok((mut f, k)) => {
                         if f.exists() {
-                            error!("file {} already exists, skip.", f.path().display());
+                            info!("file {} already exists, skip receiving.",
+                                  f.path().display());
+                            if let Err(e) = self.raft_router.rl().send_raft_msg(meta) {
+                                error!("send snapshot for token {:?} err {:?}", token, e);
+                            }
                             self.close(token);
                             return;
                         }
                         debug!("begin to receive snap {:?}", meta);
-                        mgr.wl().register(k.clone(), false);
+                        mgr.wl().register(k.clone(), SnapEntry::Receiving);
                         let mut res = f.encode_u64(meta.compute_size() as u64);
                         if res.is_ok() {
                             res = meta.write_to_writer(&mut f).map_err(From::from);
@@ -154,7 +162,7 @@ impl<R: RaftStoreRouter + 'static> Runnable<Task> for Runner<R> {
                         if let Err(e) = res {
                             error!("failed to write meta: {:?}", e);
                             self.close(token);
-                            mgr.wl().deregister(&k, false);
+                            mgr.wl().deregister(&k, &SnapEntry::Receiving);
                             return;
                         }
                         self.files.insert(token, (f, meta));
@@ -177,16 +185,17 @@ impl<R: RaftStoreRouter + 'static> Runnable<Task> for Runner<R> {
                     Some((mut writer, msg)) => {
                         let key = SnapKey::from_snap(msg.get_message().get_snapshot()).unwrap();
                         info!("saving snapshot to {}", writer.path().display());
+                        defer!({
+                            self.snap_mgr.wl().deregister(&key, &SnapEntry::Receiving);
+                            self.close(token);
+                        });
                         if let Err(e) = writer.save() {
                             error!("failed to save file {:?}: {:?}", token, e);
-                            self.snap_mgr.wl().deregister(&key, false);
                             return;
                         }
                         if let Err(e) = self.raft_router.rl().send_raft_msg(msg) {
                             error!("send snapshot for token {:?} err {:?}", token, e);
-                            self.snap_mgr.wl().deregister(&key, false);
                         }
-                        self.close(token);
                     }
                     None => error!("invalid snap token {:?}", token),
                 }
@@ -196,7 +205,7 @@ impl<R: RaftStoreRouter + 'static> Runnable<Task> for Runner<R> {
                     debug!("discard snapshot: {:?}", msg);
                     // because token is inserted, following can't panic.
                     let key = SnapKey::from_snap(msg.get_message().get_snapshot()).unwrap();
-                    self.snap_mgr.wl().deregister(&key, false);
+                    self.snap_mgr.wl().deregister(&key, &SnapEntry::Receiving);
                 }
             }
             Task::SendTo { addr, data, cb } => {

--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -50,6 +50,7 @@ pub trait Simulator {
     fn get_node_ids(&self) -> HashSet<u64>;
     fn call_command(&self, request: RaftCmdRequest, timeout: Duration) -> Result<RaftCmdResponse>;
     fn send_raft_msg(&self, msg: RaftMessage) -> Result<()>;
+    fn get_snap_dir(&self, node_id: u64) -> String;
     fn get_store_sendch(&self, node_id: u64) -> Option<SendCh>;
     fn add_filter(&self, node_id: u64, filter: Box<Filter>);
     fn clear_filters(&self, node_id: u64);
@@ -517,6 +518,10 @@ impl<T: Simulator> Cluster<T> {
             }
             try_cnt += 1;
         }
+    }
+
+    pub fn get_snap_dir(&self, node_id: u64) -> String {
+        self.sim.rl().get_snap_dir(node_id)
     }
 
     pub fn clear_filters(&mut self) {

--- a/tests/raftstore/server.rs
+++ b/tests/raftstore/server.rs
@@ -180,6 +180,10 @@ impl Simulator for ServerCluster {
         node_id
     }
 
+    fn get_snap_dir(&self, node_id: u64) -> String {
+        self.snap_paths.get(&node_id).unwrap().path().to_str().unwrap().to_owned()
+    }
+
     fn stop_node(&mut self, node_id: u64) {
         let h = self.handles.remove(&node_id).unwrap();
         let ch = self.senders.remove(&node_id).unwrap();

--- a/tests/raftstore/test_snap.rs
+++ b/tests/raftstore/test_snap.rs
@@ -12,6 +12,11 @@
 // limitations under the License.
 
 
+use std::fs;
+
+use tikv::pd::PdClient;
+
+use super::transport_simulate::IsolateRegionStore;
 use super::cluster::{Cluster, Simulator};
 use super::node::new_node_cluster;
 use super::server::new_server_cluster;
@@ -63,4 +68,81 @@ fn test_server_huge_snapshot() {
     let count = 5;
     let mut cluster = new_server_cluster(0, count);
     test_huge_snapshot(&mut cluster);
+}
+
+fn test_snap_gc<T: Simulator>(cluster: &mut Cluster<T>) {
+    // truncate the log quickly so that we can force sending snapshot.
+    cluster.cfg.store_cfg.raft_log_gc_tick_interval = 20;
+    cluster.cfg.store_cfg.raft_log_gc_limit = 2;
+    cluster.cfg.store_cfg.snap_mgr_gc_tick_interval = 50;
+    cluster.cfg.store_cfg.snap_gc_timeout = 5;
+
+    // We use three nodes([1, 2, 3]) for this test.
+    cluster.run();
+
+    // guarantee node 1 is leader
+    cluster.must_transfer_leader(1, new_peer(1, 1));
+    cluster.must_put(b"k0", b"v0");
+    assert_eq!(cluster.leader_of_region(1), Some(new_peer(1, 1)));
+
+    let pd_client = cluster.pd_client.clone();
+
+    // isolate node 3 for region 1.
+    cluster.add_filter(IsolateRegionStore::new(1, 3));
+    cluster.must_put(b"k1", b"v1");
+
+    let region = pd_client.get_region(b"").unwrap();
+
+    // split (-inf, +inf) -> (-inf, k2), [k2, +inf]
+    cluster.must_split(&region, b"k2");
+    cluster.must_put(b"k2", b"v2");
+
+    // node 1 and node 2 must have k2, but node 3 must not.
+    for i in 1..3 {
+        let engine = cluster.get_engine(i);
+        must_get_equal(&engine, b"k2", b"v2");
+    }
+
+    let engine3 = cluster.get_engine(3);
+    must_get_none(&engine3, b"k2");
+
+    for _ in 0..200 {
+        // write many logs to force log GC for region 1 and region 2.
+        // and trigger snapshot more than one time.
+        cluster.get(b"k1").unwrap();
+        cluster.get(b"k2").unwrap();
+    }
+
+    let snap_dir = cluster.get_snap_dir(3);
+    // it must have more than 2 snaps.
+    let snapfiles: Vec<_> = fs::read_dir(snap_dir).unwrap().map(|p| p.unwrap().path()).collect();
+    assert!(snapfiles.len() > 2);
+
+    cluster.clear_filters();
+
+    sleep_ms(5000);
+
+    // node 3 must have k1, k2.
+    must_get_equal(&engine3, b"k1", b"v1");
+    must_get_equal(&engine3, b"k2", b"v2");
+
+    for i in 1..4 {
+        let snap_dir = cluster.get_snap_dir(i);
+        // snapfiles should be gc.
+        let snapfiles: Vec<_> =
+            fs::read_dir(snap_dir).unwrap().map(|p| p.unwrap().path()).collect();
+        assert!(snapfiles.is_empty(), format!("{:?}", snapfiles));
+    }
+}
+
+#[test]
+fn test_node_snap_gc() {
+    let mut cluster = new_node_cluster(0, 3);
+    test_snap_gc(&mut cluster);
+}
+
+#[test]
+fn test_server_snap_gc() {
+    let mut cluster = new_server_cluster(0, 3);
+    test_snap_gc(&mut cluster);
 }

--- a/tests/raftstore/test_stats.rs
+++ b/tests/raftstore/test_stats.rs
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 use std::sync::Arc;
-use std::time::Duration;
 
 use super::cluster::{Cluster, Simulator};
 use super::node::new_node_cluster;
@@ -20,7 +19,6 @@ use super::server::new_server_cluster;
 use super::util::*;
 use tikv::pd::PdClient;
 use super::pd::TestPdClient;
-use super::transport_simulate::DelaySnapshot;
 
 fn check_available<T: Simulator>(cluster: &mut Cluster<T>) {
     let pd_client = cluster.pd_client.clone();
@@ -114,10 +112,13 @@ fn test_server_store_snap_stats() {
 
     let r1 = cluster.run_conf_change();
 
-    cluster.must_put(b"k1", b"v1");
+    // make a big snapshot
+    for i in 0..2 * 1024 {
+        let key = format!("{:01024}", i);
+        let value = format!("{:01024}", i);
+        cluster.must_put(key.as_bytes(), value.as_bytes());
+    }
 
-    // delay snapshot sending, so that we can detect this.
-    cluster.add_filter(DelaySnapshot::new(Duration::from_millis(50)));
     pd_client.must_add_peer(r1, new_peer(2, 2));
 
     must_detect_snap(&pd_client);

--- a/tests/raftstore/transport_simulate.rs
+++ b/tests/raftstore/transport_simulate.rs
@@ -330,36 +330,3 @@ impl FilterFactory for IsolateRegionStore {
              }]
     }
 }
-
-pub struct DelaySnapshotFiler {
-    duration: time::Duration,
-}
-
-impl Filter for DelaySnapshotFiler {
-    fn before(&self, msg: &RaftMessage) -> bool {
-        if msg.get_message().get_msg_type() == MessageType::MsgSnapshot {
-            thread::sleep(self.duration);
-        }
-
-        false
-    }
-    fn after(&self, x: Result<()>) -> Result<()> {
-        x
-    }
-}
-
-pub struct DelaySnapshot {
-    duration: time::Duration,
-}
-
-impl DelaySnapshot {
-    pub fn new(duration: time::Duration) -> DelaySnapshot {
-        DelaySnapshot { duration: duration }
-    }
-}
-
-impl FilterFactory for DelaySnapshot {
-    fn generate(&self, _: u64) -> Vec<Box<Filter>> {
-        vec![box DelaySnapshotFiler { duration: self.duration }]
-    }
-}

--- a/tests/test_raft.rs
+++ b/tests/test_raft.rs
@@ -1870,7 +1870,7 @@ fn test_raft_nodes() {
 }
 
 #[test]
-fn test_compaign_while_leader() {
+fn test_campaign_while_leader() {
     let mut r = new_test_raft(1, vec![1], 5, 1, new_storage());
     assert_eq!(r.state, StateRole::Follower);
     // We don't call campaign() directly because it comes after the check


### PR DESCRIPTION
It's hard and tricky to make sure snap file not leak when using ref count. So this pr changes to use GC to delete stale snap files.

@ngaut @siddontang @disksing PTAL