### PR TITLE
gc: stop scan when there is no more keys.

### DIFF
--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -18,7 +18,7 @@ mod latch;
 use std::error;
 use std::io::Error as IoError;
 
-pub use self::scheduler::{Scheduler, Msg};
+pub use self::scheduler::{Scheduler, Msg, GC_BATCH_SIZE};
 pub use self::store::SnapshotStore;
 
 quick_error! {

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -328,15 +328,20 @@ fn process_read(cid: u64, mut cmd: Command, ch: SendCh<Msg>, snapshot: Box<Snaps
             let res = reader.scan_keys(scan_key.take(), GC_BATCH_SIZE)
                 .map_err(Error::from)
                 .and_then(|(keys, next_start)| {
-                    Ok(Command::Gc {
-                        ctx: ctx.clone(),
-                        safe_point: safe_point,
-                        scan_key: next_start,
-                        keys: keys,
-                    })
+                    if keys.len() == 0 {
+                        Ok(None)
+                    } else {
+                        Ok(Some(Command::Gc {
+                            ctx: ctx.clone(),
+                            safe_point: safe_point,
+                            scan_key: next_start,
+                            keys: keys,
+                        }))
+                    }
                 });
             match res {
-                Ok(cmd) => ProcessResult::NextCommand { cmd: cmd },
+                Ok(Some(cmd)) => ProcessResult::NextCommand { cmd: cmd },
+                Ok(None) => ProcessResult::Res,
                 Err(e) => ProcessResult::Failed { err: e.into() },
             }
         }

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -51,7 +51,7 @@ use super::latch::{Latches, Lock};
 const REPORT_STATISTIC_INTERVAL: u64 = 60000; // 60 seconds
 
 // TODO: make it configurable.
-const GC_BATCH_SIZE: usize = 512;
+pub const GC_BATCH_SIZE: usize = 512;
 
 pub enum Tick {
     ReportStatistic,

--- a/tests/storage/test_storage.rs
+++ b/tests/storage/test_storage.rs
@@ -404,6 +404,8 @@ fn test_txn_store_resolve_lock() {
 #[test]
 fn test_txn_store_gc() {
     let store = new_assertion_storage();
+    store.gc_ok(1);
+
     store.put_ok(b"k", b"v1", 5, 10);
     store.put_ok(b"k", b"v2", 15, 20);
     store.gc_ok(30);

--- a/tests/storage/test_storage.rs
+++ b/tests/storage/test_storage.rs
@@ -19,6 +19,7 @@ use rand::random;
 use super::sync_storage::SyncStorage;
 use kvproto::kvrpcpb::{Context, LockInfo};
 use tikv::storage::{Mutation, Key, KvPair, make_key};
+use tikv::storage::txn::GC_BATCH_SIZE;
 
 #[derive(Clone)]
 struct AssertionStorage(SyncStorage);
@@ -404,13 +405,28 @@ fn test_txn_store_resolve_lock() {
 #[test]
 fn test_txn_store_gc() {
     let store = new_assertion_storage();
-    store.gc_ok(1);
-
     store.put_ok(b"k", b"v1", 5, 10);
     store.put_ok(b"k", b"v2", 15, 20);
     store.gc_ok(30);
     store.get_none(b"k", 15);
     store.get_ok(b"k", 25, b"v2");
+}
+
+fn test_txn_store_gc_multiple_keys(n: usize) {
+    let store = new_assertion_storage();
+    for i in 0..n {
+        let key = format!("k{}", i);
+        store.put_ok(&key.as_bytes(), b"value", 5, 10);
+    }
+    store.gc_ok(20);
+}
+
+#[test]
+fn test_txn_store_gc2() {
+    for &i in [0, 1, GC_BATCH_SIZE - 1, GC_BATCH_SIZE, GC_BATCH_SIZE + 1, GC_BATCH_SIZE * 2]
+        .iter() {
+        test_txn_store_gc_multiple_keys(i);
+    }
 }
 
 struct Oracle {


### PR DESCRIPTION
If region has no key or key number is multiple of 512, the scan could loop forever.
@siddontang @zhangjinpeng1987 