### PR TITLE
raftstore: clear callback when destroy peer

### DIFF
--- a/tests/raftstore/pd.rs
+++ b/tests/raftstore/pd.rs
@@ -405,14 +405,17 @@ impl TestPdClient {
         self.must_have_peer(region_id, peer);
     }
 
-    pub fn must_remove_peer(&self, region_id: u64, peer: metapb::Peer) {
-        let peer2 = peer.clone();
+    pub fn remove_peer(&self, region_id: u64, peer: metapb::Peer) {
         self.set_rule(box move |region: &metapb::Region, _: &metapb::Peer| {
             if region.get_id() != region_id {
                 return None;
             }
-            new_pd_remove_change_peer(region, peer2.clone())
+            new_pd_remove_change_peer(region, peer.clone())
         });
+    }
+
+    pub fn must_remove_peer(&self, region_id: u64, peer: metapb::Peer) {
+        self.remove_peer(region_id, peer.clone());
         self.must_none_peer(region_id, peer);
     }
 

--- a/tests/raftstore/test_transport.rs
+++ b/tests/raftstore/test_transport.rs
@@ -32,13 +32,14 @@ fn test_partition_write<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.partition(vec![1, 2, 3], vec![4, 5]);
     cluster.must_put(key, value);
     assert_eq!(cluster.get(key), Some(value.to_vec()));
-    assert_eq!(cluster.leader_of_region(region_id), Some(new_peer(1, 1)));
+    cluster.must_transfer_leader(region_id, new_peer(1, 1));
     cluster.clear_filters();
 
     // leader in minority, new leader should be elected
     cluster.partition(vec![1, 2], vec![3, 4, 5]);
     assert_eq!(cluster.get(key), Some(value.to_vec()));
     assert!(cluster.leader_of_region(region_id).unwrap().get_id() != 1);
+    assert!(cluster.leader_of_region(region_id).unwrap().get_id() != 2);
     cluster.must_put(key, b"changed");
     cluster.clear_filters();
 


### PR DESCRIPTION
Clear callback when peer is destroyed, which will make client retry quickly.

@ngaut @siddontang @disksing @zhangjinpeng1987 PTAL