### PR TITLE
bin/tikv-server: add "rocksdb.max-background-threads" option.

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -71,6 +71,10 @@ max-write-buffer-number = 5
 # before writing to storage.
 min-write-buffer-number-to-merge = 2
 
+# The maximum number of background threads for compactions and flushes,
+# submitted to the default LOW priority thread pool.
+max-background-threads = 1
+
 # Maximum number of concurrent background compaction jobs, submitted to
 # the default LOW priority thread pool.
 max-background-compactions = 3

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -202,7 +202,7 @@ fn get_rocksdb_option(matches: &Matches, config: &toml::Value) -> RocksdbOptions
                                                    "rocksdb.max-background-threads",
                                                    matches,
                                                    config,
-                                                   Some(3),
+                                                   Some(1),
                                                    |v| v.as_integer());
     opts.increase_parallelism(max_background_threads as i32);
 

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -198,6 +198,14 @@ fn get_rocksdb_option(matches: &Matches, config: &toml::Value) -> RocksdbOptions
     };
     opts.set_min_write_buffer_number_to_merge(min_write_buffer_number_to_merge as i32);
 
+    let max_background_threads = get_integer_value("",
+                                                   "rocksdb.max-background-threads",
+                                                   matches,
+                                                   config,
+                                                   Some(3),
+                                                   |v| v.as_integer());
+    opts.increase_parallelism(max_background_threads as i32);
+
     let max_background_compactions = get_integer_value("",
                                                        "rocksdb.max-background-compactions",
                                                        matches,


### PR DESCRIPTION
Increase parallelism for rocksdb background jobs.