### PR TITLE
make rocksdb statistics configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/ngaut/rust-rocksdb.git#8e19867987a55a4dc9f0d2ccbfcf2611bde62ecd"
+source = "git+https://github.com/ngaut/rust-rocksdb.git#87f2aa2461aed9fa78ea6b92459fee32ac2c3206"
 dependencies = [
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -459,7 +459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/ngaut/rust-rocksdb.git#8e19867987a55a4dc9f0d2ccbfcf2611bde62ecd"
+source = "git+https://github.com/ngaut/rust-rocksdb.git#87f2aa2461aed9fa78ea6b92459fee32ac2c3206"
 dependencies = [
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "librocksdb_sys 0.1.0 (git+https://github.com/ngaut/rust-rocksdb.git)",

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -120,6 +120,12 @@ level0-stop-writes-trigger = 16
 # 3 : SkipAnyCorruptedRecords, Recovery after a disaster;
 wal-recovery-mode = 2
 
+# Rocksdb Statistics provides cumulative stats over time.
+enable-statistics = false
+
+# Dump statistics periodically in information logs.
+stats-dump-period-sec = 300
+
 # For detailed explanation please refer to https://github.com/facebook/rocksdb/blob/master/include/rocksdb/table.h
 [rocksdb.block-based-table]
 # Approximate size of user data packed per block.  Note that the 

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -124,7 +124,7 @@ wal-recovery-mode = 2
 enable-statistics = false
 
 # Dump statistics periodically in information logs.
-stats-dump-period-sec = 300
+stats-dump-period-sec = 60
 
 # For detailed explanation please refer to https://github.com/facebook/rocksdb/blob/master/include/rocksdb/table.h
 [rocksdb.block-based-table]

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -121,10 +121,12 @@ level0-stop-writes-trigger = 16
 wal-recovery-mode = 2
 
 # Rocksdb Statistics provides cumulative stats over time.
+# Set it ture only when debugging performance, because it will introduce overhead.
 enable-statistics = false
 
 # Dump statistics periodically in information logs.
-stats-dump-period-sec = 60
+# Same as rocksdb's default value (10 min).
+stats-dump-period-sec = 600
 
 # For detailed explanation please refer to https://github.com/facebook/rocksdb/blob/master/include/rocksdb/table.h
 [rocksdb.block-based-table]

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -205,7 +205,7 @@ fn get_rocksdb_option(matches: &Matches, config: &toml::Value) -> RocksdbOptions
                                                   "rocksdb.stats-dump-period-sec",
                                                   matches,
                                                   config,
-                                                  Some(60),
+                                                  Some(600),
                                                   |v| v.as_integer());
     opts.set_stats_dump_period_sec(stats_dump_period_sec as usize);
 

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -194,6 +194,21 @@ fn get_rocksdb_option(matches: &Matches, config: &toml::Value) -> RocksdbOptions
     let wal_recovery_mode = util::config::parse_rocksdb_wal_recovery_mode(rmode).unwrap();
     opts.set_wal_recovery_mode(wal_recovery_mode);
 
+    let enable_statistics = config.lookup("rocksdb.enable-statistics")
+        .unwrap_or(&toml::Value::Boolean(false))
+        .as_bool()
+        .unwrap_or(false);
+    if enable_statistics {
+        opts.enable_statistics();
+    }
+    let stats_dump_period_sec = get_integer_value("",
+                                                  "rocksdb.stats-dump-period-sec",
+                                                  matches,
+                                                  config,
+                                                  Some(60),
+                                                  |v| v.as_integer());
+    opts.set_stats_dump_period_sec(stats_dump_period_sec as usize);
+
     opts
 }
 


### PR DESCRIPTION
When debugging performance, we can get more details of rocksdb by enable rocksdb's statistics. 

```
** Level 0 read latency histogram (micros):
Count: 7384 Average: 8.5678  StdDev: 6.53
Min: 0  Median: 7.0683  Max: 212
Percentiles: P50: 7.07 P75: 8.53 P99: 19.55 P99.9: 132.32 P99.99: 212.00
------------------------------------------------------
[       0,       1 )       20   0.271%   0.271%
[       1,       2 )        6   0.081%   0.352%
[       2,       3 )      162   2.194%   2.546%
[       3,       4 )      501   6.785%   9.331% #
[       4,       5 )      294   3.982%  13.313% #
[       5,       6 )     1036  14.030%  27.343% ###
[       6,       7 )     1569  21.249%  48.592% ####
[       7,       8 )     1523  20.626%  69.217% ####
[       8,       9 )      807  10.929%  80.146% ##
[       9,      10 )      311   4.212%  84.358% #
[      10,      12 )      142   1.923%  86.281%
[      12,      14 )      177   2.397%  88.678%
[      14,      16 )      433   5.864%  94.542% #
[      16,      18 )      265   3.589%  98.131% #
[      18,      20 )       83   1.124%  99.255%
[      20,      25 )       29   0.393%  99.648%
[      25,      30 )        9   0.122%  99.770%
[      30,      35 )        2   0.027%  99.797%
[      35,      40 )        4   0.054%  99.851%
[      40,      45 )        2   0.027%  99.878%
[      70,      80 )        1   0.014%  99.892%
[     120,     140 )        1   0.014%  99.905%
[     140,     160 )        2   0.027%  99.932%
[     160,     180 )        3   0.041%  99.973%
[     180,     200 )        1   0.014%  99.986%
[     200,     250 )        1   0.014% 100.000%
...
rocksdb.block.cache.hit COUNT : 9158202
rocksdb.block.cache.add COUNT : 36531
rocksdb.block.cache.add.failures COUNT : 0
rocksdb.block.cache.index.miss COUNT : 0
rocksdb.block.cache.index.hit COUNT : 0
rocksdb.block.cache.index.bytes.insert COUNT : 0
rocksdb.block.cache.index.bytes.evict COUNT : 0
rocksdb.block.cache.filter.miss COUNT : 0
rocksdb.block.cache.filter.hit COUNT : 0
rocksdb.block.cache.filter.bytes.insert COUNT : 0
rocksdb.block.cache.filter.bytes.evict COUNT : 0
rocksdb.block.cache.data.miss COUNT : 315662
rocksdb.block.cache.data.hit COUNT : 9158203
rocksdb.block.cache.bytes.read COUNT : 122705707392
rocksdb.block.cache.bytes.write COUNT : 2005227328
rocksdb.bloom.filter.useful COUNT : 50149930
rocksdb.persistent.cache.hit COUNT : 0
rocksdb.persistent.cache.miss COUNT : 0
rocksdb.sim.block.cache.hit COUNT : 0
rocksdb.sim.block.cache.miss COUNT : 0
rocksdb.memtable.hit COUNT : 7518202
rocksdb.memtable.miss COUNT : 110424648
...
```