### PR TITLE
[WIP] storage: execute gc command base on statistics

### DIFF
--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -26,6 +26,7 @@ pub struct Config {
     pub sched_concurrency: usize,
     pub sched_worker_pool_size: usize,
     pub sched_too_busy_threshold: usize,
+    pub sched_pro_exec_gc: bool,
 }
 
 impl Default for Config {
@@ -37,6 +38,7 @@ impl Default for Config {
             sched_concurrency: DEFAULT_SCHED_CONCURRENCY,
             sched_worker_pool_size: DEFAULT_SCHED_WORKER_POOL_SIZE,
             sched_too_busy_threshold: DEFAULT_SCHED_TOO_BUSY_THRESHOLD,
+            sched_pro_exec_gc: true,
         }
     }
 }

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -26,7 +26,7 @@ pub struct Config {
     pub sched_concurrency: usize,
     pub sched_worker_pool_size: usize,
     pub sched_too_busy_threshold: usize,
-    pub sched_pro_exec_gc: bool,
+    pub sched_exec_gc_on_statistics: bool,
 }
 
 impl Default for Config {
@@ -38,7 +38,7 @@ impl Default for Config {
             sched_concurrency: DEFAULT_SCHED_CONCURRENCY,
             sched_worker_pool_size: DEFAULT_SCHED_WORKER_POOL_SIZE,
             sched_too_busy_threshold: DEFAULT_SCHED_TOO_BUSY_THRESHOLD,
-            sched_pro_exec_gc: true,
+            sched_exec_gc_on_statistics: true,
         }
     }
 }

--- a/src/storage/metrics.rs
+++ b/src/storage/metrics.rs
@@ -54,4 +54,11 @@ lazy_static! {
             "Bucketed histogram of latch wait",
             &["type"]
         ).unwrap();
