### PR TITLE
raft: do not change RecentActive when resetState for progress.

### DIFF
--- a/src/raft/progress.rs
+++ b/src/raft/progress.rs
@@ -86,7 +86,6 @@ pub struct Progress {
 impl Progress {
     pub fn reset_state(&mut self, state: ProgressState) {
         self.paused = false;
-        self.recent_active = false;
         self.pending_snapshot = 0;
         self.state = state;
         self.ins.reset();


### PR DESCRIPTION
Fix #811