### PR TITLE
[DNM] demonstration of rust-metrics in marco

### DIFF
--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -41,12 +41,11 @@ use rocksdb::{Options as RocksdbOptions, BlockBasedOptions};
 use mio::tcp::TcpListener;
 use fs2::FileExt;
 use cadence::{StatsdClient, NopMetricSink};
-use metrics::reporter::ConsoleReporter;
-use metrics::metrics::StdCounter;
+use metrics::metrics::{Metric, StdCounter};
 
 use tikv::storage::{Storage, Dsn, TEMP_DIR, DEFAULT_CFS};
-use tikv::util::{self, logger, panic_hook};
-use tikv::util::metric::{self, BufferedUdpMetricSink};
+use tikv::util::{self, logger, panic_hook, HandyRwLock};
+use tikv::util::metric::{self, BufferedUdpMetricSink, ConsoleReporter};
 use tikv::server::{DEFAULT_LISTENING_ADDR, SendCh, Server, Node, Config, bind, create_event_loop,
                    create_raft_storage};
 use tikv::server::{ServerTransport, ServerRaftStoreRouter, MockRaftStoreRouter};
@@ -167,16 +166,29 @@ fn initial_new_metric() {
     if let Err(e) = metric::init_collector() {
         panic!("{}", e);
     }
-    let c = metric::collector().unwrap();
-    let r = ConsoleReporter::new(c, "ConsoleReporter");
+
+    let c = StdCounter::new();
+    register_metric!("foo", Metric::Counter(c.clone()));
+
+    let r = ConsoleReporter;
     r.start(1000);
 
-    // register_metric!("foo", StdCounter::new());
-    // counter_inc!("foo", 2);
-    // thread::spawn(|| {
-    //     counter_inc!("foo", 2);
-    //     thread::sleep_ms(1000);
-    // })
+    thread::spawn(move || {
+        // use metrics::metrics::Counter;
+        // counter_inc!("foo", 2);
+        // or
+        // c.inc();
+
+        // register a new metric after report stated
+        register_metric!("bar", Metric::Counter(StdCounter::new()));
+
+        loop {
+            counter_inc!("foo", 2);
+            counter_inc!("bar");
+
+            thread::sleep(Duration::from_millis(1000));
+        }
+    });
 }
 
 fn get_rocksdb_option(matches: &Matches, config: &toml::Value) -> RocksdbOptions {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ extern crate rustc_serialize;
 extern crate hyper;
 #[cfg(unix)]
 extern crate nix;
+extern crate metrics;
 
 #[macro_use]
 pub mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,8 @@ extern crate hyper;
 #[cfg(unix)]
 extern crate nix;
 extern crate metrics;
+#[macro_use]
+extern crate lazy_static;
 
 #[macro_use]
 pub mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 #![cfg_attr(feature = "dev", plugin(clippy))]
 #![cfg_attr(not(feature = "dev"), allow(unknown_lints))]
 #![recursion_limit="100"]
+#![feature(drop_types_in_const)]
 
 #[macro_use]
 extern crate log;

--- a/src/util/metric/macros.rs
+++ b/src/util/metric/macros.rs
@@ -87,3 +87,59 @@ macro_rules! metric_meter {
         }
     };
 }
+
+// Register a metric
+#[macro_export]
+macro_rules! register_metric {
+    ($name:expr, $metric:expr) => {
+        if let Some(c) = $crate::util::metric::collector() {
+            c.insert($name, $metric);
+        }
+    };
+}
+
+// A counter MUST have the following methods:
+//
+// inc(): Increment the counter by 1
+// inc(double v): Increment the counter by the given amount. MUST check that v >= 0.
+#[macro_export]
+macro_rules! counter_inc {
+    ($name:expr, $value:expr) => {
+        use metrics::metrics::Metric;
+
+        if let Some(registry) = $crate::util::metric::collector() {
+            if let &Metric::Counter(ref c) = registry.get($name) {
+                c.inc($value);
+            }
+        }
+    };
+
+    ($name:expr) => {
+        counter_inc!($name, 1);
+    };
+}
+
+// A gauge MUST have the following methods:
+// 
+// inc(): Increment the gauge by 1
+// inc(double v): Increment the gauge by the given amount
+// dec(): Decrement the gauge by 1
+// dec(double v): Decrement the gauge by the given amount
+// set(double v): Set the gauge to the given value
+// #[macro_export]
+// macro_rules! gauge_inc {
+//     ($name:expr, $value:expr) => {
+//         use metrics::metric::Metric;
+
+//         if let Some(c) = $crate::util::metric::collector() {
+//             if let &Metric::Counter(ref c) = registry.get($name) {
+//                 c.inc($value);
+//             }
+//         }
+//     };
+
+//     ($name:expr) => {
+//         counter_inc!($name, 1);
+//     };
+// }
+


### PR DESCRIPTION
This is a demonstration of using rust-metrics by macro.

It can register new metrics after reporter started. Metrics can be recorded by marcos.

```rust
let c = Metric::Counter(StdCounter::new());
register_metric!("foo", c);
counter_inc!("foo", 2);
// or 
c.inc();
``` 

con: 
 - all macro APIs involve a global RWLock.
 - we have to use our own reporter.

@ngaut @siddontang Later, I will add more macros, if it looks good to you