### PR TITLE
store: async destroy region

### DIFF
--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -31,9 +31,9 @@ use util::worker::Scheduler;
 use util::rocksdb;
 use raft::{self, Storage, RaftState, StorageError, Error as RaftError, Ready};
 use raftstore::{Result, Error};
-use super::worker::SnapTask;
+use super::worker::RegionTask;
 use super::keys::{self, enc_start_key, enc_end_key};
-use super::engine::{Snapshot as DbSnapshot, Peekable, Iterable, Mutable, delete_all_in_range};
+use super::engine::{Snapshot as DbSnapshot, Peekable, Iterable, Mutable};
 use super::{SnapFile, SnapKey, SnapEntry, SnapManager};
 use storage::CF_RAFT;
 
@@ -80,7 +80,7 @@ pub struct PeerStorage {
     pub applied_index_term: u64,
 
     snap_state: RefCell<SnapState>,
-    snap_sched: Scheduler<SnapTask>,
+    region_sched: Scheduler<RegionTask>,
     snap_tried_cnt: AtomicUsize,
 
     pub tag: String,
@@ -145,7 +145,7 @@ impl InvokeContext {
 impl PeerStorage {
     pub fn new(engine: Arc<DB>,
                region: &metapb::Region,
-               snap_sched: Scheduler<SnapTask>,
+               region_sched: Scheduler<RegionTask>,
                tag: String)
                -> Result<PeerStorage> {
         debug!("creating storage on {} for {:?}", engine.path(), region);
@@ -181,7 +181,7 @@ impl PeerStorage {
             raft_state: raft_state,
             apply_state: apply_state,
             snap_state: RefCell::new(SnapState::Relax),
-            snap_sched: snap_sched,
+            region_sched: region_sched,
             snap_tried_cnt: AtomicUsize::new(0),
             tag: tag,
             applied_index_term: RAFT_INIT_LOG_TERM,
@@ -348,8 +348,8 @@ impl PeerStorage {
         } else {
             return Err(raft::Error::Store(raft::StorageError::SnapshotTemporarilyUnavailable));
         }
-        let task = SnapTask::Gen { region_id: self.get_region_id() };
-        if let Err(e) = self.snap_sched.schedule(task) {
+        let task = RegionTask::Gen { region_id: self.get_region_id() };
+        if let Err(e) = self.region_sched.schedule(task) {
             error!("{} failed to schedule task snap generation: {:?}",
                    self.tag,
                    e);
@@ -494,24 +494,32 @@ impl PeerStorage {
     /// Delete all data belong to the region.
     /// If return Err, data may get partial deleted.
     pub fn clear_data(&self) -> Result<()> {
-        let timer = Instant::now();
         let (start_key, end_key) = (enc_start_key(self.get_region()),
                                     enc_end_key(self.get_region()));
-
-        try!(delete_all_in_range(&self.engine, &start_key, &end_key));
-        info!("{} clear peer data, takes {:?}", self.tag, timer.elapsed());
+        box_try!(self.region_sched.schedule(RegionTask::Destroy {
+            start_key: start_key,
+            end_key: end_key,
+        }));
         Ok(())
     }
 
     /// Delete all data that is not covered by `new_region`.
     fn clear_extra_data(&self, new_region: &metapb::Region) -> Result<()> {
-        let timer = Instant::now();
         let (old_start_key, old_end_key) = (enc_start_key(self.get_region()),
                                             enc_end_key(self.get_region()));
         let (new_start_key, new_end_key) = (enc_start_key(new_region), enc_end_key(new_region));
-        try!(delete_all_in_range(&self.engine, &old_start_key, &new_start_key));
-        try!(delete_all_in_range(&self.engine, &new_end_key, &old_end_key));
-        info!("{} clear extra data takes {:?}", self.tag, timer.elapsed());
+        if old_start_key < new_start_key {
+            box_try!(self.region_sched.schedule(RegionTask::Destroy {
+                start_key: old_start_key,
+                end_key: new_start_key,
+            }));
+        }
+        if new_end_key < old_end_key {
+            box_try!(self.region_sched.schedule(RegionTask::Destroy {
+                start_key: new_end_key,
+                end_key: old_end_key,
+            }));
+        }
         Ok(())
     }
 
@@ -618,12 +626,12 @@ impl PeerStorage {
                 }
             }
 
-            let task = SnapTask::Apply {
+            let task = RegionTask::Apply {
                 region_id: region_id,
                 abort: abort,
             };
             // TODO: gracefully remove region instead.
-            self.snap_sched.schedule(task).expect("snap apply job should not fail");
+            self.region_sched.schedule(task).expect("snap apply job should not fail");
             self.region = res.region.clone();
             return Ok(Some(res));
         }
@@ -817,9 +825,9 @@ mod test {
     use protobuf;
     use raftstore;
     use raftstore::store::*;
-    use raftstore::store::worker::{SnapRunner, MsgSender};
+    use raftstore::store::worker::{RegionRunner, MsgSender};
     use util::codec::number::NumberEncoder;
-    use raftstore::store::worker::SnapTask;
+    use raftstore::store::worker::RegionTask;
     use util::worker::{Worker, Scheduler};
     use util::HandyRwLock;
     use util::rocksdb::new_engine;
@@ -834,7 +842,7 @@ mod test {
         }
     }
 
-    fn new_storage(sched: Scheduler<SnapTask>, path: &TempDir) -> PeerStorage {
+    fn new_storage(sched: Scheduler<RegionTask>, path: &TempDir) -> PeerStorage {
         let db = new_engine(path.path().to_str().unwrap(), &[CF_DEFAULT, CF_RAFT]).unwrap();
         let db = Arc::new(db);
         bootstrap::bootstrap_store(&db, 1, 1).expect("");
@@ -842,7 +850,7 @@ mod test {
         PeerStorage::new(db, &region, sched, "".to_owned()).unwrap()
     }
 
-    fn new_storage_from_ents(sched: Scheduler<SnapTask>,
+    fn new_storage_from_ents(sched: Scheduler<RegionTask>,
                              path: &TempDir,
                              ents: &[Entry])
                              -> PeerStorage {
@@ -974,7 +982,7 @@ mod test {
         let sched = worker.scheduler();
         let mut s = new_storage_from_ents(sched, &td, &ents);
         let (tx, rx) = channel();
-        let runner = SnapRunner::new(s.engine.clone(), tx, mgr);
+        let runner = RegionRunner::new(s.engine.clone(), tx, mgr);
         worker.start(runner).unwrap();
         let snap = s.snapshot();
         let unavailable = RaftError::Store(StorageError::SnapshotTemporarilyUnavailable);
@@ -1060,7 +1068,7 @@ mod test {
         let sched = worker.scheduler();
         let s1 = new_storage_from_ents(sched.clone(), &td1, &ents);
         let (tx, rx) = channel();
-        let runner = SnapRunner::new(s1.engine.clone(), tx, mgr.clone());
+        let runner = RegionRunner::new(s1.engine.clone(), tx, mgr.clone());
         worker.start(runner).unwrap();
         assert!(s1.snapshot().is_err());
         let snap1 = match rx.recv().unwrap() {

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -44,7 +44,7 @@ use util::transport::SendCh;
 use util::get_disk_stat;
 use util::rocksdb;
 use storage::ALL_CFS;
-use super::worker::{SplitCheckRunner, SplitCheckTask, SnapTask, SnapRunner, CompactTask,
+use super::worker::{SplitCheckRunner, SplitCheckTask, RegionTask, RegionRunner, CompactTask,
                     CompactRunner, PdRunner, PdTask};
 use super::{util, Msg, Tick, SnapManager};
 use super::keys::{self, enc_start_key, enc_end_key};
@@ -74,7 +74,7 @@ pub struct Store<T: Transport, C: PdClient + 'static> {
     region_ranges: BTreeMap<Key, u64>,
     pending_regions: Vec<metapb::Region>,
     split_check_worker: Worker<SplitCheckTask>,
-    snap_worker: Worker<SnapTask>,
+    region_worker: Worker<RegionTask>,
     compact_worker: Worker<CompactTask>,
     pd_worker: Worker<PdTask>,
 
@@ -122,7 +122,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             region_peers: HashMap::new(),
             pending_raft_groups: HashSet::new(),
             split_check_worker: Worker::new("split check worker"),
-            snap_worker: Worker::new("snapshot worker"),
+            region_worker: Worker::new("snapshot worker"),
             compact_worker: Worker::new("compact worker"),
             pd_worker: Worker::new("pd worker"),
             region_ranges: BTreeMap::new(),
@@ -177,7 +177,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                       self.store_id());
                 let abort = Arc::new(AtomicBool::new(false));
                 peer.mut_store().set_snap_state(SnapState::Applying(abort.clone()));
-                box_try!(self.snap_worker.schedule(SnapTask::Apply {
+                box_try!(self.region_worker.schedule(RegionTask::Apply {
                     region_id: region_id,
                     abort: abort,
                 }));
@@ -237,10 +237,10 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                                                        self.cfg.region_split_size);
         box_try!(self.split_check_worker.start(split_check_runner));
 
-        let runner = SnapRunner::new(self.engine.clone(),
-                                     self.get_sendch(),
-                                     self.snap_mgr.clone());
-        box_try!(self.snap_worker.start(runner));
+        let runner = RegionRunner::new(self.engine.clone(),
+                                       self.get_sendch(),
+                                       self.snap_mgr.clone());
+        box_try!(self.region_worker.start(runner));
 
         box_try!(self.compact_worker.start(CompactRunner));
 
@@ -260,8 +260,8 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         self.snap_mgr.clone()
     }
 
-    pub fn snap_scheduler(&self) -> Scheduler<SnapTask> {
-        self.snap_worker.scheduler()
+    pub fn snap_scheduler(&self) -> Scheduler<RegionTask> {
+        self.region_worker.scheduler()
     }
 
     pub fn engine(&self) -> Arc<DB> {
@@ -1399,7 +1399,7 @@ impl<T: Transport, C: PdClient> mio::Handler for Store<T, C> {
         if !event_loop.is_running() {
             for (handle, name) in vec![(self.split_check_worker.stop(),
                                         self.split_check_worker.name()),
-                                       (self.snap_worker.stop(), self.snap_worker.name()),
+                                       (self.region_worker.stop(), self.region_worker.name()),
                                        (self.compact_worker.stop(), self.compact_worker.name()),
                                        (self.pd_worker.stop(), self.pd_worker.name())] {
                 if let Some(Err(e)) = handle.map(|h| h.join()) {

--- a/src/raftstore/store/worker/mod.rs
+++ b/src/raftstore/store/worker/mod.rs
@@ -11,13 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod snap;
+mod region;
 mod split_check;
 mod compact;
 mod pd;
 mod metrics;
 
-pub use self::snap::{Task as SnapTask, Runner as SnapRunner, MsgSender};
+pub use self::region::{Task as RegionTask, Runner as RegionRunner, MsgSender};
 pub use self::split_check::{Task as SplitCheckTask, Runner as SplitCheckRunner};
 pub use self::compact::{Task as CompactTask, Runner as CompactRunner};
 pub use self::pd::{Task as PdTask, Runner as PdRunner};

--- a/src/raftstore/store/worker/region.rs
+++ b/src/raftstore/store/worker/region.rs
@@ -321,7 +321,7 @@ impl<T: MsgSender> Runner<T> {
     }
 
     fn handle_destroy(&mut self, region_id: u64, start_key: Vec<u8>, end_key: Vec<u8>) {
-        info!("[region {}] deleting data in [{}, {}) of",
+        info!("[region {}] deleting data in [{}, {})",
               region_id,
               escape(&start_key),
               escape(&end_key));


### PR DESCRIPTION
Currently snapshot worker applies snapshot in single thread, it's safe to just schedule destroy task to that thread too. Hence the raftstore thread won't be blocked when deletion takes too long time to finish.