### PR TITLE
worker: enable WAL

### DIFF
--- a/src/raftstore/store/worker/compact.rs
+++ b/src/raftstore/store/worker/compact.rs
@@ -82,7 +82,7 @@ impl Runner {
         }
         // It is safe to disable WAL here. If crashed, we can still
         // compact the log after restart.
-        box_try!(task.engine.write_without_wal(wb));
+        box_try!(task.engine.write(wb));
         Ok(task.compact_idx - first_idx)
     }
 }

--- a/src/raftstore/store/worker/compact.rs
+++ b/src/raftstore/store/worker/compact.rs
@@ -80,8 +80,7 @@ impl Runner {
             let key = keys::raft_log_key(task.region_id, idx);
             box_try!(wb.delete_cf(*handle, &key));
         }
-        // It is safe to disable WAL here. If crashed, we can still
-        // compact the log after restart.
+        // It's not safe to disable WAL here. We may lost data after crashed for unknown reason.
         box_try!(task.engine.write(wb));
         Ok(task.compact_idx - first_idx)
     }


### PR DESCRIPTION
Before we figure out why data lost when tikv-server been killed, we should enable WAL.