### PR TITLE
raftstore/peer: add clock drift bound checking for lease read

### DIFF
--- a/src/raft/raft.rs
+++ b/src/raft/raft.rs
@@ -197,7 +197,7 @@ pub struct Raft<T: Storage> {
     // randomized_election_timeout is a random number between
     // [election_timeout, 2 * election_timeout - 1]. It gets reset
     // when raft changes its state to follower or candidate.
-    randomized_election_timeout: usize,
+    pub randomized_election_timeout: usize,
 
     /// Will be called when step** is about to be called.
     /// return false will skip step**.


### PR DESCRIPTION
Currently the raft status is used to check whether the raft leader has valid lease for lease read. It does not take clock drift into account so that the lease is inaccurate, and a lease read could happen on a invalid lease.

Without a accurate clock drift measurement, it is hard to implement the leader lease perfectly correct. There are ways to try to get the precise clock drift bound under different situations with the absent of TrueTime:

1. Trust the hardware clock definitely, as described in issue #964. But it does not work perfectly in VM. 
2. Specify a clock drift bound manually according to the cluster deployment or experience. But the bound could be wrongly estimated.

This PR addresses 2. It adds a clock drift bound parameter into raftstore config, and the peer will check against the that specified bound before performing a lease read.