### PR TITLE
docker: speedup release build

### DIFF
--- a/docker/release.sh
+++ b/docker/release.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 
-if [[ "$(ls -A . 2>/dev/null)" = "" ]]; then
-   echo please mount tikv source to /tikv first. >&2
-   exit 1
+clean_target=clean
+
+if [[ $1 == "--use-cache" ]]; then
+    clean_target=
 fi
 
-scl enable devtoolset-4 python27 "ROCKSDB_SYS_STATIC=1 ROCKSDB_SYS_PORTABLE=1 make clean release" 
+if [[ "$(ls -A . 2>/dev/null)" = "" ]]; then
+    echo please mount tikv source to /tikv first. >&2
+    exit 1
+fi
+
+scl enable devtoolset-4 python27 "ROCKSDB_SYS_STATIC=1 ROCKSDB_SYS_PORTABLE=1 make $clean_target release" 
+

--- a/docker/release_dockerfile
+++ b/docker/release_dockerfile
@@ -9,6 +9,15 @@ RUN yum update -y && \
 
 RUN curl -sSf https://static.rust-lang.org/rustup.sh |  sh -s -- --date=2016-08-06 --disable-sudo -y --channel=nightly
 
+ADD https://github.com/pingcap/tikv/archive/master.tar.gz /master.tar.gz
+
+# cache dep package
+RUN tar xf master.tar.gz && \
+    cd tikv-master && \
+    cargo fetch && \
+    cd .. && \
+    rm -rf master.tar.gz tikv-master
+
 COPY release.sh ./release.sh
 
 RUN chmod a+x ./release.sh
@@ -16,3 +25,4 @@ RUN chmod a+x ./release.sh
 WORKDIR /tikv
 
 ENTRYPOINT ["/release.sh"]
+


### PR DESCRIPTION
This pr speeds up release build process by:

1. cache the dependencies needed for building tikv-server, so it doesn't have to download it every time;
2. let user reuse build cache, this will be useful when trying to build a release binary several times.

@siddontang @iamxy PTAL

