### PR TITLE
util: fix rotating log file name

### DIFF
--- a/src/util/file_log.rs
+++ b/src/util/file_log.rs
@@ -42,6 +42,8 @@ fn compute_rollover_time(tm: Tm) -> Tm {
     (day_start_tm.to_utc() + duration).to_local()
 }
 
+/// Returns a Tm at the time one day before the given Tm.
+/// It expects the argument `tm` to be in local timezone. The resulting Tm is in local timezone.
 fn one_day_before(tm: Tm) -> Tm {
     let duration = time::Duration::from_std(Duration::new(ONE_DAY_SECONDS, 0)).unwrap();
     (tm.to_utc() - duration).to_local()
@@ -175,6 +177,13 @@ mod tests {
     use std::path::Path;
     use tempdir::TempDir;
     use super::{RotatingFileLoggerCore, ONE_DAY_SECONDS};
+
+    #[test]
+    fn test_one_day_before() {
+        let tm = time::strptime("2016-08-30", "%Y-%m-%d").unwrap().to_local();
+        let one_day_ago = time::strptime("2016-08-29", "%Y-%m-%d").unwrap().to_local();
+        assert_eq!(one_day_ago, super::one_day_before(tm));
+    }
 
     fn file_exists(file: &str) -> bool {
         let path = Path::new(file);


### PR DESCRIPTION
Currently the suffix of rotating log file is the day that log file rotation actually happens, which is one day after the logs happen.

```text
-rw-rw-r-- 1 tidb tidb 1978421 8月  30 14:23 pd.log
-rw-rw-r-- 1 tidb tidb   12991 8月  29 23:59 pd.log.20160829
-rw-rw-r-- 1 tidb tidb 2081968 8月  30 14:23 tidb.log
-rw-rw-r-- 1 tidb tidb   53407 8月  29 23:59 tidb.log.20160829
-rw-rw-r-- 1 tidb tidb  429948 8月  30 14:23 tikv.log
-rw-rw-r-- 1 tidb tidb    9731 8月  29 23:59 tikv.log.20160830
```

This PR revises the suffix of rotating log file name for TiKV to the day when logs happen to make it consistent with TiDB and PD.