### PR TITLE
bin, server: using default cluster id

### DIFF
--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -872,13 +872,12 @@ fn main() {
                                     Some(ROCKSDB_DSN.to_owned()),
                                     |v| v.as_str().map(|s| s.to_owned()));
     panic_hook::set_exit_hook();
-    let id = get_string_value("I",
-                              "raft.cluster-id",
-                              &matches,
-                              &config,
-                              Some(DEFAULT_CLUSTER_ID.to_string()),
-                              |v| v.as_integer().map(|i| i.to_string()));
-    let cluster_id = u64::from_str_radix(&id, 10).expect("invalid cluster id");
+    let cluster_id = get_integer_value("I",
+                                       "raft.cluster-id",
+                                       &matches,
+                                       &config,
+                                       Some(DEFAULT_CLUSTER_ID as i64),
+                                       |v| v.as_integer()) as u64;
     let mut cfg = build_cfg(&matches,
                             &config,
                             cluster_id,

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -46,8 +46,8 @@ use prometheus::{Encoder, TextEncoder};
 use tikv::storage::{Storage, TEMP_DIR, ALL_CFS};
 use tikv::util::{self, logger, file_log, panic_hook, rocksdb as rocksdb_util};
 use tikv::util::transport::SendCh;
-use tikv::server::{DEFAULT_LISTENING_ADDR, Server, Node, Config, bind, create_event_loop,
-                   create_raft_storage, Msg};
+use tikv::server::{DEFAULT_LISTENING_ADDR, DEFAULT_CLUSTER_ID, Server, Node, Config, bind,
+                   create_event_loop, create_raft_storage, Msg};
 use tikv::server::{ServerTransport, ServerRaftStoreRouter, MockRaftStoreRouter};
 use tikv::server::transport::RaftStoreRouter;
 use tikv::server::{MockStoreAddrResolver, PdStoreAddrResolver, StoreAddrResolver};
@@ -876,7 +876,7 @@ fn main() {
                               "raft.cluster-id",
                               &matches,
                               &config,
-                              None,
+                              Some(DEFAULT_CLUSTER_ID.to_string()),
                               |v| v.as_integer().map(|i| i.to_string()));
     let cluster_id = u64::from_str_radix(&id, 10).expect("invalid cluster id");
     let mut cfg = build_cfg(&matches,

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -832,7 +832,10 @@ fn main() {
                 "dsn",
                 "set which dsn to use, warning: default is rocksdb without persistent",
                 "dsn: rocksdb, raftkv");
-    opts.optopt("I", "cluster-id", "set cluster id", "must greater than 0.");
+    opts.optopt("I",
+                "cluster-id",
+                "set cluster id",
+                "in raftkv, must greater than 0; in rocksdb, 0 will be the default");
     opts.optopt("", "pd", "pd endpoints", "127.0.0.1:2379,127.0.0.1:3379");
 
     let matches = opts.parse(&args[1..]).expect("opts parse failed");
@@ -889,6 +892,9 @@ fn main() {
             run_local_server(listener, &cfg);
         }
         RAFTKV_DSN => {
+            if cluster_id == DEFAULT_CLUSTER_ID {
+                panic!("in raftkv, cluster_id must greater than 0");
+            }
             let _m = TimeMonitor::default();
             run_raft_server(listener, &matches, &config, &cfg);
         }

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -835,7 +835,7 @@ fn main() {
     opts.optopt("I",
                 "cluster-id",
                 "set cluster id",
-                "in raftkv, must greater than 0; in rocksdb, 0 will be the default");
+                "in raftkv, must greater than 0; in rocksdb, it will be ignored.");
     opts.optopt("", "pd", "pd endpoints", "127.0.0.1:2379,127.0.0.1:3379");
 
     let matches = opts.parse(&args[1..]).expect("opts parse failed");

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -15,7 +15,7 @@ pub use raftstore::store::Config as RaftStoreConfig;
 pub use storage::Config as StorageConfig;
 use super::Result;
 
-const DEFAULT_CLUSTER_ID: u64 = 0;
+pub const DEFAULT_CLUSTER_ID: u64 = 0;
 pub const DEFAULT_LISTENING_ADDR: &'static str = "127.0.0.1:20160";
 const DEFAULT_ADVERTISE_LISTENING_ADDR: &'static str = "";
 const DEFAULT_NOTIFY_CAPACITY: usize = 4096;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -34,7 +34,7 @@ pub mod node;
 pub mod resolve;
 pub mod snap;
 
-pub use self::config::{Config, DEFAULT_LISTENING_ADDR};
+pub use self::config::{Config, DEFAULT_LISTENING_ADDR, DEFAULT_CLUSTER_ID};
 pub use self::errors::{Result, Error};
 pub use self::server::{Server, create_event_loop, bind};
 pub use self::transport::{ServerTransport, ServerRaftStoreRouter, MockRaftStoreRouter};


### PR DESCRIPTION
Using default cluster id 0 if there is no `cluster-id` present. This allows users to start a tikv without any command line arguments.

PTAL @siddontang @BusyJay 

/cc @iamxy 