### PR TITLE
raftstore: check stale region with region id

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -55,7 +55,6 @@ const TRANSFER_LEADER_ALLOW_LOG_LAG: u64 = 10;
 pub enum StaleState {
     Valid,
     ToValidate,
-    Stale,
 }
 
 pub struct PendingCmd {
@@ -454,11 +453,7 @@ impl Peer {
             // Resets the `leader_missing_time` to avoid sending the same tasks to
             // PD worker continuously during the leader missing timeout.
             self.leader_missing_time = None;
-            if self.is_initialized() {
-                return StaleState::ToValidate;
-            } else {
-                return StaleState::Stale;
-            }
+            return StaleState::ToValidate;
         }
         StaleState::Valid
     }

--- a/tests/raftstore/test_stale_peer.rs
+++ b/tests/raftstore/test_stale_peer.rs
@@ -166,12 +166,12 @@ fn test_stale_peer_without_data<T: Simulator>(cluster: &mut Cluster<T>) {
     // Sleep one more second to make sure there is enough time for the peer to be destroyed.
     thread::sleep(Duration::from_secs(1));
 
-    // There must be no data on store 2 belongs to new region
+    // There must be no data on store 3 belongs to new region
     must_get_none(&engine3, b"k3");
 
-    // Check whether peer(2, 3) is destroyed.
-    // Before peer 3 is destroyed, a tombstone mark will be written into the engine.
-    // So we could check the tombstone mark to make sure peer 3 is destroyed.
+    // Check whether peer(3, 4) is destroyed.
+    // Before peer 4 is destroyed, a tombstone mark will be written into the engine.
+    // So we could check the tombstone mark to make sure peer 4 is destroyed.
     let state_key = keys::region_state_key(new_region_id);
     let state: RegionLocalState = engine3.get_msg(&state_key).unwrap().unwrap();
     assert_eq!(state.get_state(), PeerState::Tombstone);


### PR DESCRIPTION
Now pd support fetch region info via region id, we can use this API to simplify stale region check.

@siddontang @hhkbp2 PTAL