### PR TITLE
coprocessor: remove unnecessary metric.

### DIFF
--- a/src/server/coprocessor/endpoint.rs
+++ b/src/server/coprocessor/endpoint.rs
@@ -256,7 +256,6 @@ impl TiDbEndPoint {
         };
 
         select_timer.observe_duration();
-        let compose_timer = COPR_COMPOSE_HISTOGRAM.start_timer();
 
         let mut resp = Response::new();
         let mut sel_resp = SelectResponse::new();
@@ -277,7 +276,6 @@ impl TiDbEndPoint {
         let data = box_try!(sel_resp.write_to_bytes());
         resp.set_data(data);
 
-        compose_timer.observe_duration();
         Ok(resp)
     }
 }

--- a/src/server/coprocessor/metrics.rs
+++ b/src/server/coprocessor/metrics.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use prometheus::{HistogramVec, Histogram};
+use prometheus::{HistogramVec};
 
 lazy_static! {
     pub static ref COPR_REQ_HISTOGRAM_VEC: HistogramVec =
@@ -26,11 +26,5 @@ lazy_static! {
             "tikv_coprocessor_select_duration_seconds",
             "Bucketed histogram of coprocessor handle select duration",
             &["number"]
-        ).unwrap();
-
-    pub static ref COPR_COMPOSE_HISTOGRAM: Histogram =
-        register_histogram!(
-            "tikv_coprocessor_compose_resp_duration_seconds",
-            "Bucketed histogram of coprocessor compose responses duration"
         ).unwrap();
 }


### PR DESCRIPTION
It only handles response, and is very fast here. So no need using Histogram metric here. 
@BusyJay @hhkbp2 @overvenus @zhangjinpeng1987 