### PR TITLE
*: speedup shutdown

### DIFF
--- a/src/server/resolve.rs
+++ b/src/server/resolve.rs
@@ -120,7 +120,7 @@ impl StoreAddrResolver for PdStoreAddrResolver {
 
 impl Drop for PdStoreAddrResolver {
     fn drop(&mut self) {
-        if let Err(e) = self.worker.stop() {
+        if let Some(Err(e)) = self.worker.stop().map(|h| h.join()) {
             error!("failed to stop store address resolve thread: {:?}!!!", e);
         }
     }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -570,11 +570,12 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver> Handler for Server<T, S> {
         // we will quit the server here.
         // TODO: handle quit server if event_loop is_running() returns false.
         if !el.is_running() {
-            if let Err(e) = self.end_point_worker.stop() {
-                error!("failed to stop end point: {:?}", e);
-            }
+            let end_point_handle = self.end_point_worker.stop();
             if let Err(e) = self.store.stop() {
                 error!("failed to stop store: {:?}", e);
+            }
+            if let Some(Err(e)) = end_point_handle.map(|h| h.join()) {
+                error!("failed to stop end point: {:?}", e);
             }
         }
     }

--- a/tests/coprocessor/test_select.rs
+++ b/tests/coprocessor/test_select.rs
@@ -254,7 +254,7 @@ fn test_select() {
         assert_eq!(row.get_data(), &*expected_encoded);
     }
 
-    end_point.stop().unwrap();
+    end_point.stop().unwrap().join().unwrap();
 }
 
 #[test]
@@ -271,7 +271,7 @@ fn test_group_by() {
         assert_eq!(row.get_data(), &*expected_encoded);
     }
 
-    end_point.stop().unwrap();
+    end_point.stop().unwrap().join().unwrap();
 }
 
 #[test]
@@ -305,7 +305,7 @@ fn test_aggr_count() {
         assert_eq!(row.get_data(), &*expected_encoded);
     }
 
-    end_point.stop().unwrap();
+    end_point.stop().unwrap().join().unwrap();
 }
 
 #[test]
@@ -335,7 +335,7 @@ fn test_aggr_first() {
         assert_eq!(row.get_data(), &*expected_encoded);
     }
 
-    end_point.stop().unwrap();
+    end_point.stop().unwrap().join().unwrap();
 }
 
 #[test]
@@ -356,7 +356,7 @@ fn test_limit() {
         assert_eq!(row.get_data(), &*expected_encoded);
     }
 
-    end_point.stop().unwrap();
+    end_point.stop().unwrap().join().unwrap();
 }
 
 #[test]
@@ -377,7 +377,7 @@ fn test_reverse() {
         assert_eq!(row.get_data(), &*expected_encoded);
     }
 
-    end_point.stop().unwrap();
+    end_point.stop().unwrap().join().unwrap();
 }
 
 fn prepare_idx(store: &mut Store,
@@ -440,7 +440,7 @@ fn test_index() {
     for (i, &h) in handles.iter().enumerate() {
         assert_eq!(i as i64 + 1, h);
     }
-    end_point.stop().unwrap();
+    end_point.stop().unwrap().join().unwrap();
 }
 
 #[test]
@@ -465,7 +465,7 @@ fn test_index_reverse_limit() {
     for (i, &h) in handles.iter().enumerate() {
         assert_eq!(10 - i as i64, h);
     }
-    end_point.stop().unwrap();
+    end_point.stop().unwrap().join().unwrap();
 }
 
 #[test]
@@ -487,5 +487,5 @@ fn test_del_select() {
 
     assert_eq!(resp.get_rows().len(), count as usize - 1);
 
-    end_point.stop().unwrap();
+    end_point.stop().unwrap().join().unwrap();
 }

--- a/tests/raftstore/util.rs
+++ b/tests/raftstore/util.rs
@@ -33,7 +33,7 @@ use tikv::util::escape;
 pub use tikv::raftstore::store::util::find_peer;
 
 pub fn must_get(engine: &Arc<DB>, key: &[u8], value: Option<&[u8]>) {
-    for _ in 1..250 {
+    for _ in 1..300 {
         if let Ok(res) = engine.get_value(&keys::data_key(key)) {
             if value.is_some() && res.is_some() {
                 assert_eq!(value.unwrap(), &*res.unwrap());


### PR DESCRIPTION
Shutdown all the worker thread and store thread concurrently, which will speed up shutdown and avoid peer timeout when it takes long time to shutdown worker pool.

@ngaut @siddontang @disksing @zhangjinpeng1987 PTAL