### PR TITLE
raftstore: avoid deleting other region's data accidentally

### DIFF
--- a/src/raftstore/coprocessor/region_snapshot.rs
+++ b/src/raftstore/coprocessor/region_snapshot.rs
@@ -264,7 +264,7 @@ mod tests {
 
     use super::*;
     use std::sync::Arc;
-    use kvproto::metapb::Region;
+    use kvproto::metapb::{Region, Peer};
 
     type DataSet = Vec<(Vec<u8>, Vec<u8>)>;
 
@@ -278,6 +278,7 @@ mod tests {
 
     fn load_default_dataset(engine: Arc<DB>) -> (PeerStorage, DataSet) {
         let mut r = Region::new();
+        r.mut_peers().push(Peer::new());
         r.set_id(10);
         r.set_start_key(b"a2".to_vec());
         r.set_end_key(b"a7".to_vec());
@@ -378,7 +379,9 @@ mod tests {
         assert_eq!(res, base_data[1..3].to_vec());
 
         // test last region
-        let store = new_peer_storage(engine.clone(), &Region::new());
+        let mut region = Region::new();
+        region.mut_peers().push(Peer::new());
+        let store = new_peer_storage(engine.clone(), &region);
         let snap = RegionSnapshot::new(&store);
         data.clear();
         snap.scan(b"",
@@ -406,7 +409,7 @@ mod tests {
         assert_eq!(res, base_data);
 
         // test iterator with upper bound
-        let store = new_peer_storage(engine.clone(), &Region::new());
+        let store = new_peer_storage(engine.clone(), &region);
         let snap = RegionSnapshot::new(&store);
         let mut iter = snap.iter(Some(b"a5"));
         assert!(iter.seek_to_first());
@@ -452,7 +455,9 @@ mod tests {
         assert_eq!(res, expect);
 
         // test last region
-        let store = new_peer_storage(engine.clone(), &Region::new());
+        let mut region = Region::new();
+        region.mut_peers().push(Peer::new());
+        let store = new_peer_storage(engine.clone(), &region);
         let snap = RegionSnapshot::new(&store);
         let mut iter = Cursor::new(snap.iter(None), ScanMode::Mixed);
         assert!(!iter.reverse_seek(&Key::from_encoded(b"a1".to_vec())).unwrap());

--- a/src/raftstore/store/keys.rs
+++ b/src/raftstore/store/keys.rs
@@ -165,11 +165,17 @@ pub fn origin_key(key: &[u8]) -> &[u8] {
 
 /// Get the `start_key` of current region in encoded form.
 pub fn enc_start_key(region: &Region) -> Vec<u8> {
+    // only initialised region's start_key can be encoded, otherwise there must be bug
+    // somewhere.
+    assert!(!region.get_peers().is_empty());
     data_key(region.get_start_key())
 }
 
 /// Get the `end_key` of current region in encoded form.
 pub fn enc_end_key(region: &Region) -> Vec<u8> {
+    // only initialised region's start_key can be encoded, otherwise there must be bug
+    // somewhere.
+    assert!(!region.get_peers().is_empty());
     if region.get_end_key().is_empty() {
         DATA_MAX_KEY.to_vec()
     } else {

--- a/src/raftstore/store/keys.rs
+++ b/src/raftstore/store/keys.rs
@@ -165,7 +165,7 @@ pub fn origin_key(key: &[u8]) -> &[u8] {
 
 /// Get the `start_key` of current region in encoded form.
 pub fn enc_start_key(region: &Region) -> Vec<u8> {
-    // only initialised region's start_key can be encoded, otherwise there must be bug
+    // only initialized region's start_key can be encoded, otherwise there must be bugs
     // somewhere.
     assert!(!region.get_peers().is_empty());
     data_key(region.get_start_key())
@@ -173,7 +173,7 @@ pub fn enc_start_key(region: &Region) -> Vec<u8> {
 
 /// Get the `end_key` of current region in encoded form.
 pub fn enc_end_key(region: &Region) -> Vec<u8> {
-    // only initialised region's start_key can be encoded, otherwise there must be bug
+    // only initialized region's end_key can be encoded, otherwise there must be bugs
     // somewhere.
     assert!(!region.get_peers().is_empty());
     if region.get_end_key().is_empty() {

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -290,7 +290,9 @@ impl Peer {
         try!(self.get_store().clear_meta(&wb));
         try!(write_peer_state(&wb, &region, PeerState::Tombstone));
         try!(self.engine.write(wb));
-        try!(self.get_store().clear_data());
+        if self.get_store().is_initialized() {
+            try!(self.get_store().clear_data());
+        }
         self.coprocessor_host.shutdown();
         info!("{} destroy itself, takes {:?}", self.tag, t.elapsed());
 

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -816,7 +816,6 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         assert!(!p.is_applying());
 
         let is_initialized = p.is_initialized();
-        let end_key = enc_end_key(p.region());
         if let Err(e) = p.destroy() {
             // should panic here?
             error!("[region {}] destroy peer {:?} in store {} err {:?}",
@@ -827,7 +826,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             return;
         }
 
-        if is_initialized && self.region_ranges.remove(&end_key).is_none() {
+        if is_initialized && self.region_ranges.remove(&enc_end_key(p.region())).is_none() {
             panic!("[region {}] remove peer {:?} in store {}",
                    region_id,
                    peer,

--- a/tests/raftstore/test_stale_peer.rs
+++ b/tests/raftstore/test_stale_peer.rs
@@ -122,7 +122,7 @@ fn test_server_stale_peer_out_of_region() {
 /// and wouldn't be contacted anymore.
 /// In both cases, peer B would notice that the leader is missing for a long time,
 /// and it's an initialized peer without any data. It would destroy itself as
-/// as stale peer directly.
+/// as stale peer directly and should not impact other region data on the same store.
 fn test_stale_peer_without_data<T: Simulator>(cluster: &mut Cluster<T>) {
     // Use a value of 3 seconds as max time here just for test.
     // In production environment, the value of max_leader_missing_duration
@@ -166,9 +166,9 @@ fn test_stale_peer_without_data<T: Simulator>(cluster: &mut Cluster<T>) {
     // There must be no data on store 2 belongs to new region
     must_get_none(&engine2, b"k3");
 
-    // Check whether peer(2, 2) is destroyed.
-    // Before peer 2 is destroyed, a tombstone mark will be written into the engine.
-    // So we could check the tombstone mark to make sure peer 2 is destroyed.
+    // Check whether peer(2, 3) is destroyed.
+    // Before peer 3 is destroyed, a tombstone mark will be written into the engine.
+    // So we could check the tombstone mark to make sure peer 3 is destroyed.
     let state_key = keys::region_state_key(new_region_id);
     let state: RegionLocalState = engine2.get_msg(&state_key).unwrap().unwrap();
     assert_eq!(state.get_state(), PeerState::Tombstone);


### PR DESCRIPTION
Currently when destroying a region, it will not check if itself is initialized. This may delete the whole data on store. To fix this, first we should check if a region is initialized before destroying data; second we should panic when encoding `start_key` or `end_key` for an uninitialized region.

@siddontang @hhkbp2 @zhangjinpeng1987 @disksing PTAL