### PR TITLE
ci: treat warning as err on ci

### DIFF
--- a/travis-build/test.sh
+++ b/travis-build/test.sh
@@ -27,6 +27,7 @@ fi
 export ENABLE_FEATURES=default
 export LOG_FILE=tests.log
 export RUST_TEST_THREADS=1
+export RUSTFLAGS=-Dwarnings
 make test 2>&1 | tee tests.out
 status=$?
 for case in `cat tests.out | python -c "import sys


### PR DESCRIPTION
In case we forget to fix some warnings or the code may not pass the latest rust compiler check or clippy lint, we should treat all warnings as error when checking on CI.

@ngaut @siddontang @disksing @zhangjinpeng1987 PTAL