### PR TITLE
add upper bound for iterator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,9 +230,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/ngaut/rust-rocksdb.git#c84cccfee084fcfdcb03ce12c15d657c6e94c3f7"
+source = "git+https://github.com/ngaut/rust-rocksdb.git#4c8e2192a819695a88640b68016007e06fed32c3"
 dependencies = [
- "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -459,9 +459,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/ngaut/rust-rocksdb.git#c84cccfee084fcfdcb03ce12c15d657c6e94c3f7"
+source = "git+https://github.com/ngaut/rust-rocksdb.git#4c8e2192a819695a88640b68016007e06fed32c3"
 dependencies = [
- "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "librocksdb_sys 0.1.0 (git+https://github.com/ngaut/rust-rocksdb.git)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,9 +230,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/ngaut/rust-rocksdb.git#4c8e2192a819695a88640b68016007e06fed32c3"
+source = "git+https://github.com/ngaut/rust-rocksdb.git#c84cccfee084fcfdcb03ce12c15d657c6e94c3f7"
 dependencies = [
- "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -459,9 +459,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/ngaut/rust-rocksdb.git#4c8e2192a819695a88640b68016007e06fed32c3"
+source = "git+https://github.com/ngaut/rust-rocksdb.git#c84cccfee084fcfdcb03ce12c15d657c6e94c3f7"
 dependencies = [
- "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "librocksdb_sys 0.1.0 (git+https://github.com/ngaut/rust-rocksdb.git)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,9 +230,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/ngaut/rust-rocksdb.git#4c8e2192a819695a88640b68016007e06fed32c3"
+source = "git+https://github.com/ngaut/rust-rocksdb.git#435fb982041c438c3a4b9e725da9b85c544da0e4"
 dependencies = [
- "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -459,9 +459,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/ngaut/rust-rocksdb.git#4c8e2192a819695a88640b68016007e06fed32c3"
+source = "git+https://github.com/ngaut/rust-rocksdb.git#435fb982041c438c3a4b9e725da9b85c544da0e4"
 dependencies = [
- "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "librocksdb_sys 0.1.0 (git+https://github.com/ngaut/rust-rocksdb.git)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -196,14 +196,14 @@ fn get_rocksdb_default_cf_option(matches: &Matches, config: &toml::Value) -> Roc
                                        config,
                                        Some(64 * 1024),
                                        |v| v.as_integer());
-    block_base_opts.set_block_size(block_size as u64);
+    block_base_opts.set_block_size(block_size as usize);
     let block_cache_size = get_integer_value("",
                                              "rocksdb.block-based-table.block-cache-size",
                                              matches,
                                              config,
                                              Some(1024 * 1024 * 1024),
                                              |v| v.as_integer());
-    block_base_opts.set_lru_cache(block_cache_size as u64);
+    block_base_opts.set_lru_cache(block_cache_size as usize);
     let bloom_bits_per_key = get_integer_value("",
                                                "rocksdb.block-based-table.\
                                                 bloom-filter-bits-per-key",
@@ -342,7 +342,7 @@ fn get_rocksdb_write_cf_option(matches: &Matches, config: &toml::Value) -> Rocks
                                              config,
                                              Some(1024 * 1024 * 1024),
                                              |v| v.as_integer());
-    let write_cf_block_cache_size: u64 = block_cache_size as u64 / 4;
+    let write_cf_block_cache_size = block_cache_size as usize / 4;
     block_base_opts.set_lru_cache(write_cf_block_cache_size);
     opts.set_block_based_table_factory(&block_base_opts);
 

--- a/src/raftstore/coprocessor/region_snapshot.rs
+++ b/src/raftstore/coprocessor/region_snapshot.rs
@@ -123,6 +123,14 @@ pub struct RegionIterator<'a> {
     end_key: Vec<u8>,
 }
 
+fn adjust_upper_bound(upper_bound: Option<&[u8]>) -> Option<&[u8]> {
+    if let Some(k) = upper_bound {
+        if k.is_empty() { None } else { Some(k) }
+    } else {
+        None
+    }
+}
+
 // we use rocksdb's style iterator, so omit the warning.
 #[allow(should_implement_trait)]
 impl<'a> RegionIterator<'a> {
@@ -130,7 +138,7 @@ impl<'a> RegionIterator<'a> {
                region: Region,
                upper_bound: Option<&[u8]>)
                -> RegionIterator<'a> {
-        let upper_bound = RegionIterator::adjust_upper_bound(upper_bound);
+        let upper_bound = adjust_upper_bound(upper_bound);
         let encoded_upper = upper_bound.map_or_else(|| keys::enc_end_key(&region), keys::data_key);
         let iter = snap.new_iterator(Some(encoded_upper.as_slice()));
         RegionIterator {
@@ -147,7 +155,7 @@ impl<'a> RegionIterator<'a> {
                   upper_bound: Option<&[u8]>,
                   cf: &str)
                   -> RegionIterator<'a> {
-        let upper_bound = RegionIterator::adjust_upper_bound(upper_bound);
+        let upper_bound = adjust_upper_bound(upper_bound);
         let encoded_upper = upper_bound.map_or_else(|| keys::enc_end_key(&region), keys::data_key);
         let iter = snap.new_iterator_cf(cf, Some(encoded_upper.as_slice())).unwrap();
         RegionIterator {
@@ -156,14 +164,6 @@ impl<'a> RegionIterator<'a> {
             start_key: keys::enc_start_key(&region),
             end_key: keys::enc_end_key(&region),
             region: region,
-        }
-    }
-
-    fn adjust_upper_bound(upper_bound: Option<&[u8]>) -> Option<&[u8]> {
-        if let Some(k) = upper_bound {
-            if k.is_empty() { None } else { Some(k) }
-        } else {
-            None
         }
     }
 

--- a/src/raftstore/coprocessor/region_snapshot.rs
+++ b/src/raftstore/coprocessor/region_snapshot.rs
@@ -384,6 +384,21 @@ mod tests {
             }
         }
         assert_eq!(res, base_data);
+
+        // test iterator with upper bound
+        let store = new_peer_storage(engine.clone(), &Region::new());
+        let snap = RegionSnapshot::new(&store);
+        let mut iter = snap.iter(Some(b"a5"));
+        assert!(iter.seek_to_first());
+        let mut res = vec![];
+        loop {
+            res.push((iter.key().to_vec(), iter.value().to_vec()));
+            if !iter.next() {
+                break;
+            }
+        }
+        let expected_res = vec![(b"a1".to_vec(), b"v1".to_vec()), (b"a3".to_vec(), b"v3".to_vec())];
+        assert_eq!(res, expected_res);
     }
 
     #[test]

--- a/src/raftstore/coprocessor/region_snapshot.rs
+++ b/src/raftstore/coprocessor/region_snapshot.rs
@@ -131,8 +131,7 @@ impl<'a> RegionIterator<'a> {
                upper_bound: Option<&[u8]>,
                cf: &str)
                -> RegionIterator<'a> {
-        let encoded_upper =
-            upper_bound.map_or_else(|| keys::enc_end_key(&region), |v| keys::data_key(v));
+        let encoded_upper = upper_bound.map_or_else(|| keys::enc_end_key(&region), keys::data_key);
         let iter = if cf == "default" {
             snap.new_iterator(Some(encoded_upper.as_slice()))
         } else {

--- a/src/raftstore/coprocessor/region_snapshot.rs
+++ b/src/raftstore/coprocessor/region_snapshot.rs
@@ -50,12 +50,25 @@ impl RegionSnapshot {
     }
 
     pub fn iter(&self, upper_bound: Option<&[u8]>) -> RegionIterator {
-        RegionIterator::new(self.snap.new_iterator(upper_bound), self.region.clone())
+        if upper_bound.is_none() {
+            RegionIterator::new(self.snap.new_iterator(Some(keys::enc_end_key(self.get_region())
+                                    .as_slice())),
+                                self.region.clone())
+        } else {
+            RegionIterator::new(self.snap.new_iterator(upper_bound), self.region.clone())
+        }
     }
 
     pub fn iter_cf(&self, cf: &str, upper_bound: Option<&[u8]>) -> Result<RegionIterator> {
-        Ok(RegionIterator::new(try!(self.snap.new_iterator_cf(cf, upper_bound)),
-                               self.region.clone()))
+        if upper_bound.is_none() {
+            Ok(RegionIterator::new(try!(self.snap.new_iterator_cf(
+                    cf, Some(keys::enc_end_key(self.get_region()).as_slice()))
+                ),
+                                   self.region.clone()))
+        } else {
+            Ok(RegionIterator::new(try!(self.snap.new_iterator_cf(cf, upper_bound)),
+                                   self.region.clone()))
+        }
     }
 
     // scan scans database using an iterator in range [start_key, end_key), calls function f for

--- a/src/raftstore/coprocessor/region_snapshot.rs
+++ b/src/raftstore/coprocessor/region_snapshot.rs
@@ -130,6 +130,7 @@ impl<'a> RegionIterator<'a> {
                region: Region,
                upper_bound: Option<&[u8]>)
                -> RegionIterator<'a> {
+        let upper_bound = RegionIterator::adjust_upper_bound(upper_bound);
         let encoded_upper = upper_bound.map_or_else(|| keys::enc_end_key(&region), keys::data_key);
         let iter = snap.new_iterator(Some(encoded_upper.as_slice()));
         RegionIterator {
@@ -146,6 +147,7 @@ impl<'a> RegionIterator<'a> {
                   upper_bound: Option<&[u8]>,
                   cf: &str)
                   -> RegionIterator<'a> {
+        let upper_bound = RegionIterator::adjust_upper_bound(upper_bound);
         let encoded_upper = upper_bound.map_or_else(|| keys::enc_end_key(&region), keys::data_key);
         let iter = snap.new_iterator_cf(cf, Some(encoded_upper.as_slice())).unwrap();
         RegionIterator {
@@ -154,6 +156,14 @@ impl<'a> RegionIterator<'a> {
             start_key: keys::enc_start_key(&region),
             end_key: keys::enc_end_key(&region),
             region: region,
+        }
+    }
+
+    fn adjust_upper_bound(upper_bound: Option<&[u8]>) -> Option<&[u8]> {
+        if let Some(k) = upper_bound {
+            if k.is_empty() { None } else { Some(k) }
+        } else {
+            None
         }
     }
 
@@ -406,8 +416,7 @@ mod tests {
                 break;
             }
         }
-        let expected_res = vec![(b"a1".to_vec(), b"v1".to_vec()), (b"a3".to_vec(), b"v3".to_vec())];
-        assert_eq!(res, expected_res);
+        assert_eq!(res, base_data[0..2].to_vec());
     }
 
     #[test]

--- a/src/raftstore/store/worker/region.rs
+++ b/src/raftstore/store/worker/region.rs
@@ -123,7 +123,7 @@ fn delete_all_in_range(db: &DB,
         let handle = box_try!(rocksdb::get_cf_handle(db, cf));
         box_try!(db.delete_file_in_range_cf(*handle, start_key, end_key));
 
-        let mut it = box_try!(db.new_iterator_cf(cf));
+        let mut it = box_try!(db.new_iterator_cf(cf, Some(end_key)));
 
         let mut wb = WriteBatch::new();
         try!(check_abort(&abort));

--- a/src/storage/engine/raftkv.rs
+++ b/src/storage/engine/raftkv.rs
@@ -283,14 +283,14 @@ impl Snapshot for RegionSnapshot {
     fn iter<'b>(&'b self) -> engine::Result<Box<Cursor + 'b>> {
         SNAPSHOT_OP_COUNTER_VEC.with_label_values(&["iter", "default"]).inc();
 
-        Ok(box RegionSnapshot::iter(self))
+        Ok(box RegionSnapshot::iter(self, None))
     }
 
     #[allow(needless_lifetimes)]
     fn iter_cf<'b>(&'b self, cf: CfName) -> engine::Result<Box<Cursor + 'b>> {
         SNAPSHOT_OP_COUNTER_VEC.with_label_values(&["iter", cf]).inc();
 
-        Ok(box try!(RegionSnapshot::iter_cf(self, cf)))
+        Ok(box try!(RegionSnapshot::iter_cf(self, cf, None)))
     }
 }
 

--- a/src/storage/engine/raftkv.rs
+++ b/src/storage/engine/raftkv.rs
@@ -16,7 +16,6 @@ use server::transport::RaftStoreRouter;
 use raftstore::errors::Error as RaftServerError;
 use raftstore::coprocessor::{RegionSnapshot, RegionIterator};
 use raftstore::store::engine::Peekable;
-use raftstore::store::keys;
 use kvproto::raft_cmdpb::{RaftCmdRequest, RaftCmdResponse, RaftRequestHeader, Request, Response,
                           CmdType, DeleteRequest, PutRequest};
 use kvproto::errorpb;
@@ -284,12 +283,7 @@ impl Snapshot for RegionSnapshot {
     fn iter<'b>(&'b self, upper_bound: Option<&[u8]>) -> engine::Result<Box<Cursor + 'b>> {
         SNAPSHOT_OP_COUNTER_VEC.with_label_values(&["iter", "default"]).inc();
 
-        if upper_bound.is_none() {
-            Ok(box RegionSnapshot::iter(self,
-                                        Some(keys::enc_end_key(self.get_region()).as_slice())))
-        } else {
-            Ok(box RegionSnapshot::iter(self, upper_bound))
-        }
+        Ok(box RegionSnapshot::iter(self, upper_bound))
     }
 
     #[allow(needless_lifetimes)]
@@ -299,14 +293,7 @@ impl Snapshot for RegionSnapshot {
                    -> engine::Result<Box<Cursor + 'b>> {
         SNAPSHOT_OP_COUNTER_VEC.with_label_values(&["iter", cf]).inc();
 
-        if upper_bound.is_none() {
-            Ok(box try!(RegionSnapshot::iter_cf(self,
-                                                cf,
-                                                Some(keys::enc_end_key(self.get_region())
-                                                    .as_slice()))))
-        } else {
-            Ok(box try!(RegionSnapshot::iter_cf(self, cf, upper_bound)))
-        }
+        Ok(box try!(RegionSnapshot::iter_cf(self, cf, upper_bound)))
     }
 }
 

--- a/src/storage/engine/rocksdb.rs
+++ b/src/storage/engine/rocksdb.rs
@@ -166,15 +166,15 @@ impl Snapshot for RocksSnapshot {
     }
 
     #[allow(needless_lifetimes)]
-    fn iter<'b>(&'b self) -> Result<Box<Cursor + 'b>> {
+    fn iter<'b>(&'b self, upper_bound: Option<&[u8]>) -> Result<Box<Cursor + 'b>> {
         trace!("RocksSnapshot: create iterator");
