### PR TITLE
storage/cursor: add bound and linear check

### DIFF
--- a/src/raftstore/coprocessor/region_snapshot.rs
+++ b/src/raftstore/coprocessor/region_snapshot.rs
@@ -248,7 +248,7 @@ impl<'a> RegionIterator<'a> {
 
     #[inline]
     pub fn should_seekable(&self, key: &[u8]) -> Result<()> {
-        util::check_key_in_region_closed(key, &self.region)
+        util::check_key_in_region_inclusive(key, &self.region)
     }
 }
 

--- a/src/raftstore/coprocessor/region_snapshot.rs
+++ b/src/raftstore/coprocessor/region_snapshot.rs
@@ -259,7 +259,7 @@ mod tests {
     use raftstore::store::engine::*;
     use raftstore::store::keys::*;
     use raftstore::store::PeerStorage;
-    use storage::{Cursor, Key, ALL_CFS};
+    use storage::{Cursor, Key, ALL_CFS, ScanMode};
     use util::{worker, rocksdb};
 
     use super::*;
@@ -427,7 +427,7 @@ mod tests {
         let (store, test_data) = load_default_dataset(engine.clone());
 
         let snap = RegionSnapshot::new(&store);
-        let mut iter = Cursor::new(snap.iter(None), false);
+        let mut iter = Cursor::new(snap.iter(None), ScanMode::Mixed);
         assert!(!iter.reverse_seek(&Key::from_encoded(b"a2".to_vec())).unwrap());
         assert!(iter.reverse_seek(&Key::from_encoded(b"a7".to_vec())).unwrap());
         let mut pair = (iter.key().to_vec(), iter.value().to_vec());
@@ -454,7 +454,7 @@ mod tests {
         // test last region
         let store = new_peer_storage(engine.clone(), &Region::new());
         let snap = RegionSnapshot::new(&store);
-        let mut iter = Cursor::new(snap.iter(None), false);
+        let mut iter = Cursor::new(snap.iter(None), ScanMode::Mixed);
         assert!(!iter.reverse_seek(&Key::from_encoded(b"a1".to_vec())).unwrap());
         assert!(iter.reverse_seek(&Key::from_encoded(b"a2".to_vec())).unwrap());
         let pair = (iter.key().to_vec(), iter.value().to_vec());

--- a/src/raftstore/coprocessor/region_snapshot.rs
+++ b/src/raftstore/coprocessor/region_snapshot.rs
@@ -17,7 +17,7 @@ use kvproto::metapb::Region;
 
 use raftstore::store::engine::{Snapshot, Peekable, Iterable};
 use raftstore::store::{keys, util, PeerStorage};
-use raftstore::{Error, Result};
+use raftstore::Result;
 
 
 type Kv<'a> = (&'a [u8], &'a [u8]);
@@ -170,14 +170,18 @@ impl<'a> RegionIterator<'a> {
     pub fn seek_to_first(&mut self) -> bool {
         self.valid = self.iter.seek(self.start_key.as_slice().into());
 
-        self.update_valid()
+        self.update_valid(true)
     }
 
     #[inline]
-    fn update_valid(&mut self) -> bool {
+    fn update_valid(&mut self, forward: bool) -> bool {
         if self.valid {
             let key = self.iter.key();
-            self.valid = key >= &self.start_key && key < &self.end_key;
+            self.valid = if forward {
+                key < &self.end_key
+            } else {
+                key >= &self.start_key
+            };
         }
         self.valid
     }
@@ -192,18 +196,19 @@ impl<'a> RegionIterator<'a> {
         }
 
         self.valid = self.iter.valid();
-        self.update_valid()
+        self.update_valid(false)
     }
 
     pub fn seek(&mut self, key: &[u8]) -> Result<bool> {
-        let key = try!(self.should_seekable(key));
+        try!(self.should_seekable(key));
+        let key = keys::data_key(key);
         if key == self.end_key {
             self.valid = false;
         } else {
             self.valid = self.iter.seek(key.as_slice().into());
         }
 
-        Ok(self.update_valid())
+        Ok(self.update_valid(true))
     }
 
     pub fn prev(&mut self) -> bool {
@@ -212,7 +217,7 @@ impl<'a> RegionIterator<'a> {
         }
         self.valid = self.iter.prev();
 
-        self.update_valid()
+        self.update_valid(false)
     }
 
     pub fn next(&mut self) -> bool {
@@ -221,7 +226,7 @@ impl<'a> RegionIterator<'a> {
         }
         self.valid = self.iter.next();
 
-        self.update_valid()
+        self.update_valid(true)
     }
 
     #[inline]
@@ -242,12 +247,8 @@ impl<'a> RegionIterator<'a> {
     }
 
     #[inline]
-    fn should_seekable(&self, key: &[u8]) -> Result<Vec<u8>> {
-        let key = keys::data_key(key);
-        if key < self.start_key || key > self.end_key {
-            return Err(Error::KeyNotInRegion(key.to_vec(), self.region.clone()));
-        }
-        Ok(key)
+    pub fn should_seekable(&self, key: &[u8]) -> Result<()> {
+        util::check_key_in_region_closed(key, &self.region)
     }
 }
 
@@ -426,7 +427,7 @@ mod tests {
         let (store, test_data) = load_default_dataset(engine.clone());
 
         let snap = RegionSnapshot::new(&store);
-        let mut iter = Cursor::new(snap.iter(None));
+        let mut iter = Cursor::new(snap.iter(None), false);
         assert!(!iter.reverse_seek(&Key::from_encoded(b"a2".to_vec())).unwrap());
         assert!(iter.reverse_seek(&Key::from_encoded(b"a7".to_vec())).unwrap());
         let mut pair = (iter.key().to_vec(), iter.value().to_vec());
@@ -453,7 +454,7 @@ mod tests {
         // test last region
         let store = new_peer_storage(engine.clone(), &Region::new());
         let snap = RegionSnapshot::new(&store);
-        let mut iter = Cursor::new(snap.iter(None));
+        let mut iter = Cursor::new(snap.iter(None), false);
         assert!(!iter.reverse_seek(&Key::from_encoded(b"a1".to_vec())).unwrap());
         assert!(iter.reverse_seek(&Key::from_encoded(b"a2".to_vec())).unwrap());
         let pair = (iter.key().to_vec(), iter.value().to_vec());

--- a/src/raftstore/coprocessor/region_snapshot.rs
+++ b/src/raftstore/coprocessor/region_snapshot.rs
@@ -426,7 +426,7 @@ mod tests {
         let (store, test_data) = load_default_dataset(engine.clone());
 
         let snap = RegionSnapshot::new(&store);
-        let mut iter = snap.iter(None);
+        let mut iter = Cursor::new(snap.iter(None));
         assert!(!iter.reverse_seek(&Key::from_encoded(b"a2".to_vec())).unwrap());
         assert!(iter.reverse_seek(&Key::from_encoded(b"a7".to_vec())).unwrap());
         let mut pair = (iter.key().to_vec(), iter.value().to_vec());
@@ -453,7 +453,7 @@ mod tests {
         // test last region
         let store = new_peer_storage(engine.clone(), &Region::new());
         let snap = RegionSnapshot::new(&store);
-        let mut iter = snap.iter(None);
+        let mut iter = Cursor::new(snap.iter(None));
         assert!(!iter.reverse_seek(&Key::from_encoded(b"a1".to_vec())).unwrap());
         assert!(iter.reverse_seek(&Key::from_encoded(b"a2".to_vec())).unwrap());
         let pair = (iter.key().to_vec(), iter.value().to_vec());

--- a/src/raftstore/store/keys.rs
+++ b/src/raftstore/store/keys.rs
@@ -147,14 +147,8 @@ pub fn region_state_key(region_id: u64) -> Vec<u8> {
     make_region_meta_key(region_id, REGION_STATE_SUFFIX)
 }
 
-pub fn validate_data_key(key: &[u8]) -> Result<()> {
-    if !key.starts_with(DATA_PREFIX_KEY) {
-        return Err(box_err!("invalid data key {}, must start with {}",
-                            escape(key),
-                            DATA_PREFIX));
-    }
-
-    Ok(())
+pub fn validate_data_key(key: &[u8]) -> bool {
+    key.starts_with(DATA_PREFIX_KEY)
 }
 
 pub fn data_key(key: &[u8]) -> Vec<u8> {
@@ -165,7 +159,7 @@ pub fn data_key(key: &[u8]) -> Vec<u8> {
 }
 
 pub fn origin_key(key: &[u8]) -> &[u8] {
-    validate_data_key(key).expect("");
+    assert!(validate_data_key(key));
     &key[DATA_PREFIX_KEY.len()..]
 }
 
@@ -268,7 +262,7 @@ mod tests {
 
     #[test]
     fn test_data_key() {
-        validate_data_key(&data_key(b"abc")).unwrap();
-        validate_data_key(b"abc").unwrap_err();
+        assert!(validate_data_key(&data_key(b"abc")));
+        assert!(!validate_data_key(b"abc"));
     }
 }

--- a/src/raftstore/store/util.rs
+++ b/src/raftstore/store/util.rs
@@ -50,7 +50,7 @@ pub fn get_uuid_from_req(cmd: &RaftCmdRequest) -> Option<Uuid> {
 }
 
 /// Check if key in region range [`start_key`, `end_key`].
-pub fn check_key_in_region_closed(key: &[u8], region: &metapb::Region) -> Result<()> {
+pub fn check_key_in_region_inclusive(key: &[u8], region: &metapb::Region) -> Result<()> {
     let end_key = region.get_end_key();
     let start_key = region.get_start_key();
     if key >= start_key && (end_key.is_empty() || key <= end_key) {
@@ -96,20 +96,23 @@ mod tests {
     // Tests the util function `check_key_in_region`.
     #[test]
     fn test_check_key_in_region() {
-        let test_cases = vec![("", "", "", true),
-                              ("", "", "6", true),
-                              ("", "3", "6", false),
-                              ("4", "3", "6", true),
-                              ("4", "3", "", true),
-                              ("2", "3", "6", false),
-                              ("", "3", "6", false),
-                              ("", "3", "", false)];
-        for (key, start_key, end_key, is_in_region) in test_cases {
+        let test_cases = vec![("", "", "", true, true),
+                              ("", "", "6", true, true),
+                              ("", "3", "6", false, false),
+                              ("4", "3", "6", true, true),
+                              ("4", "3", "", true, true),
+                              ("2", "3", "6", false, false),
+                              ("", "3", "6", false, false),
+                              ("", "3", "", false, false),
+                              ("6", "3", "6", false, true)];
+        for (key, start_key, end_key, is_in_region, is_in_region_inclusive) in test_cases {
             let mut region = metapb::Region::new();
             region.set_start_key(start_key.as_bytes().to_vec());
             region.set_end_key(end_key.as_bytes().to_vec());
-            let result = check_key_in_region(key.as_bytes(), &region);
+            let mut result = check_key_in_region(key.as_bytes(), &region);
             assert_eq!(result.is_ok(), is_in_region);
+            result = check_key_in_region_inclusive(key.as_bytes(), &region);
+            assert_eq!(result.is_ok(), is_in_region_inclusive)
         }
     }
 

--- a/src/raftstore/store/util.rs
+++ b/src/raftstore/store/util.rs
@@ -49,6 +49,18 @@ pub fn get_uuid_from_req(cmd: &RaftCmdRequest) -> Option<Uuid> {
     Uuid::from_bytes(cmd.get_header().get_uuid())
 }
 
+/// Check if key in region range [`start_key`, `end_key`].
+pub fn check_key_in_region_closed(key: &[u8], region: &metapb::Region) -> Result<()> {
+    let end_key = region.get_end_key();
+    let start_key = region.get_start_key();
+    if key >= start_key && (end_key.is_empty() || key <= end_key) {
+        Ok(())
+    } else {
+        Err(Error::KeyNotInRegion(key.to_vec(), region.clone()))
+    }
+}
+
+/// Check if key in region range [`start_key`, `end_key`).
 pub fn check_key_in_region(key: &[u8], region: &metapb::Region) -> Result<()> {
     let end_key = region.get_end_key();
     let start_key = region.get_start_key();

--- a/src/server/coprocessor/endpoint.rs
+++ b/src/server/coprocessor/endpoint.rs
@@ -29,7 +29,7 @@ use threadpool::ThreadPool;
 use storage::{Engine, SnapshotStore};
 use kvproto::msgpb::{MessageType, Message};
 use kvproto::coprocessor::{Request, Response, KeyRange};
-use storage::{engine, Snapshot, Key};
+use storage::{engine, Snapshot, Key, ScanMode};
 use util::codec::table::TableDecoder;
 use util::codec::number::NumberDecoder;
 use util::codec::datum::DatumDecoder;
@@ -636,7 +636,11 @@ impl<'a> SelectContext<'a> {
             } else {
                 range.get_start().to_vec()
             };
-            let mut scanner = try!(self.snap.scanner());
+            let mut scanner = try!(self.snap.scanner(if desc {
+                ScanMode::Mixed
+            } else {
+                ScanMode::Forward
+            }));
             while limit > row_count {
                 let kv = if desc {
                     try!(scanner.reverse_seek(Key::from_raw(&seek_key)))
@@ -692,7 +696,11 @@ impl<'a> SelectContext<'a> {
         } else {
             r.get_start().to_vec()
         };
-        let mut scanner = try!(self.snap.scanner());
+        let mut scanner = try!(self.snap.scanner(if desc {
+            ScanMode::Mixed
+        } else {
+            ScanMode::Forward
+        }));
         while row_cnt < limit {
             let nk = if desc {
                 try!(scanner.reverse_seek(Key::from_raw(&seek_key)))

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -185,14 +185,9 @@ impl<'a> Cursor<'a> {
                 if self.iter.key() < key.encoded() {
                     self.iter.next();
                 }
-            } else if self.iter.seek_to_first() {
-                return Ok(true);
             } else {
-                self.max_key = Some(key.encoded().to_owned());
-                if self.min_key.as_ref().map_or(true, |k| k > key.encoded()) {
-                    self.min_key = Some(key.encoded().to_owned());
-                }
-                return Ok(false);
+                assert!(self.iter.seek_to_first());
+                return Ok(true);
             }
         } else {
             // ord == Less
@@ -226,7 +221,7 @@ impl<'a> Cursor<'a> {
         }
         if !try!(self.iter.seek(key)) && !self.iter.seek_to_last() {
             self.min_key = Some(key.encoded().to_owned());
-            if self.max_key.as_ref().map_or(true, |k| k < key.encoded()) {
+            if self.max_key.as_ref().map_or(true, |k| k > key.encoded()) {
                 self.max_key = Some(key.encoded().to_owned());
             }
             return Ok(false);
@@ -264,7 +259,8 @@ impl<'a> Cursor<'a> {
             if self.iter.valid() {
                 self.iter.prev();
             } else {
-                self.iter.seek_to_last();
+                assert!(self.iter.seek_to_last());
+                return Ok(true);
             }
         } else {
             near_loop!(self.iter.prev() && self.iter.key() >= key.encoded(),

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -376,6 +376,7 @@ mod tests {
 
         test_get_put(e.as_ref());
         test_batch(e.as_ref());
+        test_empty_seek(e.as_ref());
         test_seek(e.as_ref());
         test_near_seek(e.as_ref());
         test_cf(e.as_ref());
@@ -534,6 +535,17 @@ mod tests {
             let key = format!("y{}", i);
             must_delete(engine, key.as_bytes());
         }
+    }
+
+    fn test_empty_seek(engine: &Engine) {
+        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let mut cursor = snapshot.iter(None, ScanMode::Mixed).unwrap();
+        assert!(!cursor.near_reverse_seek(&make_key(b"x")).unwrap());
+        assert!(!cursor.near_reverse_seek(&make_key(b"z")).unwrap());
+        assert!(!cursor.near_reverse_seek(&make_key(b"w")).unwrap());
+        assert!(!cursor.near_seek(&make_key(b"x")).unwrap());
+        assert!(!cursor.near_seek(&make_key(b"z")).unwrap());
+        assert!(!cursor.near_seek(&make_key(b"w")).unwrap());
     }
 
     macro_rules! assert_seek {

--- a/src/storage/engine/raftkv.rs
+++ b/src/storage/engine/raftkv.rs
@@ -31,7 +31,7 @@ use rocksdb::DB;
 use protobuf::RepeatedField;
 
 use storage::engine;
-use super::{Engine, Modify, Cursor, Snapshot, Callback};
+use super::{Engine, Modify, Cursor, Snapshot, Callback, Iterator as EngineIterator};
 use storage::{Key, Value, CfName, CF_DEFAULT};
 use super::metrics::*;
 
@@ -276,20 +276,20 @@ impl Snapshot for RegionSnapshot {
     }
 
     #[allow(needless_lifetimes)]
-    fn iter<'b>(&'b self, upper_bound: Option<&[u8]>) -> engine::Result<Box<Cursor + 'b>> {
-        Ok(box RegionSnapshot::iter(self, upper_bound))
+    fn iter<'b>(&'b self, upper_bound: Option<&[u8]>) -> engine::Result<Cursor<'b>> {
+        Ok(Cursor::new(RegionSnapshot::iter(self, upper_bound)))
     }
 
     #[allow(needless_lifetimes)]
     fn iter_cf<'b>(&'b self,
                    cf: CfName,
                    upper_bound: Option<&[u8]>)
-                   -> engine::Result<Box<Cursor + 'b>> {
-        Ok(box try!(RegionSnapshot::iter_cf(self, cf, upper_bound)))
+                   -> engine::Result<Cursor<'b>> {
+        Ok(Cursor::new(try!(RegionSnapshot::iter_cf(self, cf, upper_bound))))
     }
 }
 
-impl<'a> Cursor for RegionIterator<'a> {
+impl<'a> EngineIterator for RegionIterator<'a> {
     fn next(&mut self) -> bool {
         RegionIterator::next(self)
     }

--- a/src/storage/engine/raftkv.rs
+++ b/src/storage/engine/raftkv.rs
@@ -31,7 +31,7 @@ use rocksdb::DB;
 use protobuf::RepeatedField;
 
 use storage::engine;
-use super::{Engine, Modify, Cursor, Snapshot, Callback, Iterator as EngineIterator};
+use super::{Engine, Modify, Cursor, Snapshot, ScanMode, Callback, Iterator as EngineIterator};
 use storage::{Key, Value, CfName, CF_DEFAULT};
 use super::metrics::*;
 
@@ -276,17 +276,20 @@ impl Snapshot for RegionSnapshot {
     }
 
     #[allow(needless_lifetimes)]
-    fn iter<'b>(&'b self, upper_bound: Option<&[u8]>, linear: bool) -> engine::Result<Cursor<'b>> {
-        Ok(Cursor::new(RegionSnapshot::iter(self, upper_bound), linear))
+    fn iter<'b>(&'b self,
+                upper_bound: Option<&[u8]>,
+                mode: ScanMode)
+                -> engine::Result<Cursor<'b>> {
+        Ok(Cursor::new(RegionSnapshot::iter(self, upper_bound), mode))
     }
 
     #[allow(needless_lifetimes)]
     fn iter_cf<'b>(&'b self,
                    cf: CfName,
                    upper_bound: Option<&[u8]>,
-                   linear: bool)
+                   mode: ScanMode)
                    -> engine::Result<Cursor<'b>> {
-        Ok(Cursor::new(try!(RegionSnapshot::iter_cf(self, cf, upper_bound)), linear))
+        Ok(Cursor::new(try!(RegionSnapshot::iter_cf(self, cf, upper_bound)), mode))
     }
 }
 

--- a/src/storage/engine/rocksdb.rs
+++ b/src/storage/engine/rocksdb.rs
@@ -20,7 +20,8 @@ use raftstore::store::engine::{Snapshot as RocksSnapshot, Peekable, Iterable};
 use util::escape;
 use util::rocksdb;
 use util::worker::{Runnable, Worker, Scheduler};
-use super::{Engine, Snapshot, Modify, Cursor, Iterator as EngineIterator, Callback, TEMP_DIR, Result, Error};
+use super::{Engine, Snapshot, Modify, Cursor, Iterator as EngineIterator, Callback, TEMP_DIR,
+            Result, Error};
 use tempdir::TempDir;
 
 enum Task {
@@ -166,15 +167,19 @@ impl Snapshot for RocksSnapshot {
     }
 
     #[allow(needless_lifetimes)]
-    fn iter<'b>(&'b self, upper_bound: Option<&[u8]>) -> Result<Cursor<'b>> {
+    fn iter<'b>(&'b self, upper_bound: Option<&[u8]>, linear: bool) -> Result<Cursor<'b>> {
         trace!("RocksSnapshot: create iterator");
-        Ok(Cursor::new(self.new_iterator(upper_bound)))
+        Ok(Cursor::new(self.new_iterator(upper_bound), linear))
     }
 
     #[allow(needless_lifetimes)]
-    fn iter_cf<'b>(&'b self, cf: CfName, upper_bound: Option<&[u8]>) -> Result<Cursor<'b>> {
+    fn iter_cf<'b>(&'b self,
+                   cf: CfName,
+                   upper_bound: Option<&[u8]>,
+                   linear: bool)
+                   -> Result<Cursor<'b>> {
         trace!("RocksSnapshot: create cf iterator");
-        Ok(Cursor::new(try!(self.new_iterator_cf(cf, upper_bound))))
+        Ok(Cursor::new(try!(self.new_iterator_cf(cf, upper_bound)), linear))
     }
 }
 

--- a/src/storage/engine/rocksdb.rs
+++ b/src/storage/engine/rocksdb.rs
@@ -21,7 +21,7 @@ use util::escape;
 use util::rocksdb;
 use util::worker::{Runnable, Worker, Scheduler};
 use super::{Engine, Snapshot, Modify, Cursor, Iterator as EngineIterator, Callback, TEMP_DIR,
-            Result, Error};
+            ScanMode, Result, Error};
 use tempdir::TempDir;
 
 enum Task {
@@ -167,19 +167,19 @@ impl Snapshot for RocksSnapshot {
     }
 
     #[allow(needless_lifetimes)]
-    fn iter<'b>(&'b self, upper_bound: Option<&[u8]>, linear: bool) -> Result<Cursor<'b>> {
+    fn iter<'b>(&'b self, upper_bound: Option<&[u8]>, mode: ScanMode) -> Result<Cursor<'b>> {
         trace!("RocksSnapshot: create iterator");
-        Ok(Cursor::new(self.new_iterator(upper_bound), linear))
+        Ok(Cursor::new(self.new_iterator(upper_bound), mode))
     }
 
     #[allow(needless_lifetimes)]
     fn iter_cf<'b>(&'b self,
                    cf: CfName,
                    upper_bound: Option<&[u8]>,
-                   linear: bool)
+                   mode: ScanMode)
                    -> Result<Cursor<'b>> {
         trace!("RocksSnapshot: create cf iterator");
-        Ok(Cursor::new(try!(self.new_iterator_cf(cf, upper_bound)), linear))
+        Ok(Cursor::new(try!(self.new_iterator_cf(cf, upper_bound)), mode))
     }
 }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -30,7 +30,7 @@ mod metrics;
 
 pub use self::config::Config;
 pub use self::engine::{Engine, Snapshot, Dsn, TEMP_DIR, new_engine, Modify, Cursor,
-                       Error as EngineError};
+                       Error as EngineError, ScanMode};
 pub use self::engine::raftkv::RaftKv;
 pub use self::txn::{SnapshotStore, Scheduler, Msg};
 pub use self::types::{Key, Value, KvPair, make_key};

