### PR TITLE
travis: fix linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,15 @@ release:
 	cp -f ./target/release/tikv-server ./bin
 
 test:
-	# Default Mac OSX `ulimit -n` is 256, too small. 
-	ulimit -n 2000 && LOG_LEVEL=DEBUG RUST_BACKTRACE=1 cargo test --features ${ENABLE_FEATURES} -- --nocapture
-	# TODO: remove following target once https://github.com/rust-lang/cargo/issues/2984 is resolved.
-	ulimit -n 2000 && LOG_LEVEL=DEBUG RUST_BACKTRACE=1 cargo test --features ${ENABLE_FEATURES} --bench benches -- --nocapture 
+	# Default Mac OSX `ulimit -n` is 256, too small. When SIP is enabled, DYLD_LIBRARY_PATH will not work
+	# in subshell, so we have to set it again here.
+	export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}:${LOCAL_DIR}/lib" && \
+	export LOG_LEVEL=DEBUG && \
+	export RUST_BACKTRACE=1 && \
+	ulimit -n 2000 && \
+	cargo test --features ${ENABLE_FEATURES} -- --nocapture && \
+	cargo test --features ${ENABLE_FEATURES} --bench benches -- --nocapture 
+	# TODO: remove above target once https://github.com/rust-lang/cargo/issues/2984 is resolved.
 
 bench:
 	# Default Mac OSX `ulimit -n` is 256, too small. 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ release:
 
 test:
 	# Default Mac OSX `ulimit -n` is 256, too small. When SIP is enabled, DYLD_LIBRARY_PATH will not work
-	# in subshell, so we have to set it again here.
+	# in subshell, so we have to set it again here. LOCAL_DIR is defined in .travis.yml.
 	export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}:${LOCAL_DIR}/lib" && \
 	export LOG_LEVEL=DEBUG && \
 	export RUST_BACKTRACE=1 && \


### PR DESCRIPTION
Now the default OSX image [has upgrade to Xcode 7.3](https://blog.travis-ci.com/2016-10-04-osx-73-default-image-live/), the SIP [is enabled](https://github.com/travis-ci/travis-ci/issues/5819#issuecomment-212064301) by default, which will wipe out all custom environment variables that starts with `DYLD_` when exec a subshell. So we need to set `DYLD_LIBRARY_PATH` in subshell too.

@ngaut @siddontang @disksing @zhangjinpeng1987 PTAL