### PR TITLE
bin/util: make column families's options work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
       addons:
          apt:
             sources: ['ubuntu-toolchain-r-test']
-            packages: ['g++-4.8', 'zlib1g-dev', 'libbz2-dev', 'libsnappy-dev', 'libjemalloc-dev', 'curl', 'libdw-dev', 'libelf-dev', 'elfutils', 'binutils-dev']
+            packages: ['g++-4.8', 'zlib1g-dev', 'libbz2-dev', 'libsnappy-dev', 'curl', 'libdw-dev', 'libelf-dev', 'elfutils', 'binutils-dev']
     - os: osx
       rust: nightly
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/ngaut/rust-rocksdb.git#fd83e59bda39f7ba5cddf94270e16343c44c6a8d"
+source = "git+https://github.com/ngaut/rust-rocksdb.git#561f1bf8bb9184727fa83d9ac62514b5f83a4a88"
 dependencies = [
  "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -404,7 +404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/ngaut/rust-rocksdb.git#fd83e59bda39f7ba5cddf94270e16343c44c6a8d"
+source = "git+https://github.com/ngaut/rust-rocksdb.git#561f1bf8bb9184727fa83d9ac62514b5f83a4a88"
 dependencies = [
  "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "librocksdb_sys 0.1.0 (git+https://github.com/ngaut/rust-rocksdb.git)",

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -115,3 +115,12 @@ block-size = "64KB"
 # block-cache used to cache uncompressed blocks, big block-cache can speed up read
 block-cache-size = "1GB"
 
+# If you're doing point lookups you definitely want to turn bloom filters on, We use
+# bloom filters to avoid unnecessary disk reads. Default bits_per_key is 10, which
+# yields ~1% false positive rate. Larger bits_per_key values will reduce false positive
+# rate, but increase memory usage and space amplification.
+bloom-filter-bits-per-key = 10
+
+# false means one sst file one bloom filter, true means evry block has a corresponding bloom filter
+block-based-bloom-filter = false
+

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -164,6 +164,10 @@ fn initial_metric(matches: &Matches, config: &toml::Value, node_id: Option<u64>)
 }
 
 fn get_rocksdb_option(matches: &Matches, config: &toml::Value) -> RocksdbOptions {
+    get_rocksdb_default_cf_option(matches, config)
+}
+
+fn get_rocksdb_default_cf_option(matches: &Matches, config: &toml::Value) -> RocksdbOptions {
     let mut opts = RocksdbOptions::new();
     let mut block_base_opts = BlockBasedOptions::new();
     let block_size = get_integer_value("",
@@ -440,7 +444,8 @@ fn build_raftkv(matches: &Matches,
     let trans = ServerTransport::new(ch);
     let path = Path::new(&cfg.storage.path).to_path_buf();
     let opts = get_rocksdb_option(matches, config);
-    let cfs_opts = vec![get_rocksdb_option(matches, config), get_rocksdb_lock_cf_option()];
+    let cfs_opts = vec![get_rocksdb_default_cf_option(matches, config),
+                        get_rocksdb_lock_cf_option()];
     let mut db_path = path.clone();
     db_path.push("db");
     let engine = Arc::new(rocksdb_util::new_engine_opt(opts,

--- a/src/util/rocksdb.rs
+++ b/src/util/rocksdb.rs
@@ -55,6 +55,8 @@ pub fn new_engine_opt(mut opts: Options,
     // Currently we support 1) Create new db. 2) Open a db with CFs we want. 3) Open db with no
     // CF.
     // TODO: Support open db with incomplete CFs.
+
+    // opts is used as Rocksdb's DBOptions when call DB::open_cf
     opts.create_if_missing(false);
     let cfs_ref_opts: Vec<&Options> = cfs_opts.iter().collect();
     match DB::open_cf(&opts, path, cfs, &cfs_ref_opts) {
@@ -62,12 +64,14 @@ pub fn new_engine_opt(mut opts: Options,
         Err(e) => warn!("open rocksdb fail: {}", e),
     }
 
+    // opts is used as Rocksdb's Options(include DBOptions and ColumnFamilyOptions)
+    // when call DB::open
     opts.create_if_missing(true);
     let mut db = match DB::open(&opts, path) {
         Ok(db) => db,
         Err(e) => return Err(e),
     };
-    for (&cf, &cf_opts) in cfs.iter().zip(cfs_ref_opts.iter()) {
+    for (&cf, &cf_opts) in cfs.iter().zip(&cfs_ref_opts) {
         if cf == "default" {
             continue;
         }

--- a/src/util/rocksdb.rs
+++ b/src/util/rocksdb.rs
@@ -22,27 +22,42 @@ pub fn get_cf_handle<'a>(db: &'a DB, cf: &str) -> Result<&'a DBCFHandle, String>
 pub fn open(path: &str, cfs: &[&str]) -> Result<DB, String> {
     let mut opts = Options::new();
     opts.create_if_missing(false);
-    open_opt(&opts, path, cfs)
+    let mut cfs_opts = vec![];
+    for _ in 0..cfs.len() {
+        cfs_opts.push(Options::new());
+    }
+    open_opt(&opts, path, cfs, cfs_opts)
 }
 
-pub fn open_opt(opts: &Options, path: &str, cfs: &[&str]) -> Result<DB, String> {
-    let cf_opts: Vec<Options> = cfs.iter().map(|_| Options::new()).collect();
-    let cf_ref_opts: Vec<&Options> = cf_opts.iter().collect();
-    DB::open_cf(opts, path, cfs, &cf_ref_opts)
+pub fn open_opt(opts: &Options,
+                path: &str,
+                cfs: &[&str],
+                cfs_opts: Vec<Options>)
+                -> Result<DB, String> {
+    let cfs_ref_opts: Vec<&Options> = cfs_opts.iter().collect();
+    DB::open_cf(opts, path, cfs, &cfs_ref_opts)
 }
 
 pub fn new_engine(path: &str, cfs: &[&str]) -> Result<DB, String> {
     let opts = Options::new();
-    new_engine_opt(opts, path, cfs)
+    let mut cfs_opts = vec![];
+    for _ in 0..cfs.len() {
+        cfs_opts.push(Options::new());
+    }
+    new_engine_opt(opts, path, cfs, cfs_opts)
 }
 
-pub fn new_engine_opt(mut opts: Options, path: &str, cfs: &[&str]) -> Result<DB, String> {
-    // TODO: configurable opts for each CF.
+pub fn new_engine_opt(mut opts: Options,
+                      path: &str,
+                      cfs: &[&str],
+                      cfs_opts: Vec<Options>)
+                      -> Result<DB, String> {
     // Currently we support 1) Create new db. 2) Open a db with CFs we want. 3) Open db with no
     // CF.
     // TODO: Support open db with incomplete CFs.
     opts.create_if_missing(false);
-    match open_opt(&opts, path, cfs) {
+    let cfs_ref_opts: Vec<&Options> = cfs_opts.iter().collect();
+    match DB::open_cf(&opts, path, cfs, &cfs_ref_opts) {
         Ok(db) => return Ok(db),
         Err(e) => warn!("open rocksdb fail: {}", e),
     }
@@ -52,11 +67,11 @@ pub fn new_engine_opt(mut opts: Options, path: &str, cfs: &[&str]) -> Result<DB,
         Ok(db) => db,
         Err(e) => return Err(e),
     };
-    for &cf in cfs {
+    for (&cf, &cf_opts) in cfs.iter().zip(cfs_ref_opts.iter()) {
         if cf == "default" {
             continue;
         }
-        if let Err(e) = db.create_cf(cf, &opts) {
+        if let Err(e) = db.create_cf(cf, cf_opts) {
             return Err(e);
         }
     }

--- a/travis-build/Makefile
+++ b/travis-build/Makefile
@@ -17,9 +17,9 @@ ${ROCKSDB_DIR}/librocksdb.so: ${ROCKSDB_DIR}/libgflags.a
 	export CPLUS_INCLUDE_PATH="${CPLUS_INCLUDE_PATH}:${ROCKSDB_DIR}/include" && \
 	export CXX=${COMPILER} && \
 	cd /tmp && \
-	curl -L https://github.com/facebook/rocksdb/archive/rocksdb-4.3.1.tar.gz -o rocksdb.tar.gz && \
+	curl -L https://github.com/facebook/rocksdb/archive/rocksdb-4.9.tar.gz -o rocksdb.tar.gz && \
 	tar xf rocksdb.tar.gz && \
-	cd rocksdb-rocksdb-4.3.1 && \
+	cd rocksdb-rocksdb-4.9 && \
 	make shared_lib && \
 	cp librocksdb.so* ${ROCKSDB_DIR}
 


### PR DESCRIPTION
Rocksdb has many different ways to open a db, let's have a look at the following two ways, 1) open db with the specified "name"; 2) open db with column families. The functions is declared as follows:
```
static Status Open(const Options& options, const std::string& name, DB** dbptr); 
static Status Open(const DBOptions& db_options, const std::string& name,
                                const std::vector<ColumnFamilyDescriptor>& column_families,
                                std::vector<ColumnFamilyHandle*>* handles, DB** dbptr);
```
Let's focus on the type of first parameter, they are different. Type Options is a wrapper, it is drived from DBOptions and ColumnFamilyOptions. DBOptions is used to control the behavor of db, like log directory, wal directory, max wal size, max background compaction threads and so on. ColumnFamilyOptions is used to control the behavor of column family, like write buffer size, compression type, condition of compaciton tigger, block cache size and so on.

Let‘s attention to rust-rocksdb library, it's DBOptions is Corresponds to Rocksdb's Options, and no type Corresponds to rocksdb's DBOptions and ColumnFamilyOptions. When we use rust-rocksdb's DBOptions, it can be passed to rocksdb as rocksdb's Options, DBOptions or ColumnFamilyOptions.

Take a look at how tikv open rocksdb, 1) try open_cf with cf_options not we provide, 2) if 1 successed, return, otherwise create db and all cfs with opts that we provide. When we start tikv with all cf are existed, we will drop options we have configed.