--- a/src/storage/mvcc/reader.rs
+++ b/src/storage/mvcc/reader.rs
@@ -20,9 +20,9 @@ use super::write::{Write, WriteType};
 pub struct MvccReader<'a> {
     snapshot: &'a Snapshot,
     // cursors are used for speeding up scans.
-    data_cursor: Option<Box<Cursor + 'a>>,
-    lock_cursor: Option<Box<Cursor + 'a>>,
-    write_cursor: Option<Box<Cursor + 'a>>,
+    data_cursor: Option<Cursor<'a>>,
+    lock_cursor: Option<Cursor<'a>>,
+    write_cursor: Option<Cursor<'a>>,
 
     // true: the reader mainly used for scanning,
     // false: the reader mainly used for point get.

--- a/tests/storage/test_raftkv.rs
+++ b/tests/storage/test_raftkv.rs
@@ -136,7 +136,7 @@ fn assert_none_cf(ctx: &Context, engine: &Engine, cf: CfName, key: &[u8]) {
 
 fn assert_seek(ctx: &Context, engine: &Engine, key: &[u8], pair: (&[u8], &[u8])) {
     let snapshot = engine.snapshot(ctx).unwrap();
-    let mut iter = snapshot.iter(None).unwrap();
+    let mut iter = snapshot.iter(None, false).unwrap();
     iter.seek(&make_key(key)).unwrap();
     assert_eq!((iter.key(), iter.value()),
                (&*bytes::encode_bytes(pair.0), pair.1));
@@ -187,7 +187,7 @@ fn seek(ctx: &Context, engine: &Engine) {
     assert_seek(ctx, engine, b"y", (b"z", b"2"));
     assert_seek(ctx, engine, b"x\x00", (b"z", b"2"));
     let snapshot = engine.snapshot(ctx).unwrap();
-    let mut iter = snapshot.iter(None).unwrap();
+    let mut iter = snapshot.iter(None, false).unwrap();
     assert!(!iter.seek(&make_key(b"z\x00")).unwrap());
     must_delete(ctx, engine, b"x");
     must_delete(ctx, engine, b"z");
@@ -197,7 +197,7 @@ fn near_seek(ctx: &Context, engine: &Engine) {
     must_put(ctx, engine, b"x", b"1");
     must_put(ctx, engine, b"z", b"2");
     let snapshot = engine.snapshot(ctx).unwrap();
-    let mut cursor = snapshot.iter(None).unwrap();
+    let mut cursor = snapshot.iter(None, false).unwrap();
     assert_near_seek(&mut cursor, b"x", (b"x", b"1"));
     assert_near_seek(&mut cursor, b"a", (b"x", b"1"));
     assert_near_reverse_seek(&mut cursor, b"z1", (b"z", b"2"));

--- a/tests/storage/test_raftkv.rs
+++ b/tests/storage/test_raftkv.rs
@@ -136,7 +136,7 @@ fn assert_none_cf(ctx: &Context, engine: &Engine, cf: CfName, key: &[u8]) {
 
 fn assert_seek(ctx: &Context, engine: &Engine, key: &[u8], pair: (&[u8], &[u8])) {
     let snapshot = engine.snapshot(ctx).unwrap();
-    let mut iter = snapshot.iter(None, false).unwrap();
+    let mut iter = snapshot.iter(None, ScanMode::Mixed).unwrap();
     iter.seek(&make_key(key)).unwrap();
     assert_eq!((iter.key(), iter.value()),
                (&*bytes::encode_bytes(pair.0), pair.1));
@@ -187,7 +187,7 @@ fn seek(ctx: &Context, engine: &Engine) {
     assert_seek(ctx, engine, b"y", (b"z", b"2"));
     assert_seek(ctx, engine, b"x\x00", (b"z", b"2"));
     let snapshot = engine.snapshot(ctx).unwrap();
-    let mut iter = snapshot.iter(None, false).unwrap();
+    let mut iter = snapshot.iter(None, ScanMode::Mixed).unwrap();
     assert!(!iter.seek(&make_key(b"z\x00")).unwrap());
     must_delete(ctx, engine, b"x");
     must_delete(ctx, engine, b"z");
@@ -197,7 +197,7 @@ fn near_seek(ctx: &Context, engine: &Engine) {
     must_put(ctx, engine, b"x", b"1");
     must_put(ctx, engine, b"z", b"2");
     let snapshot = engine.snapshot(ctx).unwrap();
-    let mut cursor = snapshot.iter(None, false).unwrap();
+    let mut cursor = snapshot.iter(None, ScanMode::Mixed).unwrap();
     assert_near_seek(&mut cursor, b"x", (b"x", b"1"));
     assert_near_seek(&mut cursor, b"a", (b"x", b"1"));
     assert_near_reverse_seek(&mut cursor, b"z1", (b"z", b"2"));

--- a/tests/storage/test_raftkv.rs
+++ b/tests/storage/test_raftkv.rs
@@ -198,14 +198,13 @@ fn near_seek(ctx: &Context, engine: &Engine) {
     must_put(ctx, engine, b"z", b"2");
     let snapshot = engine.snapshot(ctx).unwrap();
     let mut cursor = snapshot.iter(None).unwrap();
-    let cursor_mut = cursor.as_mut();
-    assert_near_seek(cursor_mut, b"x", (b"x", b"1"));
-    assert_near_seek(cursor_mut, b"a", (b"x", b"1"));
-    assert_near_reverse_seek(cursor_mut, b"z1", (b"z", b"2"));
-    assert_near_reverse_seek(cursor_mut, b"x1", (b"x", b"1"));
-    assert_near_seek(cursor_mut, b"y", (b"z", b"2"));
-    assert_near_seek(cursor_mut, b"x\x00", (b"z", b"2"));
-    assert!(!cursor_mut.near_seek(&make_key(b"z\x00")).unwrap());
+    assert_near_seek(&mut cursor, b"x", (b"x", b"1"));
+    assert_near_seek(&mut cursor, b"a", (b"x", b"1"));
+    assert_near_reverse_seek(&mut cursor, b"z1", (b"z", b"2"));
+    assert_near_reverse_seek(&mut cursor, b"x1", (b"x", b"1"));
+    assert_near_seek(&mut cursor, b"y", (b"z", b"2"));
+    assert_near_seek(&mut cursor, b"x\x00", (b"z", b"2"));
+    assert!(!cursor.near_seek(&make_key(b"z\x00")).unwrap());
     must_delete(ctx, engine, b"x");
     must_delete(ctx, engine, b"z");
 }


### PR DESCRIPTION
This pr contains two improvements:

1. When doing heavy scan, the lock cursor will just scan forward(or backward), so we can save some unnecessary backward (or forward) move by checking if current cursor is doing linear seek;
2. Cursor has a consistent view to the underlying data, so once failed to seek a key, any key larger than the key can't be seek too, so we can add a bound check.

@ngaut @siddontang @disksing @zhangjinpeng1987 PTAL