### PR TITLE
raftstore: cache term

### DIFF
--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -78,6 +78,7 @@ pub struct PeerStorage {
     pub raft_state: RaftLocalState,
     pub apply_state: RaftApplyState,
     pub applied_index_term: u64,
+    pub last_term: u64,
 
     snap_state: RefCell<SnapState>,
     region_sched: Scheduler<RegionTask>,
@@ -114,6 +115,7 @@ pub struct InvokeContext {
     pub raft_state: RaftLocalState,
     pub apply_state: RaftApplyState,
     pub wb: WriteBatch,
+    last_term: u64,
     engine: Arc<DB>,
 }
 
@@ -123,6 +125,7 @@ impl InvokeContext {
             raft_state: store.raft_state.clone(),
             apply_state: store.apply_state.clone(),
             wb: WriteBatch::new(),
+            last_term: store.last_term,
             engine: store.engine.clone(),
         }
     }
@@ -160,6 +163,16 @@ impl PeerStorage {
                     raft_state
                 }
             };
+        let last_term = match raft_state.get_last_index() {
+            0 => 0,
+            RAFT_INIT_LOG_INDEX => RAFT_INIT_LOG_TERM,
+            idx => {
+                let e: Entry =
+                    try!(engine.get_msg_cf(CF_RAFT, &keys::raft_log_key(region.get_id(), idx)))
+                        .unwrap();
+                e.get_term()
+            }
+        };
         let apply_state =
             match try!(engine.get_msg_cf(CF_RAFT, &keys::apply_state_key(region.get_id()))) {
                 Some(s) => s,
@@ -185,6 +198,7 @@ impl PeerStorage {
             snap_tried_cnt: AtomicUsize::new(0),
             tag: tag,
             applied_index_term: RAFT_INIT_LOG_TERM,
+            last_term: last_term,
         })
     }
 
@@ -279,6 +293,9 @@ impl PeerStorage {
             return Ok(self.truncated_term());
         }
         try!(self.check_range(idx, idx + 1));
+        if self.truncated_term() == self.last_term || idx == self.last_index() {
+            return Ok(self.last_term);
+        }
         let key = keys::raft_log_key(self.get_region_id(), idx);
         match try!(self.engine.get_msg_cf::<Entry>(CF_RAFT, &key)) {
             Some(entry) => Ok(entry.get_term()),
@@ -410,7 +427,9 @@ impl PeerStorage {
                                    entry));
         }
 
-        let last_index = entries[entries.len() - 1].get_index();
+        let e = entries.last().unwrap();
+        let last_index = e.get_index();
+        let last_term = e.get_term();
 
         // Delete any previously appended log entries which never committed.
         for i in (last_index + 1)..(prev_last_index + 1) {
@@ -418,6 +437,7 @@ impl PeerStorage {
         }
 
         ctx.raft_state.set_last_index(last_index);
+        ctx.last_term = last_term;
 
         Ok(last_index)
     }
@@ -638,6 +658,7 @@ impl PeerStorage {
 
         self.raft_state = ctx.raft_state;
         self.apply_state = ctx.apply_state;
+        self.last_term = ctx.last_term;
         // If we apply snapshot ok, we should update some infos like applied index too.
         if let Some(res) = apply_snap_res {
             let abort = Arc::new(AtomicBool::new(false));


### PR DESCRIPTION
Currently almost every call to term will invoke `rocksdb::get`. This pr reduce the call times by caching the term of last_index. If `truncated_term` is equal to `last_term`, then every entry between truncated_index and last_index should have the same term.
