### PR TITLE
raftstore: speed up canceling applying snap

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 #![feature(slice_patterns)]
 #![feature(box_syntax)]
 #![feature(const_fn)]
+#![feature(integer_atomics)]
 #![cfg_attr(feature = "dev", plugin(clippy))]
 #![cfg_attr(not(feature = "dev"), allow(unknown_lints))]
 #![recursion_limit="100"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@
 #![feature(slice_patterns)]
 #![feature(box_syntax)]
 #![feature(const_fn)]
-#![feature(integer_atomics)]
 #![cfg_attr(feature = "dev", plugin(clippy))]
 #![cfg_attr(not(feature = "dev"), allow(unknown_lints))]
 #![recursion_limit="100"]

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -480,7 +480,8 @@ impl Peer {
                 if self.get_store().is_canceling_snap() {
                     return Ok(None);
                 }
-                warn!("receiving a new snap {:?} when applying the old one, try to abort.",
+                warn!("{} receiving a new snap {:?} when applying the old one, try to abort.",
+                      self.tag,
                       ready.snapshot);
                 if !self.mut_store().cancel_applying_snap() {
                     return Ok(None);

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -477,12 +477,14 @@ impl Peer {
         let is_applying = self.get_store().is_applying_snap();
         if is_applying {
             if !raft::is_empty_snap(&ready.snapshot) {
-                if !self.get_store().is_canceling_snap() {
-                    warn!("receiving a new snap {:?} when applying the old one, try to abort.",
-                          ready.snapshot);
-                    self.mut_store().cancel_applying_snap();
+                if self.get_store().is_canceling_snap() {
+                    return Ok(None);
                 }
-                return Ok(None);
+                warn!("receiving a new snap {:?} when applying the old one, try to abort.",
+                      ready.snapshot);
+                if !self.mut_store().cancel_applying_snap() {
+                    return Ok(None);
+                }
             }
             // skip apply
             ready.committed_entries = vec![];

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 use std::sync::{self, Arc};
-use std::sync::atomic::{AtomicUsize, Ordering, AtomicBool};
+use std::sync::atomic::{AtomicUsize, Ordering, AtomicU8};
 use std::cell::RefCell;
 use std::error;
 use std::time::Instant;
@@ -43,6 +43,10 @@ pub const RAFT_INIT_LOG_TERM: u64 = 5;
 pub const RAFT_INIT_LOG_INDEX: u64 = 5;
 const MAX_SNAP_TRY_CNT: usize = 5;
 
+pub const JOB_STATUS_PENDING: u8 = 0;
+pub const JOB_STATUS_RUNNING: u8 = 1;
+pub const JOB_STATUS_CANCEL: u8 = 2;
+
 pub type Ranges = Vec<(Vec<u8>, Vec<u8>)>;
 
 #[derive(Debug)]
@@ -50,7 +54,7 @@ pub enum SnapState {
     Relax,
     Generating,
     Snap(Snapshot),
-    Applying(Arc<AtomicBool>),
+    Applying(Arc<AtomicU8>),
     ApplyAborted,
     Failed,
 }
@@ -619,14 +623,18 @@ impl PeerStorage {
     #[inline]
     pub fn is_canceling_snap(&self) -> bool {
         match *self.snap_state.borrow() {
-            SnapState::Applying(ref abort) => abort.load(Ordering::Relaxed),
+            SnapState::Applying(ref status) => status.load(Ordering::Relaxed) == JOB_STATUS_CANCEL,
             _ => false,
         }
     }
 
-    pub fn cancel_applying_snap(&mut self) {
-        if let SnapState::Applying(ref abort) = *self.snap_state.borrow() {
-            abort.store(true, Ordering::Relaxed);
+    /// Cancel applying snapshot, return true if the job can be considered actually cancelled.
+    pub fn cancel_applying_snap(&mut self) -> bool {
+        match *self.snap_state.borrow() {
+            SnapState::Applying(ref status) => {
+                status.swap(JOB_STATUS_CANCEL, Ordering::Relaxed) == JOB_STATUS_PENDING
+            }
+            _ => false,
         }
     }
 
@@ -642,6 +650,17 @@ impl PeerStorage {
 
     pub fn get_region_id(&self) -> u64 {
         self.region.get_id()
+    }
+
+    pub fn schedule_applying_snapshot(&mut self) {
+        let status = Arc::new(AtomicU8::new(JOB_STATUS_PENDING));
+        self.set_snap_state(SnapState::Applying(status.clone()));
+        let task = RegionTask::Apply {
+            region_id: self.get_region_id(),
+            status: status,
+        };
+        // TODO: gracefully remove region instead.
+        self.region_sched.schedule(task).expect("snap apply job should not fail");
     }
 
     pub fn handle_raft_ready(&mut self, ready: &Ready) -> Result<Option<ApplySnapResult>> {
@@ -681,9 +700,6 @@ impl PeerStorage {
         self.last_term = ctx.last_term;
         // If we apply snapshot ok, we should update some infos like applied index too.
         if let Some(res) = apply_snap_res {
-            let abort = Arc::new(AtomicBool::new(false));
-            self.set_snap_state(SnapState::Applying(abort.clone()));
-
             // cleanup data before scheduling apply task
             if self.is_initialized() {
                 if let Err(e) = self.clear_extra_data(&res.region) {
@@ -697,12 +713,8 @@ impl PeerStorage {
                 }
             }
 
-            let task = RegionTask::Apply {
-                region_id: region_id,
-                abort: abort,
-            };
-            // TODO: gracefully remove region instead.
-            self.region_sched.schedule(task).expect("snap apply job should not fail");
+            self.schedule_applying_snapshot();
+
             self.region = res.region.clone();
             return Ok(Some(res));
         }

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 use std::sync::{self, Arc};
-use std::sync::atomic::{AtomicUsize, Ordering, AtomicU8};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::cell::RefCell;
 use std::error;
 use std::time::Instant;
@@ -43,9 +43,9 @@ pub const RAFT_INIT_LOG_TERM: u64 = 5;
 pub const RAFT_INIT_LOG_INDEX: u64 = 5;
 const MAX_SNAP_TRY_CNT: usize = 5;
 
-pub const JOB_STATUS_PENDING: u8 = 0;
-pub const JOB_STATUS_RUNNING: u8 = 1;
-pub const JOB_STATUS_CANCEL: u8 = 2;
+pub const JOB_STATUS_PENDING: usize = 0;
+pub const JOB_STATUS_RUNNING: usize = 1;
+pub const JOB_STATUS_CANCEL: usize = 2;
 
 pub type Ranges = Vec<(Vec<u8>, Vec<u8>)>;
 
@@ -54,7 +54,7 @@ pub enum SnapState {
     Relax,
     Generating,
     Snap(Snapshot),
-    Applying(Arc<AtomicU8>),
+    Applying(Arc<AtomicUsize>),
     ApplyAborted,
     Failed,
 }
@@ -653,7 +653,7 @@ impl PeerStorage {
     }
 
     pub fn schedule_applying_snapshot(&mut self) {
-        let status = Arc::new(AtomicU8::new(JOB_STATUS_PENDING));
+        let status = Arc::new(AtomicUsize::new(JOB_STATUS_PENDING));
         self.set_snap_state(SnapState::Applying(status.clone()));
         let task = RegionTask::Apply {
             region_id: self.get_region_id(),

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -499,7 +499,9 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             let target_peer_id = target.get_id();
             if p.peer_id() < target_peer_id {
                 if p.is_applying() && !p.mut_store().cancel_applying_snap() {
-                    warn!("Stale peer {} is applying snapshot, will destroy next time.",
+                    warn!("[region {}] Stale peer {} is applying snapshot, will destroy next \
+                           time.",
+                          region_id,
                           p.peer_id());
                     return Ok(false);
                 }

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
 use std::rc::Rc;
 use std::cell::RefCell;
 use std::option::Option;
@@ -306,12 +305,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                 info!("region {:?} is applying in store {}",
                       local_state.get_region(),
                       self.store_id());
-                let abort = Arc::new(AtomicBool::new(false));
-                peer.mut_store().set_snap_state(SnapState::Applying(abort.clone()));
-                box_try!(self.region_worker.schedule(RegionTask::Apply {
-                    region_id: region_id,
-                    abort: abort,
-                }));
+                peer.mut_store().schedule_applying_snapshot();
             }
 
             self.region_ranges.insert(enc_end_key(region), region_id);
@@ -500,13 +494,11 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         // current peer is stale, then we should remove current peer
         let mut has_peer = false;
         let mut stale_peer = None;
-        if let Some(p) = self.region_peers.get(&region_id) {
+        if let Some(p) = self.region_peers.get_mut(&region_id) {
             has_peer = true;
             let target_peer_id = target.get_id();
             if p.peer_id() < target_peer_id {
-                if p.is_applying() {
-                    // to remove the applying peer, we should find a reliable way to abort
-                    // the apply process.
+                if p.is_applying() && !p.mut_store().cancel_applying_snap() {
                     warn!("Stale peer {} is applying snapshot, will destroy next time.",
                           p.peer_id());
                     return Ok(false);


### PR DESCRIPTION
When the applying snapshot job is in queue, it can be canceled directly. So we won't block any rebalance procedure.

@siddontang @hhkbp2 @zhangjinpeng1987  PTAL