### PR TITLE
coprocessor: simplify metric.

### DIFF
--- a/src/server/coprocessor/metrics.rs
+++ b/src/server/coprocessor/metrics.rs
@@ -18,13 +18,6 @@ lazy_static! {
         register_histogram_vec!(
             "tikv_coprocessor_request_duration_seconds",
             "Bucketed histogram of coprocessor handle request duration",
-            &["number"]
-        ).unwrap();
-
-    pub static ref COPR_SELECT_HISTOGRAM_VEC: HistogramVec =
-        register_histogram_vec!(
-            "tikv_coprocessor_select_duration_seconds",
-            "Bucketed histogram of coprocessor handle select duration",
-            &["number"]
+            &["type", "req"]
         ).unwrap();
 }


### PR DESCRIPTION
+ Origin 101 and 102 is not readable in metric, use string instead.
+ Using one metric with two labels is enough. 

@ngaut @BusyJay @hhkbp2  @overvenus 