-        Ok(box self.new_iterator(None))
+        Ok(box self.new_iterator(upper_bound))
     }
 
     #[allow(needless_lifetimes)]
-    fn iter_cf<'b>(&'b self, cf: CfName) -> Result<Box<Cursor + 'b>> {
+    fn iter_cf<'b>(&'b self, cf: CfName, upper_bound: Option<&[u8]>) -> Result<Box<Cursor + 'b>> {
         trace!("RocksSnapshot: create cf iterator");
-        Ok(box try!(self.new_iterator_cf(cf, None)))
+        Ok(box try!(self.new_iterator_cf(cf, upper_bound)))
     }
 }
 

--- a/src/storage/engine/rocksdb.rs
+++ b/src/storage/engine/rocksdb.rs
@@ -168,13 +168,13 @@ impl Snapshot for RocksSnapshot {
     #[allow(needless_lifetimes)]
     fn iter<'b>(&'b self) -> Result<Box<Cursor + 'b>> {
         trace!("RocksSnapshot: create iterator");
-        Ok(box self.new_iterator())
+        Ok(box self.new_iterator(None))
     }
 
     #[allow(needless_lifetimes)]
     fn iter_cf<'b>(&'b self, cf: CfName) -> Result<Box<Cursor + 'b>> {
         trace!("RocksSnapshot: create cf iterator");
