### PR TITLE
util: add buffered metric client

### DIFF
--- a/src/util/metric/mod.rs
+++ b/src/util/metric/mod.rs
@@ -14,6 +14,8 @@
 use std::error;
 use std::fmt;
 use std::io;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::net::{ToSocketAddrs, SocketAddr, UdpSocket};
 
@@ -69,15 +71,20 @@ pub fn client() -> Option<&'static Metric> {
     unsafe { CLIENT.map(|c| &*c) }
 }
 
-/// Implementation of a `MetricSink` that emits metrics over UDP with nonblocking mode.
-// TODO: add buffer.
-pub struct NonblockUdpMetricSink {
+pub struct BufferedUdpMetricSink {
     sink_addr: SocketAddr,
     socket: UdpSocket,
+
+    buffer: Mutex<Vec<u8>>,
+    last_flush_time: Mutex<Instant>,
+    flush_period: Duration,
 }
 
-impl NonblockUdpMetricSink {
-    pub fn from<A>(sink_addr: A, socket: UdpSocket) -> MetricResult<NonblockUdpMetricSink>
+impl BufferedUdpMetricSink {
+    pub fn from<A>(sink_addr: A,
+                   socket: UdpSocket,
+                   flush_period: Duration)
+                   -> MetricResult<BufferedUdpMetricSink>
         where A: ToSocketAddrs
     {
         let mut addr_iter = try!(sink_addr.to_socket_addrs());
@@ -87,15 +94,40 @@ impl NonblockUdpMetricSink {
         // Moves this UDP stream into nonblocking mode.
         try!(socket.set_nonblocking(true));
 
-        Ok(NonblockUdpMetricSink {
+        Ok(BufferedUdpMetricSink {
             sink_addr: addr,
             socket: socket,
+
+            buffer: Mutex::new(Vec::with_capacity(1024)),
+            flush_period: flush_period,
+            last_flush_time: Mutex::new(Instant::now()),
         })
+    }
+
+    fn append_to_buffer(&self, metric: &str) -> io::Result<usize> {
+        let mut buffer = self.buffer.lock().unwrap();
+        let mut last_flush_time = self.last_flush_time.lock().unwrap();
+
+        // +1 for '\n'
+        if (buffer.len() + metric.len() + 1) > buffer.capacity() ||
+           (last_flush_time.elapsed() >= self.flush_period) {
+            self.flush(&mut buffer);
+            *last_flush_time = Instant::now();
+        }
+
+        buffer.extend_from_slice(metric.as_bytes());
+        buffer.push('\n' as u8);
+        Ok(metric.len())
+    }
+
+    fn flush(&self, buffer: &mut Vec<u8>) {
+        let _ = self.socket.send_to(buffer.as_slice(), &self.sink_addr);
+        buffer.clear();
     }
 }
 
-impl MetricSink for NonblockUdpMetricSink {
+impl MetricSink for BufferedUdpMetricSink {
     fn emit(&self, metric: &str) -> io::Result<usize> {
-        self.socket.send_to(metric.as_bytes(), &self.sink_addr)
+        self.append_to_buffer(metric)
     }
 }


### PR DESCRIPTION
A buffered metric sink with a pseudo timeout mechanism.

Benchmark([link](https://gist.github.com/overvenus/31b3adba8d60fbc81325a958a0e9fc9d)):

```
➜  bench_metric git:(master) ✗ cargo bench bench_single                   
     Running target/release/bench_metric-b6de8d742c9d8b0f

running 3 tests
test tests::bench_single_thread_block_udp    ... bench:       3,492 ns/iter (+/- 137)
test tests::bench_single_thread_buffer_udp   ... bench:         135 ns/iter (+/- 4)
test tests::bench_single_thread_nonblock_udp ... bench:       3,487 ns/iter (+/- 530)

test result: ok. 0 passed; 0 failed; 0 ignored; 3 measured
```

3 threads send 15000 metrics concurrently.

```
➜  bench_metric git:(master) ✗ cargo bench bench_multi_thread_block_udp
     Running target/release/bench_metric-b6de8d742c9d8b0f

running 1 test
test tests::bench_multi_thread_block_udp     ... bench:  37,487,056 ns/iter (+/- 3,148,835)

test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured

➜  bench_metric git:(master) ✗ cargo bench bench_multi_thread_nonblock_udp
     Running target/release/bench_metric-b6de8d742c9d8b0f

running 1 test
test tests::bench_multi_thread_nonblock_udp  ... bench:  37,389,796 ns/iter (+/- 3,202,220)

test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured

➜  bench_metric git:(master) ✗ cargo bench bench_multi_thread_buffer_udp  
     Running target/release/bench_metric-b6de8d742c9d8b0f

running 1 test
test tests::bench_multi_thread_buffer_udp    ... bench:   4,425,618 ns/iter (+/- 230,592)

test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
```