+
+    pub static ref SCHED_GC_EXECUTE_COUNTER_VEC: CounterVec =
+        register_counter_vec!(
+            "tikv_scheduler_gc_command_total",
+            "Total number of commands executed by worker pool.",
+            &["type"]
+        ).unwrap();
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -269,21 +269,20 @@ impl Storage {
 
         let engine = self.engine.clone();
         let builder = thread::Builder::new().name(thd_name!("storage-scheduler"));
-        let el = handle.event_loop.take().unwrap();
+        let mut el = handle.event_loop.take().unwrap();
         let sched_concurrency = config.sched_concurrency;
         let sched_worker_pool_size = config.sched_worker_pool_size;
-        let sched_pro_exec_gc = config.sched_pro_exec_gc;
+        let sched_exec_gc_on_statistics = config.sched_exec_gc_on_statistics;
         let sched_too_busy_threshold = config.sched_too_busy_threshold;
         let ch = self.sendch.clone();
         let h = try!(builder.spawn(move || {
             let mut sched = Scheduler::new(engine,
                                            ch,
                                            sched_concurrency,
-                                           sched_pro_exec_gc,
+                                           sched_exec_gc_on_statistics,
                                            sched_too_busy_threshold,
                                            sched_worker_pool_size);
-            let mut event_loop = el;
-            if let Err(e) = sched.run(&mut event_loop) {
+            if let Err(e) = sched.run(&mut el) {
                 panic!("scheduler run err: {:?}", e);
             }
             info!("scheduler stopped");

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -272,9 +272,15 @@ impl Storage {
         let mut el = handle.event_loop.take().unwrap();
         let sched_concurrency = config.sched_concurrency;
         let sched_worker_pool_size = config.sched_worker_pool_size;
+        let sched_pro_exec_gc = config.sched_pro_exec_gc;
         let sched_too_busy_threshold = config.sched_too_busy_threshold;
         let ch = self.sendch.clone();
         let h = try!(builder.spawn(move || {
+            let mut sched = Scheduler::new(engine,
+                                           ch,
+                                           sched_concurrency,
+                                           sched_pro_exec_gc,
+                                           sched_worker_pool_size);
             let mut sched = Scheduler::new(engine,
                                            ch,
                                            sched_concurrency,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -269,7 +269,7 @@ impl Storage {
 
         let engine = self.engine.clone();
         let builder = thread::Builder::new().name(thd_name!("storage-scheduler"));
-        let mut el = handle.event_loop.take().unwrap();
+        let el = handle.event_loop.take().unwrap();
         let sched_concurrency = config.sched_concurrency;
         let sched_worker_pool_size = config.sched_worker_pool_size;
         let sched_pro_exec_gc = config.sched_pro_exec_gc;
@@ -288,6 +288,9 @@ impl Storage {
                                            sched_too_busy_threshold);
             if let Err(e) = el.run(&mut sched) {
                 panic!("scheduler run err:{:?}", e);
+            let mut event_loop = el;
+            if let Err(e) = sched.run(&mut event_loop) {
+                panic!("scheduler run err: {:?}", e);
             }
             info!("scheduler stopped");
         }));

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -280,14 +280,8 @@ impl Storage {
                                            ch,
                                            sched_concurrency,
                                            sched_pro_exec_gc,
+                                           sched_too_busy_threshold,
                                            sched_worker_pool_size);
-            let mut sched = Scheduler::new(engine,
-                                           ch,
-                                           sched_concurrency,
-                                           sched_worker_pool_size,
-                                           sched_too_busy_threshold);
-            if let Err(e) = el.run(&mut sched) {
-                panic!("scheduler run err:{:?}", e);
             let mut event_loop = el;
             if let Err(e) = sched.run(&mut event_loop) {
                 panic!("scheduler run err: {:?}", e);

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -14,6 +14,7 @@
 mod store;
 mod scheduler;
 mod latch;
+mod statistics;
 
 use std::error;
 use std::io::Error as IoError;

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -627,7 +627,15 @@ impl Scheduler {
 
     fn should_schedule(&mut self, cmd: &Command) -> bool {
         match *cmd {
-            Command::Gc { ref ctx, .. } => self.should_schedule_gc(ctx),
+            Command::Gc { ref ctx, .. } => {
+                SCHED_GC_EXECUTE_COUNTER_VEC.with_label_values(&["received"]).inc();
+                if self.should_schedule_gc(ctx) {
+                    SCHED_GC_EXECUTE_COUNTER_VEC.with_label_values(&["executed"]).inc();
+                    true
+                } else {
+                    false
+                }
+            }
             _ => true,
         }
     }

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -921,18 +921,21 @@ mod tests {
     fn test_gc_dice_loop() {
         let multiple = 4;
 
-        let mut true_count = test_gc_dice_true_count(0, WRITE_STATS_BASE, 256*multiple);
+        let mut true_count = test_gc_dice_true_count(0, WRITE_STATS_BASE, 256 * multiple);
         assert_eq!(true_count, 0);
 
-        true_count = test_gc_dice_true_count(10 * WRITE_STATS_BASE, WRITE_STATS_BASE, 256*multiple);
+        true_count =
+            test_gc_dice_true_count(10 * WRITE_STATS_BASE, WRITE_STATS_BASE, 256 * multiple);
         assert_eq!(true_count >= 0 * multiple, true);
         assert_eq!(true_count <= 20 * multiple, true);
 
-        true_count = test_gc_dice_true_count(150 * WRITE_STATS_BASE, WRITE_STATS_BASE, 256*multiple);
+        true_count =
+            test_gc_dice_true_count(150 * WRITE_STATS_BASE, WRITE_STATS_BASE, 256 * multiple);
         assert_eq!(true_count >= 140 * multiple, true);
         assert_eq!(true_count <= 160 * multiple, true);
 
-        true_count = test_gc_dice_true_count(300 * WRITE_STATS_BASE, WRITE_STATS_BASE, 256*multiple);
+        true_count =
+            test_gc_dice_true_count(300 * WRITE_STATS_BASE, WRITE_STATS_BASE, 256 * multiple);
         assert_eq!(true_count >= 250 * multiple, true);
     }
 }

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -607,6 +607,8 @@ impl Scheduler {
         let res = pro > x;
         if res {
             self.write_stats.clear_history(region_id);
+
+            info!("schedule GC command for region {}", region_id);
         }
 
         res

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -814,6 +814,7 @@ impl Scheduler {
 
         // The gc command maybe execute for a region that has no write for a long time, the
         // probability of execution for this kinds of regions increasing as time passing by.
+        // This is useful for the situation that store crash down and the statistics data lose.
         self.write_stats.incr_foreach(INIT_WRITE_STATS);
 
         self.register_roll_stats_tick(event_loop);

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -32,7 +32,6 @@
 //! to the scheduler.
 
 use rand;
-use std::u8;
 use std::boxed::Box;
 use std::time::Duration;
 use std::fmt::{self, Formatter, Debug};
@@ -51,14 +50,13 @@ use super::Result;
 use super::Error;
 use super::store::SnapshotStore;
 use super::latch::{Latches, Lock};
-use super::statistics::{RegionsWriteStats, ROLL_INTERVAL_SECS, CHECK_EXPIRED_INTERVAL_SECS};
+use super::statistics::{RegionsWriteStats, ROLL_INTERVAL_SECS, CHECK_EXPIRED_INTERVAL_SECS, U8_MAX};
 use super::super::metrics::*;
 
 // TODO: make it configurable.
 pub const GC_BATCH_SIZE: usize = 512;
 pub const WRITE_STATS_BASE: u64 = 64;
-pub const STATS_EXPIRED_SECS: i64 = 24 * 3600; // 24 hours
-const U8_MAX: u64 = u8::max_value() as u64;
+pub const STATS_EXPIRED_SECS: u64 = 24 * 3600; // 24 hours
 
 /// Process result of a command.
 pub enum ProcessResult {
@@ -620,7 +618,7 @@ impl Scheduler {
         let x = rand::random::<u8>();
         let res = pro > x;
         if res {
-            info!("schedule GC command for region {}", region_id);
+            info!("region [{}] schedule GC command", region_id);
             self.write_stats.clear_history(region_id);
         }
 

--- a/src/storage/txn/statistics.rs
+++ b/src/storage/txn/statistics.rs
@@ -1,0 +1,80 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+pub const ROLL_INTERVAL_SECS: u64 = 60 * 10;
+
+struct WriteStats {
+    pub history: u64,
+    pub current: u64,
+}
+
+impl WriteStats {
+    pub fn new() -> WriteStats {
+        WriteStats {
+            history: 0,
+            current: 0,
+        }
+    }
+
+    pub fn roll(&mut self) {
+        self.history += self.current;
+        self.current = 0;
+    }
+
+    pub fn incr(&mut self, n: u64) {
+        self.current += n;
+    }
+
+    pub fn clear_history(&mut self) {
+        self.history = 0;
+    }
+}
+
+pub struct RegionsWriteStats {
+    // region_id -> write stats
+    stats: HashMap<u64, WriteStats>,
+}
+
+impl RegionsWriteStats {
+    pub fn new() -> RegionsWriteStats {
+        RegionsWriteStats { stats: HashMap::new() }
+    }
+
+    pub fn incr(&mut self, region_id: u64, n: u64) {
+        let stat = self.stats.entry(region_id).or_insert_with(WriteStats::new);
+        stat.incr(n);
+    }
+
+    pub fn incr_foreach(&mut self, n: u64) {
+        for (_, stat) in &mut self.stats {
+            stat.incr(n);
+        }
+    }
+
+    pub fn roll(&mut self) {
+        for (_, stat) in &mut self.stats {
+            stat.roll();
+        }
+    }
+
+    pub fn clear_history(&mut self, region_id: u64) {
+        let stat = self.stats.entry(region_id).or_insert_with(WriteStats::new);
+        stat.clear_history();
+    }
+
+    pub fn get_history(&self, region_id: u64) -> u64 {
+        self.stats.get(&region_id).map_or(0, |s| s.history)
+    }
+}

--- a/src/storage/txn/statistics.rs
+++ b/src/storage/txn/statistics.rs
@@ -78,3 +78,25 @@ impl RegionsWriteStats {
         self.stats.get(&region_id).map_or(0, |s| s.history)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::RegionsWriteStats;
+
+    #[test]
+    fn test_regions_write_stats() {
+        let mut stats = RegionsWriteStats::new();
+
+        stats.incr(1, 100);
+        assert_eq!(stats.get_history(1), 0);
+        stats.roll();
+        assert_eq!(stats.get_history(1), 100);
+        stats.clear_history(1);
+        assert_eq!(stats.get_history(1), 0);
+
+        stats.incr_foreach(100);
+        assert_eq!(stats.get_history(1), 0);
+        stats.roll();
+        assert_eq!(stats.get_history(1), 100);
+    }
+}

--- a/src/storage/txn/statistics.rs
+++ b/src/storage/txn/statistics.rs
@@ -100,7 +100,7 @@ impl RegionsWriteStats {
         let expired = self.collect_expired(timeout_secs);
 
         for region_id in expired {
-            info!("Remove expired statistics for region {}", region_id);
+            info!("region [{}] Remove expired statistics", region_id);
             self.stats.remove(&region_id);
         }
     }

--- a/src/storage/txn/statistics.rs
+++ b/src/storage/txn/statistics.rs
@@ -11,13 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use time::{get_time, Timespec};
 use std::collections::HashMap;
 
 pub const ROLL_INTERVAL_SECS: u64 = 60 * 10;
+pub const CHECK_EXPIRED_INTERVAL_SECS: u64 = 60 * 60;
 
 struct WriteStats {
     pub history: u64,
     pub current: u64,
+    pub last_active: Timespec,
 }
 
 impl WriteStats {
@@ -25,6 +28,7 @@ impl WriteStats {
         WriteStats {
             history: 0,
             current: 0,
+            last_active: get_time(),
         }
     }
 
@@ -57,15 +61,10 @@ impl RegionsWriteStats {
         stat.incr(n);
     }
 
-    pub fn incr_foreach(&mut self, n: u64) {
-        for (_, stat) in &mut self.stats {
-            stat.incr(n);
-        }
-    }
-
-    pub fn roll(&mut self) {
+    pub fn roll_and_up(&mut self, base: u64) {
         for (_, stat) in &mut self.stats {
             stat.roll();
+            stat.incr(base);
         }
     }
 
@@ -77,11 +76,55 @@ impl RegionsWriteStats {
     pub fn get_history(&self, region_id: u64) -> u64 {
         self.stats.get(&region_id).map_or(0, |s| s.history)
     }
+
+    // used for test
+    #[allow(dead_code)]
+    pub fn get_current(&self, region_id: u64) -> u64 {
+        self.stats.get(&region_id).map_or(0, |s| s.current)
+    }
+
+    fn collect_expired(&self, timeout_secs: i64) -> Vec<u64> {
+        let now = get_time();
+        let mut expired = Vec::with_capacity(self.stats.len());
+        for (region_id, stat) in &self.stats {
+            if stat.last_active.sec + timeout_secs < now.sec {
+                expired.push(*region_id);
+            }
+        }
+        expired
+    }
+
+    // If a region don't receive GC command for a long time, it probably that
+    // 1) the region has moved to another store, or
+    // 2) the region's leader has transferred to another peer
+    // has happened, we don't need to hold WriteStats for this region anymore.
+    pub fn check_expired(&mut self, timeout_secs: i64) {
+        let expired = self.collect_expired(timeout_secs);
+
+        for region_id in expired {
+            info!("Remove expired statistics for region {}", region_id);
+            self.stats.remove(&region_id);
+        }
+    }
+
+    // When receive GC command for a region, we update the last_active of this region.
+    pub fn update_active(&mut self, region_id: u64) {
+        let now = get_time();
+        let stat = self.stats.entry(region_id).or_insert_with(WriteStats::new);
+        stat.last_active = now;
+    }
+
+    // used for test
+    #[allow(dead_code)]
+    pub fn exist(&self, region_id: u64) -> bool {
+        self.stats.contains_key(&region_id)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::RegionsWriteStats;
+    use std::{thread, time};
 
     #[test]
     fn test_regions_write_stats() {
@@ -89,14 +132,20 @@ mod tests {
 
         stats.incr(1, 100);
         assert_eq!(stats.get_history(1), 0);
-        stats.roll();
+        assert_eq!(stats.get_current(1), 100);
+        stats.roll_and_up(100);
         assert_eq!(stats.get_history(1), 100);
+        assert_eq!(stats.get_current(1), 100);
         stats.clear_history(1);
         assert_eq!(stats.get_history(1), 0);
 
-        stats.incr_foreach(100);
-        assert_eq!(stats.get_history(1), 0);
-        stats.roll();
-        assert_eq!(stats.get_history(1), 100);
+        stats.update_active(1);
+        stats.check_expired(10);
+        assert_eq!(stats.exist(1), true);
+
+        let two_seconds = time::Duration::from_secs(2);
+        thread::sleep(two_seconds);
+        stats.check_expired(1);
+        assert_eq!(stats.exist(1), false);
     }
 }

--- a/src/storage/txn/statistics.rs
+++ b/src/storage/txn/statistics.rs
@@ -13,7 +13,6 @@
 
 use std::time::{Instant, Duration};
 use std::collections::HashMap;
-use rand::{self, Rng};
 use std::u8;
 
 pub const ROLL_INTERVAL_SECS: u64 = 60 * 10;
@@ -65,15 +64,9 @@ impl RegionsWriteStats {
     }
 
     pub fn roll_and_up(&mut self, base: u64) {
-        let mut rng = rand::thread_rng();
         for (_, stat) in &mut self.stats {
             stat.roll();
-
-            // We initialize the stat with random number between [0 - base]. If we just use base
-            // initialize the stat, A large number of regions that haven't been written yet might
-            // execute GC command at about the same time.
-            let score = base * rng.gen::<u8>() as u64 / U8_MAX;
-            stat.incr(score);
+            stat.incr(base);
         }
     }
 

--- a/src/storage/txn/statistics.rs
+++ b/src/storage/txn/statistics.rs
@@ -91,7 +91,7 @@ impl RegionsWriteStats {
         let mut expired = Vec::with_capacity(self.stats.len());
         let now = Instant::now();
         for (region_id, stat) in &self.stats {
-            let duration = now.duration_since(stat.last_active.clone());
+            let duration = now.duration_since(stat.last_active);
             if duration > timeout {
                 expired.push(*region_id);
             }

--- a/tests/storage/test_storage.rs
+++ b/tests/storage/test_storage.rs
@@ -20,6 +20,7 @@ use super::sync_storage::SyncStorage;
 use kvproto::kvrpcpb::{Context, LockInfo};
 use tikv::storage::{Mutation, Key, KvPair, make_key};
 use tikv::storage::txn::GC_BATCH_SIZE;
+use tikv::storage::config::Config as StorageConfig;
 
 #[derive(Clone)]
 struct AssertionStorage(SyncStorage);
@@ -434,7 +435,9 @@ fn test_txn_store_resolve_lock() {
 
 #[test]
 fn test_txn_store_gc() {
-    let store = new_assertion_storage();
+    let mut cfg = StorageConfig::new();
+    cfg.sched_pro_exec_gc = false;
+    let store = AssertionStorage(SyncStorage::new(&cfg));
     store.put_ok(b"k", b"v1", 5, 10);
     store.put_ok(b"k", b"v2", 15, 20);
     store.gc_ok(30);

--- a/tests/storage/test_storage.rs
+++ b/tests/storage/test_storage.rs
@@ -436,7 +436,7 @@ fn test_txn_store_resolve_lock() {
 #[test]
 fn test_txn_store_gc() {
     let mut cfg = StorageConfig::new();
-    cfg.sched_pro_exec_gc = false;
+    cfg.sched_exec_gc_on_statistics = false;
     let store = AssertionStorage(SyncStorage::new(&cfg));
     store.put_ok(b"k", b"v1", 5, 10);
     store.put_ok(b"k", b"v2", 15, 20);


### PR DESCRIPTION
Currently we execute GC command for each region periodically, and the GC command is a kind of expensive operation that must scan whole region. If a region has no write after previous GC command executed, when a new GC command arrived for this region, we don't need to execute it.
This pr make GC command execute base on write statistics. 
