### PR TITLE
server/node: Ensure store is fully initialized at startup

### DIFF
--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -129,9 +129,10 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         })
     }
 
-    // Do something before store runs.
-    // TODO: should not accept request before prepare is finished.
-    fn prepare(&mut self) -> Result<()> {
+    /// Initialize this store. It scans the db engine, load all regions
+    /// and their peers from it, and schedule snapshot worker if neccessary.
+    /// WARN: This store should not be used before Initialized.
+    pub fn init(&mut self) -> Result<()> {
         // Scan region meta to get saved regions.
         let start_key = keys::REGION_META_MIN_KEY;
         let end_key = keys::REGION_META_MAX_KEY;
@@ -188,8 +189,6 @@ impl<T: Transport, C: PdClient> Store<T, C> {
     }
 
     pub fn run(&mut self, event_loop: &mut EventLoop<Self>) -> Result<()> {
-        try!(self.prepare());
-
         try!(self.snap_mgr.wl().init());
 
         self.register_raft_base_tick(event_loop);

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -129,8 +129,8 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         })
     }
 
-    /// Initialize this store. It scans the db engine, load all regions
-    /// and their peers from it, and schedule snapshot worker if neccessary.
+    /// Initialize this store. It scans the db engine, loads all regions
+    /// and their peers from it, and schedules snapshot worker if neccessary.
     /// WARN: This store should not be used before Initialized.
     pub fn init(&mut self) -> Result<()> {
         // Scan region meta to get saved regions.

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -106,10 +106,9 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         try!(cfg.validate());
 
         let sendch = SendCh::new(sender);
-
         let peer_cache = HashMap::new();
 
-        Ok(Store {
+        let mut s = Store {
             cfg: cfg,
             store: meta,
             engine: engine,
@@ -126,13 +125,15 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             pd_client: pd_client,
             peer_cache: Arc::new(RwLock::new(peer_cache)),
             snap_mgr: mgr,
-        })
+        };
+        try!(s.init());
+        Ok(s)
     }
 
     /// Initialize this store. It scans the db engine, loads all regions
     /// and their peers from it, and schedules snapshot worker if neccessary.
-    /// WARN: This store should not be used before Initialized.
-    pub fn init(&mut self) -> Result<()> {
+    /// WARN: This store should not be used before initialized.
+    fn init(&mut self) -> Result<()> {
         // Scan region meta to get saved regions.
         let start_key = keys::REGION_META_MIN_KEY;
         let end_key = keys::REGION_META_MAX_KEY;

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -211,7 +211,7 @@ impl<C> Node<C>
         let store = self.store.clone();
         let ch = event_loop.channel();
 
-        let (sender, receiver) = mpsc::channel();
+        let (tx, rx) = mpsc::channel();
         let builder = thread::Builder::new().name(thd_name!(format!("raftstore-{}", store_id)));
         let h = try!(builder.spawn(move || {
             let mut store = Store::new(ch, store, cfg, db, trans, pd_client, snap_mgr).unwrap();
@@ -219,13 +219,13 @@ impl<C> Node<C>
             if let Err(e) = store.init() {
                 panic!("store {} prepare err {:?}", store_id, e);
             }
-            sender.send(0).unwrap();
+            tx.send(0).unwrap();
             if let Err(e) = store.run(&mut event_loop) {
                 error!("store {} run err {:?}", store_id, e);
             };
         }));
         // wait for store to be fully initialized(or error happens during its initialization)
-        receiver.recv().unwrap();
+        rx.recv().unwrap();
 
         self.store_handle = Some(h);
         Ok(())

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 use std::thread;
-use std::sync::Arc;
+use std::sync::{Arc, mpsc};
 
 use mio::EventLoop;
 use rocksdb::DB;
@@ -211,13 +211,23 @@ impl<C> Node<C>
         let store = self.store.clone();
         let ch = event_loop.channel();
 
+        let (tx, rx): (mpsc::Sender<i32>, mpsc::Receiver<i32>) = mpsc::channel();
         let builder = thread::Builder::new().name(thd_name!(format!("raftstore-{}", store_id)));
         let h = try!(builder.spawn(move || {
             let mut store = Store::new(ch, store, cfg, db, trans, pd_client, snap_mgr).unwrap();
+            let result = store.init();
+            // make sure the initialization of store is finished (even if error happens) in startup
+            tx.send(0).unwrap();
+            if let Err(e) = result {
+                error!("store {} prepare err {:?}", store_id, e);
+                return;
+            }
             if let Err(e) = store.run(&mut event_loop) {
                 error!("store {} run err {:?}", store_id, e);
             };
         }));
+        // wait for store to be fully initialized(or error happens during its initialization)
+        let _ = rx.recv();
 
         self.store_handle = Some(h);
         Ok(())

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -215,7 +215,7 @@ impl<C> Node<C>
         let builder = thread::Builder::new().name(thd_name!(format!("raftstore-{}", store_id)));
         let h = try!(builder.spawn(move || {
             let mut store = match Store::new(ch, store, cfg, db, trans, pd_client, snap_mgr) {
-                Err(e) => panic!("store {} prepare err {:?}", store_id, e),
+                Err(e) => panic!("construct store {} err {:?}", store_id, e),
                 Ok(s) => s,
             };
             tx.send(0).unwrap();


### PR DESCRIPTION
Fix https://github.com/pingcap/tikv/issues/982.

Please notice that it's possible to fail on `store.init()`. Currently this PR follows the behavior of old code to let main thread continue even it fails on store initialization.