-        Ok(box try!(self.new_iterator_cf(cf)))
+        Ok(box try!(self.new_iterator_cf(cf, None)))
     }
 }
 

--- a/tests/storage/test_raftkv.rs
+++ b/tests/storage/test_raftkv.rs
@@ -136,7 +136,7 @@ fn assert_none_cf(ctx: &Context, engine: &Engine, cf: CfName, key: &[u8]) {
 
 fn assert_seek(ctx: &Context, engine: &Engine, key: &[u8], pair: (&[u8], &[u8])) {
     let snapshot = engine.snapshot(ctx).unwrap();
-    let mut iter = snapshot.iter().unwrap();
+    let mut iter = snapshot.iter(None).unwrap();
     iter.seek(&make_key(key)).unwrap();
     assert_eq!((iter.key(), iter.value()),
                (&*bytes::encode_bytes(pair.0), pair.1));
@@ -187,7 +187,7 @@ fn seek(ctx: &Context, engine: &Engine) {
     assert_seek(ctx, engine, b"y", (b"z", b"2"));
     assert_seek(ctx, engine, b"x\x00", (b"z", b"2"));
     let snapshot = engine.snapshot(ctx).unwrap();
-    let mut iter = snapshot.iter().unwrap();
+    let mut iter = snapshot.iter(None).unwrap();
     assert!(!iter.seek(&make_key(b"z\x00")).unwrap());
     must_delete(ctx, engine, b"x");
     must_delete(ctx, engine, b"z");
@@ -197,7 +197,7 @@ fn near_seek(ctx: &Context, engine: &Engine) {
     must_put(ctx, engine, b"x", b"1");
     must_put(ctx, engine, b"z", b"2");
     let snapshot = engine.snapshot(ctx).unwrap();
-    let mut cursor = snapshot.iter().unwrap();
+    let mut cursor = snapshot.iter(None).unwrap();
     let cursor_mut = cursor.as_mut();
     assert_near_seek(cursor_mut, b"x", (b"x", b"1"));
     assert_near_seek(cursor_mut, b"a", (b"x", b"1"));


### PR DESCRIPTION
Add upper bound for iterator to speed up region scan when there are a lot of deleted keys.