### PR TITLE
raft/raftstore: use PeerStorage directly, remove rl/wl.

### DIFF
--- a/src/raft/raft.rs
+++ b/src/raft/raft.rs
@@ -279,6 +279,11 @@ impl<T: Storage> Raft<T> {
     }
 
     #[inline]
+    pub fn mut_store(&mut self) -> &mut T {
+        self.raft_log.mut_store()
+    }
+
+    #[inline]
     pub fn get_snap(&self) -> Option<&Snapshot> {
         self.raft_log.get_unstable().snapshot.as_ref()
     }

--- a/src/raft/raft_log.rs
+++ b/src/raft/raft_log.rs
@@ -85,8 +85,14 @@ impl<T: Storage> RaftLog<T> {
         self.term(self.last_index()).expect("unexpected error when getting the last term")
     }
 
+    #[inline]
     pub fn get_store(&self) -> &T {
         &self.store
+    }
+
+    #[inline]
+    pub fn mut_store(&mut self) -> &mut T {
+        &mut self.store
     }
 
     pub fn term(&self, idx: u64) -> Result<u64> {

--- a/src/raft/raw_node.rs
+++ b/src/raft/raw_node.rs
@@ -347,4 +347,9 @@ impl<T: Storage> RawNode<T> {
     pub fn get_store(&self) -> &T {
         self.raft.get_store()
     }
+
+    #[inline]
+    pub fn mut_store(&mut self) -> &mut T {
+        self.raft.mut_store()
+    }
 }

--- a/src/raftstore/store/mod.rs
+++ b/src/raftstore/store/mod.rs
@@ -33,6 +33,6 @@ pub use self::transport::Transport;
 pub use self::peer::Peer;
 pub use self::bootstrap::{bootstrap_store, bootstrap_region, write_region, clear_region};
 pub use self::engine::{Peekable, Iterable, Mutable, new_engine, new_engine_opt};
-pub use self::peer_storage::{PeerStorage, do_snapshot, SnapState, RaftStorage, RAFT_INIT_LOG_TERM,
+pub use self::peer_storage::{PeerStorage, do_snapshot, SnapState, RAFT_INIT_LOG_TERM,
                              RAFT_INIT_LOG_INDEX};
 pub use self::snap::{SnapFile, SnapKey, SnapManager, new_snap_mgr, SnapEntry};

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -35,7 +35,7 @@ use raftstore::coprocessor::split_observer::SplitObserver;
 use util::{escape, HandyRwLock, SlowTimer};
 use pd::PdClient;
 use super::store::Store;
-use super::peer_storage::{PeerStorage, RaftStorage, ApplySnapResult, write_initial_state};
+use super::peer_storage::{PeerStorage, ApplySnapResult, write_initial_state};
 use super::util;
 use super::msg::Callback;
 use super::cmd_resp;
@@ -146,7 +146,7 @@ pub struct Peer {
     engine: Arc<DB>,
     pub peer: metapb::Peer,
     region_id: u64,
-    pub raft_group: RawNode<RaftStorage>,
+    pub raft_group: RawNode<PeerStorage>,
     pending_cmds: PendingCmdQueue,
     peer_cache: Arc<RwLock<HashMap<u64, metapb::Peer>>>,
     coprocessor_host: CoprocessorHost,
@@ -206,7 +206,6 @@ impl Peer {
         let sched = store.snap_scheduler();
         let ps = try!(PeerStorage::new(store.engine(), &region, sched));
         let applied_index = ps.applied_index();
-        let storage = RaftStorage::new(ps);
 
         let raft_cfg = raft::Config {
             id: peer_id,
@@ -220,7 +219,7 @@ impl Peer {
             tag: format!("[region {}]", region.get_id()),
         };
 
-        let raft_group = try!(RawNode::new(&raft_cfg, storage, &[]));
+        let raft_group = try!(RawNode::new(&raft_cfg, ps, &[]));
 
         let mut peer = Peer {
             engine: store.engine(),
@@ -259,14 +258,14 @@ impl Peer {
         }
 
         let wb = WriteBatch::new();
-        try!(self.get_store().rl().scan_region(self.engine.as_ref(),
-                                               &mut |key, _| {
-                                                   try!(wb.delete(key));
-                                                   Ok(true)
-                                               }));
+        try!(self.get_store().scan_region(self.engine.as_ref(),
+                                          &mut |key, _| {
+                                              try!(wb.delete(key));
+                                              Ok(true)
+                                          }));
         let mut local_state = RegionLocalState::new();
         local_state.set_state(PeerState::Tombstone);
-        local_state.set_region(self.get_store().rl().get_region().clone());
+        local_state.set_region(self.get_store().get_region().clone());
         try!(wb.put_msg(&keys::region_state_key(self.region_id), &local_state));
         try!(self.engine.write(wb));
 
@@ -280,7 +279,7 @@ impl Peer {
     }
 
     pub fn is_initialized(&self) -> bool {
-        self.get_store().rl().is_initialized()
+        self.get_store().is_initialized()
     }
 
     pub fn load_all_coprocessors(&mut self) {
@@ -289,7 +288,7 @@ impl Peer {
     }
 
     pub fn region(&self) -> metapb::Region {
-        self.get_store().rl().get_region().clone()
+        self.get_store().get_region().clone()
     }
 
     pub fn peer_id(&self) -> u64 {
@@ -309,12 +308,17 @@ impl Peer {
     }
 
     #[inline]
-    pub fn get_store(&self) -> &RaftStorage {
+    pub fn get_store(&self) -> &PeerStorage {
         self.raft_group.get_store()
     }
 
+    #[inline]
+    pub fn mut_store(&mut self) -> &mut PeerStorage {
+        self.raft_group.mut_store()
+    }
+
     pub fn is_applying_snap(&self) -> bool {
-        self.get_store().rl().is_applying_snap()
+        self.get_store().is_applying_snap()
     }
 
     fn send_ready_metric(&self, ready: &Ready) {
@@ -358,7 +362,7 @@ impl Peer {
                self.region_id);
 
         let mut ready = self.raft_group.ready();
-        let is_applying = self.get_store().rl().is_applying_snap();
+        let is_applying = self.get_store().is_applying_snap();
         if is_applying {
             // skip apply and snapshot
             ready.committed_entries = vec![];
@@ -375,7 +379,7 @@ impl Peer {
             try!(self.send(trans, &ready.messages));
         }
 
-        let apply_result = try!(self.get_store().wl().handle_raft_ready(&ready));
+        let apply_result = try!(self.mut_store().handle_raft_ready(&ready));
 
         if !self.is_leader() {
             try!(self.send(trans, &ready.messages));
@@ -489,7 +493,7 @@ impl Peer {
 
     fn propose_normal(&mut self, mut cmd: RaftCmdRequest) -> Result<()> {
         // TODO: validate request for unexpected changes.
-        try!(self.coprocessor_host.pre_propose(&self.raft_group.get_store().rl(), &mut cmd));
+        try!(self.coprocessor_host.pre_propose(&self.raft_group.get_store(), &mut cmd));
         let data = try!(cmd.write_to_bytes());
         try!(self.raft_group.propose(data));
         Ok(())
@@ -521,7 +525,7 @@ impl Peer {
             }
         }
 
-        let last_index = self.get_store().rl().last_index();
+        let last_index = self.get_store().last_index();
         last_index <= status.progress[&peer_id].matched + TRANSFER_LEADER_ALLOW_LOG_LAG
     }
 
@@ -595,7 +599,7 @@ impl Peer {
         }
 
         // Try to find in region, if found, set in cache.
-        for peer in self.get_store().rl().get_region().get_peers() {
+        for peer in self.get_store().get_region().get_peers() {
             if peer.get_id() == peer_id {
                 self.peer_cache.wl().insert(peer_id, peer.clone());
                 return Some(peer.clone());
@@ -705,11 +709,11 @@ impl Peer {
         if data.is_empty() {
             // when a peer become leader, it will send an empty entry.
             let wb = WriteBatch::new();
-            let mut state = self.get_store().rl().apply_state.clone();
+            let mut state = self.get_store().apply_state.clone();
             state.set_applied_index(index);
             try!(wb.put_msg(&keys::apply_state_key(self.region_id), &state));
             try!(self.engine.write_without_wal(wb));
-            self.get_store().wl().apply_state = state;
+            self.mut_store().apply_state = state;
             return Ok(None);
         }
 
@@ -795,7 +799,7 @@ impl Peer {
         }
 
         let cb = cb.unwrap();
-        self.coprocessor_host.post_apply(&self.raft_group.get_store().rl(), &cmd, &mut resp);
+        self.coprocessor_host.post_apply(self.raft_group.get_store(), &cmd, &mut resp);
         // TODO: if we have exec_result, maybe we should return this callback too. Outer
         // store will call it after handing exec result.
         // Bind uuid here.
@@ -825,7 +829,7 @@ impl Peer {
             return Ok((resp, None));
         }
 
-        let last_applied_index = self.get_store().rl().applied_index();
+        let last_applied_index = self.get_store().applied_index();
         if last_applied_index >= index {
             return Err(box_err!("applied index moved backwards, {} >= {}",
                                 last_applied_index,
@@ -835,7 +839,7 @@ impl Peer {
         let engine = self.engine.clone();
         let mut ctx = ExecContext {
             snap: Snapshot::new(engine),
-            apply_state: self.get_store().rl().apply_state.clone(),
+            apply_state: self.get_store().apply_state.clone(),
             wb: WriteBatch::new(),
             req: req,
         };
@@ -848,8 +852,8 @@ impl Peer {
         ctx.save(self.region_id).expect("save state must not fail");
 
         // Commit write and change storage fields atomically.
-        let mut storage = self.get_store().wl();
-        match self.engine.write_without_wal(ctx.wb) {
+        let mut storage = self.mut_store();
+        match storage.engine.write_without_wal(ctx.wb) {
             Ok(_) => {
                 storage.apply_state = ctx.apply_state;
 
@@ -1119,7 +1123,7 @@ impl Peer {
         let compact_index = req.get_compact_log().get_compact_index();
         let resp = AdminResponse::new();
 
-        let first_index = self.get_store().rl().first_index();
+        let first_index = self.get_store().first_index();
         if compact_index <= first_index {
             debug!("compact index {} <= first index {}, no need to compact",
                    compact_index,
@@ -1127,7 +1131,7 @@ impl Peer {
             return Ok((resp, None));
         }
 
-        try!(self.get_store().rl().compact(&mut ctx.apply_state, compact_index));
+        try!(self.get_store().compact(&mut ctx.apply_state, compact_index));
         Ok((resp,
             Some(ExecResult::CompactLog { state: ctx.apply_state.get_truncated_state().clone() })))
     }
@@ -1159,7 +1163,7 @@ impl Peer {
 
     fn check_data_key(&self, key: &[u8]) -> Result<()> {
         // region key range has no data prefix, so we must use origin key to check.
-        try!(util::check_key_in_region(key, self.get_store().rl().get_region()));
+        try!(util::check_key_in_region(key, self.get_store().get_region()));
 
         Ok(())
     }
@@ -1251,7 +1255,7 @@ impl Peer {
 
     fn do_snap(&mut self, _: &ExecContext, _: &Request) -> Result<Response> {
         let mut resp = Response::new();
-        resp.mut_snap().set_region(self.get_store().rl().get_region().clone());
+        resp.mut_snap().set_region(self.get_store().get_region().clone());
         Ok(resp)
     }
 }

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -149,13 +149,13 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                 return Ok(true);
             }
             let region = local_state.get_region();
-            let peer = try!(Peer::create(self, region));
+            let mut peer = try!(Peer::create(self, region));
 
             if local_state.get_state() == PeerState::Applying {
                 info!("region {:?} is applying in store {}",
                       local_state.get_region(),
                       self.store_id());
-                peer.get_store().wl().set_snap_state(SnapState::Applying);
+                peer.mut_store().set_snap_state(SnapState::Applying);
                 box_try!(self.snap_worker.schedule(SnapTask::Apply { region_id: region_id }));
             }
 
@@ -239,7 +239,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
 
     fn on_raft_base_tick(&mut self, event_loop: &mut EventLoop<Self>) {
         for (&region_id, peer) in &mut self.region_peers {
-            if !peer.get_store().rl().is_applying_snap() {
+            if !peer.get_store().is_applying_snap() {
                 peer.raft_group.tick();
                 self.pending_raft_groups.insert(region_id);
             }
@@ -358,7 +358,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         // TODO: for case f, if 2 is stale for a long time, 2 will communicate with pd and pd will
         // tell 2 is stale, so 2 can remove itself.
         if let Some(peer) = self.region_peers.get(&region_id) {
-            let region = &peer.get_store().rl().region;
+            let region = &peer.get_store().region;
             let epoch = region.get_region_epoch();
 
             if util::is_epoch_stale(from_epoch, epoch) &&
@@ -436,7 +436,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         if let Some(peer) = self.region_peers.get(&region_id) {
             // TODO: need checking peer id changed?
             let from_epoch = msg.get_region_epoch();
-            if util::is_epoch_stale(peer.get_store().rl().region.get_region_epoch(), from_epoch) {
+            if util::is_epoch_stale(peer.get_store().region.get_region_epoch(), from_epoch) {
                 // TODO: ask pd to guarantee we are stale now.
                 warn!("peer {:?} for region {} receives gc message, remove",
                       msg.get_to_peer(),
@@ -455,7 +455,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
 
         // Check if we can accept the snapshot
         // TODO: we need to inject failure or re-order network packet to test the situation
-        if !self.region_peers[&region_id].get_store().rl().is_initialized() &&
+        if !self.region_peers[&region_id].get_store().is_initialized() &&
            msg.get_message().has_snapshot() {
             let snap = msg.get_message().get_snapshot();
             let mut snap_data = RaftSnapshotData::new();
@@ -565,7 +565,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
 
     fn on_ready_compact_log(&mut self, region_id: u64, state: RaftTruncatedState) {
         let peer = self.region_peers.get(&region_id).unwrap();
-        let task = CompactTask::new(&peer.get_store().rl(), state.get_index() + 1);
+        let task = CompactTask::new(peer.get_store(), state.get_index() + 1);
         if let Err(e) = self.compact_worker.schedule(task) {
             error!("failed to schedule compact task: {}", e);
         }
@@ -580,7 +580,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             // If the store received a raft msg with the new region raft group
             // before splitting, it will creates a uninitialized peer.
             // We can remove this uninitialized peer directly.
-            if peer.get_store().rl().is_initialized() {
+            if peer.get_store().is_initialized() {
                 panic!("duplicated region {} for split region", new_region_id);
             }
         }
@@ -804,8 +804,8 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                 .map(|p| p.matched)
                 .min()
                 .unwrap();
-            let applied_idx = peer.get_store().rl().applied_index();
-            let first_idx = peer.get_store().rl().first_index();
+            let applied_idx = peer.get_store().applied_index();
+            let first_idx = peer.get_store().first_index();
             let compact_idx;
             if applied_idx > first_idx && applied_idx - first_idx >= self.cfg.raft_log_gc_limit {
                 compact_idx = applied_idx;
@@ -863,7 +863,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                   id,
                   peer.size_diff_hint,
                   self.cfg.region_check_size_diff);
-            let task = SplitCheckTask::new(&peer.get_store().rl());
+            let task = SplitCheckTask::new(peer.get_store());
             if let Err(e) = self.split_check_worker.schedule(task) {
                 error!("failed to schedule split check: {}", e);
             }
@@ -1029,7 +1029,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                         is_applying_snap = false;
                     }
                     Some(peer) => {
-                        let s = peer.get_store().rl();
+                        let s = peer.get_store();
                         compacted_idx = s.truncated_index();
                         compacted_term = s.truncated_term();
                         is_applying_snap = s.is_applying_snap();
@@ -1116,7 +1116,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             None => return,
             Some(peer) => peer,
         };
-        let mut storage = peer.get_store().wl();
+        let mut storage = peer.mut_store();
         if !storage.is_snap_state(SnapState::Generating) {
             // snapshot no need anymore.
             return;
@@ -1133,7 +1133,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
 
     fn on_snap_apply_res(&mut self, region_id: u64, is_success: bool) {
         let peer = self.region_peers.get_mut(&region_id).unwrap();
-        let mut storage = peer.get_store().wl();
+        let mut storage = peer.mut_store();
         assert!(storage.is_snap_state(SnapState::Applying),
                 "snap state should not change during applying");
         if !is_success {
@@ -1303,7 +1303,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
 
     fn execute_region_detail(&mut self, request: RaftCmdRequest) -> Result<StatusResponse> {
         let peer = try!(self.mut_target_peer(&request));
-        if !peer.get_store().rl().is_initialized() {
+        if !peer.get_store().is_initialized() {
             let region_id = request.get_header().get_region_id();
             return Err(Error::RegionNotInitialized(region_id));
         }


### PR DESCRIPTION
@ngaut @BusyJay @disksing @zhangjinpeng1987 