### PR TITLE
copr: quick fix for decimal incompatibility

### DIFF
--- a/src/util/codec/datum.rs
+++ b/src/util/codec/datum.rs
@@ -31,10 +31,11 @@ const COMPACT_BYTES_FLAG: u8 = 2;
 const INT_FLAG: u8 = 3;
 const UINT_FLAG: u8 = 4;
 const FLOAT_FLAG: u8 = 5;
-const DECIMAL_FLAG: u8 = 6;
+const NEW_DECIMAL_FLAG: u8 = 6;
 const DURATION_FLAG: u8 = 7;
 const VAR_INT_FLAG: u8 = 8;
 const VAR_UINT_FLAG: u8 = 9;
+const DECIMAL_FLAG: u8 = 10;
 const MAX_FLAG: u8 = 250;
 
 #[derive(PartialEq, Clone)]
@@ -667,6 +668,7 @@ pub fn split_datum(buf: &[u8], desc: bool) -> Result<(&[u8], &[u8])> {
         NIL_FLAG => 0,
         FLOAT_FLAG => number::F64_SIZE,
         DURATION_FLAG => number::I64_SIZE,
+        NEW_DECIMAL_FLAG => try!(mysql::dec_encoded_len(&buf[1..])),
         DECIMAL_FLAG => mysql::encoded_len(&buf[1..]),
         VAR_INT_FLAG => {
             let mut v = &buf[1..];

--- a/src/util/codec/mysql/mod.rs
+++ b/src/util/codec/mysql/mod.rs
@@ -50,6 +50,7 @@ fn parse_frac(s: &[u8], fsp: u8) -> Result<u32> {
 }
 
 mod duration;
+mod mydecimal;
 pub mod decimal;
 pub mod types;
 mod time;
@@ -57,6 +58,7 @@ mod time;
 pub use self::duration::Duration;
 pub use self::decimal::{Decimal, DecimalEncoder, DecimalDecoder, encoded_len};
 pub use self::types::{has_unsigned_flag, has_not_null_flag};
+pub use self::mydecimal::dec_encoded_len;
 pub use self::time::Time;
 
 #[cfg(test)]

--- a/src/util/codec/mysql/mydecimal.rs
+++ b/src/util/codec/mysql/mydecimal.rs
@@ -1,0 +1,44 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+use util::codec::Result;
+
+// A word holds 9 digits.
+const DIGITS_PER_WORD: u8 = 9;
+// A word is 4 bytes i32.
+const WORD_SIZE: u8 = 4;
+const DIG_2_BYTES: &'static [u8] = &[0, 1, 1, 2, 2, 3, 3, 4, 4, 4];
+
+/// Return the first encoded decimal's length.
+pub fn dec_encoded_len(encoded: &[u8]) -> Result<usize> {
+    if encoded.len() < 3 {
+        return Err(box_err!("decimal too short: {} < 3", encoded.len()));
+    }
+
+    let precision = encoded[0];
+    let frac_cnt = encoded[1];
+    if precision < frac_cnt {
+        return Err(box_err!("invalid decimal, precision {} < frac_cnt {}",
+                            precision,
+                            frac_cnt));
+    }
+    let int_cnt = precision - frac_cnt;
+    let int_word_cnt = int_cnt / DIGITS_PER_WORD;
+    let frac_word_cnt = frac_cnt / DIGITS_PER_WORD;
+    let int_left = (int_cnt - int_word_cnt * DIGITS_PER_WORD) as usize;
+    let frac_left = (frac_cnt - frac_word_cnt * DIGITS_PER_WORD) as usize;
+    let int_len = (int_word_cnt * WORD_SIZE + DIG_2_BYTES[int_left]) as usize;
+    let frac_len = (frac_word_cnt * WORD_SIZE + DIG_2_BYTES[frac_left]) as usize;
+    Ok(int_len + frac_len + 2)
+}


### PR DESCRIPTION
Because TiDB has enable the new decimal implementation but not TiKV, push down won't work when Decimal is involved. This is a quick fix for this incompatibility. But please note that it still won't work when you are using aggregation functions like `sum` or `average`.

@ngaut @coocood @shenli @qiuyesuifeng PTAL