### PR TITLE
*: add version information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tikv"
 version = "0.0.1"
 keywords = ["KV", "distributed-systems", "raft"]
+build = "build.rs"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.0.1"
 keywords = ["KV", "distributed-systems", "raft"]
 build = "build.rs"
 
+[build-dependencies]
+time = "0.1"
+
 [features]
 default = []
 dev = ["clippy"]

--- a/build.rs
+++ b/build.rs
@@ -42,6 +42,5 @@ fn utc_time() -> String {
 fn commit_hash() -> String {
     let mut cmd = Command::new("git");
     cmd.args(&["rev-parse", "HEAD"]);
-    cmd.output().ok().map_or("None".to_owned(),
-                             |o| String::from_utf8(o.stdout).unwrap_or("None".to_owned()))
+    cmd.output().ok().and_then(|o| String::from_utf8(o.stdout).ok()).unwrap_or("None".to_owned())
 }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,61 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::error::Error;
+use std::path::PathBuf;
+use std::process::Command;
+
+struct Ignore;
+
+impl<E> From<E> for Ignore
+    where E: Error
+{
+    fn from(_: E) -> Ignore {
+        Ignore
+    }
+}
+
+fn main() {
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+
+    File::create(out_dir.join("build-info.txt"))
+        .unwrap()
+        .write_all(build_info().as_bytes())
+        .unwrap();
+}
+
+// build_info returns a string of commit hash and utc time or an empty string.
+fn build_info() -> String {
+    match (commit_hash(), utc_time()) {
+        // explicit separates outputs by '\n'.
+        (Ok(hash), Ok(date)) => format!("{}\n{}", hash.trim_right(), date),
+        _ => String::new(),
+    }
+}
+
+fn utc_time() -> Result<String, Ignore> {
+    Ok(try!(String::from_utf8(try!(Command::new("date")
+            .args(&["-u", "+%Y-%m-%d %I:%M:%S"])
+            .output())
+        .stdout)))
+}
+
+fn commit_hash() -> Result<String, Ignore> {
+    Ok(try!(String::from_utf8(try!(Command::new("git")
+            .args(&["rev-parse", "HEAD"])
+            .output())
+        .stdout)))
+}

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -641,6 +641,10 @@ fn main() {
     };
 
     initial_log(&matches, &config);
+
+    // Print version information.
+    util::print_tikv_info();
+
     let addr = get_string_value("A",
                                 "server.addr",
                                 &matches,

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -369,6 +369,23 @@ impl<L, R> Either<L, R> {
     }
 }
 
+/// `build_info` returns a tuple of Strings that contains build utc time and commit hash.
+fn build_info() -> (String, String) {
+    let raw = include_str!(concat!(env!("OUT_DIR"), "/build-info.txt"));
+    let mut parts = raw.split('\n');
+
+    (parts.next().unwrap_or("None").to_owned(), parts.next().unwrap_or("None").to_owned())
+}
+
+/// `print_tikv_info` prints the tikv version information to the standard output.
+pub fn print_tikv_info() {
+    let (hash, date) = build_info();
+    info!("Welcome to the TiKV.");
+    info!("Version:");
+    info!("Git Commit Hash: {}", hash);
+    info!("UTC Build Time:  {}", date);
+}
+
 #[cfg(test)]
 mod tests {
     use std::net::{SocketAddr, AddrParseError};


### PR DESCRIPTION
Resolve #950 

This PR uses `build.rs`, however we can compute the build date and hash in Makefile and pass them to tikv as environment variables. I choose `build.rs` because this is how we do things in rust.
