### PR TITLE
store: clear PEER_DO_COMMAND_HISTOGRAM

### DIFF
--- a/src/raftstore/store/metrics.rs
+++ b/src/raftstore/store/metrics.rs
@@ -41,12 +41,6 @@ lazy_static! {
             "Total number of raft entry conf change handled."
         ).unwrap();
 
-    pub static ref PEER_DO_COMMAND_HISTOGRAM: Histogram =
-        register_histogram!(
-            "tikv_raftstore_do_command_duration_seconds",
-            "Bucketed histogram of peer doing command duration"
-        ).unwrap();
-
     pub static ref PEER_APPLY_LOG_HISTOGRAM: Histogram =
         register_histogram!(
             "tikv_raftstore_apply_log_duration_seconds",

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -22,7 +22,6 @@ use std::time::{Instant, Duration};
 use rocksdb::{DB, WriteBatch, Writable};
 use protobuf::{self, Message};
 use uuid::Uuid;
-use prometheus::HistogramTimer;
 
 use kvproto::metapb;
 use kvproto::eraftpb::{self, ConfChangeType};
@@ -63,7 +62,6 @@ pub struct PendingCmd {
     pub uuid: Uuid,
     pub term: u64,
     pub cb: Callback,
-    pub _timer: HistogramTimer,
 }
 
 #[derive(Debug)]

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -909,7 +909,6 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             uuid: uuid,
             term: term,
             cb: cb,
-            _timer: PEER_DO_COMMAND_HISTOGRAM.start_timer(),
         };
         try!(peer.propose(pending_cmd, msg, resp));
 


### PR DESCRIPTION
metric tikv_storage_engine_async_request_duration_seconds_bucket can
cover it, duplicated.

@ngaut @BusyJay @disksing @hhkbp2 @overvenus 