### PR TITLE
copr: support timezone (fixed offset)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,7 +601,7 @@ dependencies = [
 [[package]]
 name = "tipb"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/tipb.git#89d447d2cc7b0019e697fb95e65981d3a641b7ec"
+source = "git+https://github.com/pingcap/tipb.git#38084aeaf922fb5d41284865d64b2113f3ae5f1c"
 dependencies = [
  "protobuf 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/server/coprocessor/aggregate.rs
+++ b/src/server/coprocessor/aggregate.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 use tipb::expression::{Expr, ExprType};
 
-use util::codec::Datum;
+use util::codec::{Datum, Context};
 use util::xeval::evaluator;
 
 use super::Result;
@@ -27,7 +27,7 @@ pub fn build_aggr_func(expr: &Expr) -> Result<Box<AggrFunc>> {
 /// `AggrFunc` is used to execute aggregate operations.
 pub trait AggrFunc {
     /// `update` is used for update aggregate context.
-    fn update(&mut self, args: Vec<Datum>) -> Result<()>;
+    fn update(&mut self, ctx: &Context, args: Vec<Datum>) -> Result<()>;
     /// `calc` calculates the aggregated result and push it to collector.
     fn calc(&mut self, collector: &mut Vec<Datum>) -> Result<()>;
 }
@@ -35,7 +35,7 @@ pub trait AggrFunc {
 type Count = u64;
 
 impl AggrFunc for Count {
-    fn update(&mut self, args: Vec<Datum>) -> Result<()> {
+    fn update(&mut self, _: &Context, args: Vec<Datum>) -> Result<()> {
         for arg in args {
             if arg == Datum::Null {
                 return Ok(());
@@ -54,7 +54,7 @@ impl AggrFunc for Count {
 type First = Option<Datum>;
 
 impl AggrFunc for First {
-    fn update(&mut self, mut args: Vec<Datum>) -> Result<()> {
+    fn update(&mut self, _: &Context, mut args: Vec<Datum>) -> Result<()> {
         if self.is_some() {
             return Ok(());
         }
@@ -100,7 +100,7 @@ impl Sum {
 }
 
 impl AggrFunc for Sum {
-    fn update(&mut self, args: Vec<Datum>) -> Result<()> {
+    fn update(&mut self, _: &Context, args: Vec<Datum>) -> Result<()> {
         try!(self.add_asssign(args));
         Ok(())
     }
@@ -123,7 +123,7 @@ struct Avg {
 }
 
 impl AggrFunc for Avg {
-    fn update(&mut self, args: Vec<Datum>) -> Result<()> {
+    fn update(&mut self, _: &Context, args: Vec<Datum>) -> Result<()> {
         if try!(self.sum.add_asssign(args)) {
             self.cnt += 1;
         }
@@ -151,7 +151,7 @@ impl Extremum {
 }
 
 impl AggrFunc for Extremum {
-    fn update(&mut self, mut args: Vec<Datum>) -> Result<()> {
+    fn update(&mut self, ctx: &Context, mut args: Vec<Datum>) -> Result<()> {
         if args.len() != 1 {
             return Err(box_err!("max/min only support one column, but got {}", args.len()));
         }
@@ -159,7 +159,7 @@ impl AggrFunc for Extremum {
             return Ok(());
         }
         if let Some(ref d) = self.datum {
-            if box_try!(d.cmp(&args[0])) != self.ord {
+            if box_try!(d.cmp(ctx, &args[0])) != self.ord {
                 return Ok(());
             }
         }

--- a/src/server/coprocessor/aggregate.rs
+++ b/src/server/coprocessor/aggregate.rs
@@ -1,8 +1,8 @@
 use std::cmp::Ordering;
 use tipb::expression::{Expr, ExprType};
 
-use util::codec::{Datum, Context};
-use util::xeval::evaluator;
+use util::codec::Datum;
+use util::xeval::{evaluator, EvalContext};
 
 use super::Result;
 
@@ -27,7 +27,7 @@ pub fn build_aggr_func(expr: &Expr) -> Result<Box<AggrFunc>> {
 /// `AggrFunc` is used to execute aggregate operations.
 pub trait AggrFunc {
     /// `update` is used for update aggregate context.
-    fn update(&mut self, ctx: &Context, args: Vec<Datum>) -> Result<()>;
+    fn update(&mut self, ctx: &EvalContext, args: Vec<Datum>) -> Result<()>;
     /// `calc` calculates the aggregated result and push it to collector.
     fn calc(&mut self, collector: &mut Vec<Datum>) -> Result<()>;
 }
@@ -35,7 +35,7 @@ pub trait AggrFunc {
 type Count = u64;
 
 impl AggrFunc for Count {
-    fn update(&mut self, _: &Context, args: Vec<Datum>) -> Result<()> {
+    fn update(&mut self, _: &EvalContext, args: Vec<Datum>) -> Result<()> {
         for arg in args {
             if arg == Datum::Null {
                 return Ok(());
@@ -54,7 +54,7 @@ impl AggrFunc for Count {
 type First = Option<Datum>;
 
 impl AggrFunc for First {
-    fn update(&mut self, _: &Context, mut args: Vec<Datum>) -> Result<()> {
+    fn update(&mut self, _: &EvalContext, mut args: Vec<Datum>) -> Result<()> {
         if self.is_some() {
             return Ok(());
         }
@@ -100,7 +100,7 @@ impl Sum {
 }
 
 impl AggrFunc for Sum {
-    fn update(&mut self, _: &Context, args: Vec<Datum>) -> Result<()> {
+    fn update(&mut self, _: &EvalContext, args: Vec<Datum>) -> Result<()> {
         try!(self.add_asssign(args));
         Ok(())
     }
@@ -123,7 +123,7 @@ struct Avg {
 }
 
 impl AggrFunc for Avg {
-    fn update(&mut self, _: &Context, args: Vec<Datum>) -> Result<()> {
+    fn update(&mut self, _: &EvalContext, args: Vec<Datum>) -> Result<()> {
         if try!(self.sum.add_asssign(args)) {
             self.cnt += 1;
         }
@@ -151,7 +151,7 @@ impl Extremum {
 }
 
 impl AggrFunc for Extremum {
-    fn update(&mut self, ctx: &Context, mut args: Vec<Datum>) -> Result<()> {
+    fn update(&mut self, ctx: &EvalContext, mut args: Vec<Datum>) -> Result<()> {
         if args.len() != 1 {
             return Err(box_err!("max/min only support one column, but got {}", args.len()));
         }

--- a/src/server/coprocessor/endpoint.rs
+++ b/src/server/coprocessor/endpoint.rs
@@ -33,7 +33,7 @@ use storage::{engine, Snapshot, Key, ScanMode};
 use util::codec::table::TableDecoder;
 use util::codec::number::NumberDecoder;
 use util::codec::datum::DatumDecoder;
-use util::codec::{Datum, table, datum, mysql};
+use util::codec::{Datum, table, datum, mysql, Context};
 use util::xeval::Evaluator;
 use util::{escape, duration_to_ms, Either};
 use util::worker::{BatchRunnable, Scheduler};
@@ -327,6 +327,7 @@ fn get_pk(col: &ColumnInfo, h: i64) -> Datum {
 
 #[inline]
 fn inflate_with_col<'a, T>(eval: &mut Evaluator,
+                           ctx: &Context,
                            values: &HashMap<i64, &[u8]>,
                            cols: T,
                            h: i64)
@@ -345,7 +346,7 @@ fn inflate_with_col<'a, T>(eval: &mut Evaluator,
                         return Err(box_err!("column {} of {} is missing", col_id, h));
                     }
                     None => Datum::Null,
-                    Some(bs) => box_try!(bs.clone().decode_col_value(col)),
+                    Some(bs) => box_try!(bs.clone().decode_col_value(ctx, col)),
                 };
                 e.insert(value);
             }
@@ -364,6 +365,7 @@ fn get_chunk(chunks: &mut Vec<Chunk>) -> &mut Chunk {
 }
 
 pub struct SelectContextCore {
+    ctx: Context,
     sel: SelectRequest,
     eval: Evaluator,
     cols: Either<HashSet<i64>, Vec<i64>>,
@@ -420,6 +422,7 @@ impl SelectContextCore {
         };
 
         Ok(SelectContextCore {
+            ctx: box_try!(Context::new(&sel)),
             aggr: !sel.get_aggregates().is_empty() || !sel.get_group_by().is_empty(),
             aggr_cols: aggr_cols,
             sel: sel,
@@ -453,8 +456,8 @@ impl SelectContextCore {
         if !self.sel.has_field_where() {
             return Ok(false);
         }
-        try!(inflate_with_col(&mut self.eval, values, &self.cond_cols, h));
-        let res = box_try!(self.eval.eval(self.sel.get_field_where()));
+        try!(inflate_with_col(&mut self.eval, &self.ctx, values, &self.cond_cols, h));
+        let res = box_try!(self.eval.eval(&self.ctx, self.sel.get_field_where()));
         let b = box_try!(res.into_bool());
         Ok(b.map_or(true, |v| !v))
     }
@@ -495,7 +498,7 @@ impl SelectContextCore {
         }
         let mut vals = Vec::with_capacity(items.len());
         for item in items {
-            let v = box_try!(self.eval.eval(item.get_expr()));
+            let v = box_try!(self.eval.eval(&self.ctx, item.get_expr()));
             vals.push(v);
         }
         let res = box_try!(datum::encode_value(&vals));
@@ -503,7 +506,7 @@ impl SelectContextCore {
     }
 
     fn aggregate(&mut self, h: i64, values: &HashMap<i64, &[u8]>) -> Result<()> {
-        try!(inflate_with_col(&mut self.eval, values, &self.aggr_cols, h));
+        try!(inflate_with_col(&mut self.eval, &self.ctx, values, &self.aggr_cols, h));
         let gk = Rc::new(try!(self.get_group_key()));
         let aggr_exprs = self.sel.get_aggregates();
         match self.gk_aggrs.entry(gk.clone()) {
@@ -511,16 +514,16 @@ impl SelectContextCore {
                 let funcs = e.into_mut();
                 for (expr, func) in aggr_exprs.iter().zip(funcs) {
                     // TODO: cache args
-                    let args = box_try!(self.eval.batch_eval(expr.get_children()));
-                    try!(func.update(args));
+                    let args = box_try!(self.eval.batch_eval(&self.ctx, expr.get_children()));
+                    try!(func.update(&self.ctx, args));
                 }
             }
             Entry::Vacant(e) => {
                 let mut aggrs = Vec::with_capacity(aggr_exprs.len());
                 for expr in aggr_exprs {
                     let mut aggr = try!(aggregate::build_aggr_func(expr));
-                    let args = box_try!(self.eval.batch_eval(expr.get_children()));
-                    try!(aggr.update(args));
+                    let args = box_try!(self.eval.batch_eval(&self.ctx, expr.get_children()));
+                    try!(aggr.update(&self.ctx, args));
                     aggrs.push(aggr);
                 }
                 self.gks.push(gk);

--- a/src/server/coprocessor/endpoint.rs
+++ b/src/server/coprocessor/endpoint.rs
@@ -33,8 +33,8 @@ use storage::{engine, Snapshot, Key, ScanMode};
 use util::codec::table::TableDecoder;
 use util::codec::number::NumberDecoder;
 use util::codec::datum::DatumDecoder;
-use util::codec::{Datum, table, datum, mysql, Context};
-use util::xeval::Evaluator;
+use util::codec::{Datum, table, datum, mysql};
+use util::xeval::{Evaluator, EvalContext};
 use util::{escape, duration_to_ms, Either};
 use util::worker::{BatchRunnable, Scheduler};
 use server::OnResponse;
@@ -327,7 +327,7 @@ fn get_pk(col: &ColumnInfo, h: i64) -> Datum {
 
 #[inline]
 fn inflate_with_col<'a, T>(eval: &mut Evaluator,
-                           ctx: &Context,
+                           ctx: &EvalContext,
                            values: &HashMap<i64, &[u8]>,
                            cols: T,
                            h: i64)
@@ -365,7 +365,7 @@ fn get_chunk(chunks: &mut Vec<Chunk>) -> &mut Chunk {
 }
 
 pub struct SelectContextCore {
-    ctx: Context,
+    ctx: EvalContext,
     sel: SelectRequest,
     eval: Evaluator,
     cols: Either<HashSet<i64>, Vec<i64>>,
@@ -422,7 +422,7 @@ impl SelectContextCore {
         };
 
         Ok(SelectContextCore {
-            ctx: box_try!(Context::new(&sel)),
+            ctx: box_try!(EvalContext::new(&sel)),
             aggr: !sel.get_aggregates().is_empty() || !sel.get_group_by().is_empty(),
             aggr_cols: aggr_cols,
             sel: sel,

--- a/src/util/codec/mod.rs
+++ b/src/util/codec/mod.rs
@@ -38,7 +38,7 @@ pub mod table;
 pub mod convert;
 pub mod mysql;
 
-pub use self::datum::Datum;
+pub use self::datum::{Datum, Context};
 
 use std::str::Utf8Error;
 use std::string::FromUtf8Error;

--- a/src/util/codec/mod.rs
+++ b/src/util/codec/mod.rs
@@ -38,7 +38,7 @@ pub mod table;
 pub mod convert;
 pub mod mysql;
 
-pub use self::datum::{Datum, Context};
+pub use self::datum::Datum;
 
 use std::str::Utf8Error;
 use std::string::FromUtf8Error;

--- a/src/util/codec/mysql/time.rs
+++ b/src/util/codec/mysql/time.rs
@@ -251,6 +251,9 @@ impl Time {
         Time::new(t, types::DATETIME as u8, fsp as i8)
     }
 
+    /// Get time from packed u64. When `tp` is `TIMESTAMP`, the packed time should
+    /// be a UTC time; otherwise the packed time should be in the same timezone as `tz`
+    /// specified.
     pub fn from_packed_u64(t: u64, tp: u8, fsp: i8, tz: &FixedOffset) -> Result<Time> {
         if t == 0 {
             return Time::new(zero_time(tz), tp, fsp);
@@ -276,6 +279,9 @@ impl Time {
         Time::new(t, tp, fsp as i8)
     }
 
+    /// Serialize time to a u64.
+    ///
+    /// If `tp` is TIMESTAMP, it will be converted to a UTC time first.
     pub fn to_packed_u64(&self) -> u64 {
         if self.is_zero() {
             return 0;

--- a/src/util/codec/table.rs
+++ b/src/util/codec/table.rs
@@ -19,7 +19,7 @@ use tipb::schema::ColumnInfo;
 
 use super::number::{NumberDecoder, NumberEncoder};
 use super::bytes::BytesDecoder;
-use super::datum::DatumDecoder;
+use super::datum::{DatumDecoder, Context};
 use super::{Result, Datum, datum};
 use super::mysql::{types, Duration, Time};
 use util::escape;
@@ -130,7 +130,10 @@ pub fn encode_index_seek_key(table_id: i64, idx_id: i64, encoded: &[u8]) -> Vec<
 }
 
 // `decode_index_key` decodes datums from an index key.
-pub fn decode_index_key(mut encoded: &[u8], infos: &[ColumnInfo]) -> Result<Vec<Datum>> {
+pub fn decode_index_key(ctx: &Context,
+                        mut encoded: &[u8],
+                        infos: &[ColumnInfo])
+                        -> Result<Vec<Datum>> {
     encoded = &encoded[PREFIX_LEN + ID_LEN..];
     let mut res = vec![];
 
@@ -139,7 +142,7 @@ pub fn decode_index_key(mut encoded: &[u8], infos: &[ColumnInfo]) -> Result<Vec<
             return Err(box_err!("{} is too short.", escape(encoded)));
         }
         let mut v = try!(encoded.decode_datum());
-        v = try!(unflatten(v, info));
+        v = try!(unflatten(ctx, v, info));
         res.push(v);
     }
 
@@ -147,7 +150,7 @@ pub fn decode_index_key(mut encoded: &[u8], infos: &[ColumnInfo]) -> Result<Vec<
 }
 
 /// `unflatten` converts a raw datum to a column datum.
-fn unflatten(datum: Datum, col: &ColumnInfo) -> Result<Datum> {
+fn unflatten(ctx: &Context, datum: Datum, col: &ColumnInfo) -> Result<Datum> {
     if let Datum::Null = datum {
         return Ok(datum);
     }
@@ -172,7 +175,7 @@ fn unflatten(datum: Datum, col: &ColumnInfo) -> Result<Datum> {
         types::NEW_DECIMAL => Ok(datum),
         types::DATE | types::DATETIME | types::TIMESTAMP => {
             let fsp = col.get_decimal() as i8;
-            let t = try!(Time::from_packed_u64(datum.u64(), col.get_tp() as u8, fsp));
+            let t = try!(Time::from_packed_u64(datum.u64(), col.get_tp() as u8, fsp, &ctx.tz));
             Ok(Datum::Time(t))
         }
         types::DURATION => Duration::from_nanos(datum.i64(), 0).map(Datum::Dur),
@@ -188,15 +191,18 @@ fn unflatten(datum: Datum, col: &ColumnInfo) -> Result<Datum> {
 
 pub trait TableDecoder: DatumDecoder {
     // `decode_col_value` decodes data to a Datum according to the column info.
-    fn decode_col_value(&mut self, col: &ColumnInfo) -> Result<Datum> {
+    fn decode_col_value(&mut self, ctx: &Context, col: &ColumnInfo) -> Result<Datum> {
         let d = try!(self.decode_datum());
-        unflatten(d, col)
+        unflatten(ctx, d, col)
     }
 
     // `decode_row` decodes a byte slice into datums.
     // TODO: We should only decode columns in the cols map.
     // Row layout: colID1, value1, colID2, value2, .....
-    fn decode_row(&mut self, cols: &HashMap<i64, ColumnInfo>) -> Result<HashMap<i64, Datum>> {
+    fn decode_row(&mut self,
+                  ctx: &Context,
+                  cols: &HashMap<i64, ColumnInfo>)
+                  -> Result<HashMap<i64, Datum>> {
         let mut values = try!(self.decode());
         if values.get(0).map_or(true, |d| *d == Datum::Null) {
             return Ok(HashMap::new());
@@ -213,7 +219,7 @@ pub trait TableDecoder: DatumDecoder {
             };
             let v = drain.next().unwrap();
             if let Some(ci) = cols.get(&id) {
-                let v = try!(unflatten(v, ci));
+                let v = try!(unflatten(ctx, v, ci));
                 row.insert(id, v);
             }
         }
@@ -290,7 +296,8 @@ mod test {
                          new_col_info(types::LONG_LONG)];
         let buf = datum::encode_key(&tests).unwrap();
         let encoded = encode_index_seek_key(1, 2, &buf);
-        assert_eq!(tests, decode_index_key(&encoded, &types).unwrap());
+        assert_eq!(tests,
+                   decode_index_key(&Default::default(), &encoded, &types).unwrap());
     }
 
     fn new_col_info(tp: u8) -> ColumnInfo {
@@ -336,7 +343,7 @@ mod test {
         let bs = encode_row(col_values, &col_ids).unwrap();
         assert!(!bs.is_empty());
 
-        let r = bs.as_slice().decode_row(&cols).unwrap();
+        let r = bs.as_slice().decode_row(&Default::default(), &cols).unwrap();
         assert_eq!(row, r);
 
         let mut datums: HashMap<_, _>;
@@ -344,7 +351,7 @@ mod test {
         assert_eq!(col_encoded, datums);
 
         cols.insert(4, new_col_info(types::FLOAT));
-        let r = bs.as_slice().decode_row(&cols).unwrap();
+        let r = bs.as_slice().decode_row(&Default::default(), &cols).unwrap();
         assert_eq!(row, r);
         col_id_set.insert(4);
         datums = cut_row_as_owned(&bs, &col_id_set);
@@ -352,7 +359,7 @@ mod test {
 
         cols.remove(&4);
         cols.remove(&3);
-        let r = bs.as_slice().decode_row(&cols).unwrap();
+        let r = bs.as_slice().decode_row(&Default::default(), &cols).unwrap();
         row.remove(&3);
         assert_eq!(row, r);
         col_id_set.remove(&3);
@@ -363,7 +370,7 @@ mod test {
 
         let bs = encode_row(vec![], &[]).unwrap();
         assert!(!bs.is_empty());
-        assert!(bs.as_slice().decode_row(&cols).unwrap().is_empty());
+        assert!(bs.as_slice().decode_row(&Default::default(), &cols).unwrap().is_empty());
         datums = cut_row_as_owned(&bs, &col_id_set);
         assert!(datums.is_empty());
     }
@@ -380,7 +387,7 @@ mod test {
             .zip(&col_types)
             .zip(&col_values)
             .map(|((id, t), v)| {
-                let unflattened = super::unflatten(v.clone(), t).unwrap();
+                let unflattened = super::unflatten(&Default::default(), v.clone(), t).unwrap();
                 let encoded = datum::encode_key(&[unflattened]).unwrap();
                 (*id, encoded)
             })
@@ -390,7 +397,7 @@ mod test {
         let bs = encode_index_seek_key(1, 1, &key);
         assert!(!bs.is_empty());
 
-        let r = decode_index_key(&bs, &col_types).unwrap();
+        let r = decode_index_key(&Default::default(), &bs, &col_types).unwrap();
         assert_eq!(col_values, r);
 
         let mut res: (HashMap<_, _>, _) = cut_idx_key_as_owned(&bs, &col_ids);
@@ -405,7 +412,7 @@ mod test {
 
         let bs = encode_index_seek_key(1, 1, &[]);
         assert!(!bs.is_empty());
-        assert!(decode_index_key(&bs, &[]).unwrap().is_empty());
+        assert!(decode_index_key(&Default::default(), &bs, &[]).unwrap().is_empty());
         res = cut_idx_key_as_owned(&bs, &[]);
         assert!(res.0.is_empty());
         assert!(res.1.is_empty());

--- a/src/util/xeval/evaluator.rs
+++ b/src/util/xeval/evaluator.rs
@@ -28,7 +28,9 @@ use tipb::select::SelectRequest;
 use chrono::FixedOffset;
 
 #[derive(Debug)]
+/// Some global variables needed in an evaluation.
 pub struct EvalContext {
+    /// timezone to use when parse/calculate time.
     pub tz: FixedOffset,
 }
 
@@ -38,10 +40,12 @@ impl Default for EvalContext {
     }
 }
 
+const A_DAY: i64 = 3600 * 24;
+
 impl EvalContext {
     pub fn new(sel: &SelectRequest) -> Result<EvalContext> {
         let offset = sel.get_time_zone_offset();
-        if offset <= -3600 * 24 || offset >= 3600 * 24 {
+        if offset <= -A_DAY || offset >= A_DAY {
             return Err(Error::Eval(format!("invalid tz offset {}", offset)));
         }
         let tz = match FixedOffset::east_opt(offset as i32) {

--- a/src/util/xeval/evaluator.rs
+++ b/src/util/xeval/evaluator.rs
@@ -40,12 +40,12 @@ impl Default for EvalContext {
     }
 }
 
-const A_DAY: i64 = 3600 * 24;
+const ONE_DAY: i64 = 3600 * 24;
 
 impl EvalContext {
     pub fn new(sel: &SelectRequest) -> Result<EvalContext> {
         let offset = sel.get_time_zone_offset();
-        if offset <= -A_DAY || offset >= A_DAY {
+        if offset <= -ONE_DAY || offset >= ONE_DAY {
             return Err(Error::Eval(format!("invalid tz offset {}", offset)));
         }
         let tz = match FixedOffset::east_opt(offset as i32) {

--- a/src/util/xeval/mod.rs
+++ b/src/util/xeval/mod.rs
@@ -37,4 +37,4 @@ quick_error! {
 use std::result;
 pub type Result<T> = result::Result<T, Error>;
 
-pub use self::evaluator::Evaluator;
+pub use self::evaluator::{Evaluator, EvalContext};


### PR DESCRIPTION
We need to compare string with timestamp sometimes, it will get a wrong result if not taking timezone into consideration.

@ngaut @coocood @shenli @qiuyesuifeng PTAL