### PR TITLE
pdclient: adjust get region by id

### DIFF
--- a/src/pd/mod.rs
+++ b/src/pd/mod.rs
@@ -79,7 +79,7 @@ pub trait PdClient: Send + Sync {
     fn get_region(&self, key: &[u8]) -> Result<metapb::Region>;
 
     // Get region by region id.
-    fn get_region_by_id(&self, region_id: u64) -> Result<metapb::Region>;
+    fn get_region_by_id(&self, region_id: u64) -> Result<Option<metapb::Region>>;
 
     // Leader for a region will use this to heartbeat Pd.
     fn region_heartbeat(&self,

--- a/src/pd/protocol.rs
+++ b/src/pd/protocol.rs
@@ -91,7 +91,7 @@ impl super::PdClient for RpcClient {
         Ok(resp.take_get_region().take_region())
     }
 
-    fn get_region_by_id(&self, region_id: u64) -> Result<metapb::Region> {
+    fn get_region_by_id(&self, region_id: u64) -> Result<Option<metapb::Region>> {
         let mut get_region_by_id = pdpb::GetRegionByIDRequest::new();
         get_region_by_id.set_region_id(region_id);
 
@@ -100,7 +100,11 @@ impl super::PdClient for RpcClient {
 
         let mut resp = try!(self.send(&req));
         try!(check_resp(&resp));
-        Ok(resp.take_get_region_by_id().take_region())
+        if resp.take_get_region_by_id().has_region() {
+            Ok(Some(resp.take_get_region_by_id().take_region()))
+        } else {
+            Ok(None)
+        }
     }
 
     fn region_heartbeat(&self,

--- a/src/pd/protocol.rs
+++ b/src/pd/protocol.rs
@@ -100,7 +100,7 @@ impl super::PdClient for RpcClient {
 
         let mut resp = try!(self.send(&req));
         try!(check_resp(&resp));
-        if resp.take_get_region_by_id().has_region() {
+        if resp.get_get_region_by_id().has_region() {
             Ok(Some(resp.take_get_region_by_id().take_region()))
         } else {
             Ok(None)

--- a/src/server/resolve.rs
+++ b/src/server/resolve.rs
@@ -201,7 +201,7 @@ mod tests {
         fn get_region(&self, _: &[u8]) -> Result<metapb::Region> {
             unimplemented!();
         }
-        fn get_region_by_id(&self, _: u64) -> Result<metapb::Region> {
+        fn get_region_by_id(&self, _: u64) -> Result<Option<metapb::Region>> {
             unimplemented!();
         }
         fn region_heartbeat(&self,

--- a/tests/pd/test_rpc_client.rs
+++ b/tests/pd/test_rpc_client.rs
@@ -49,7 +49,7 @@ fn test_rpc_client() {
     let tmp_store = client.get_store(store_id).unwrap();
     assert_eq!(tmp_store.get_id(), store.get_id());
 
-    let tmp_region = client.get_region_by_id(region_id).unwrap();
+    let tmp_region = client.get_region_by_id(region_id).unwrap().unwrap();
     assert_eq!(tmp_region.get_id(), region.get_id());
 
     let mut prev_id = 0;

--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -225,17 +225,19 @@ impl<T: Simulator> Cluster<T> {
     }
 
     fn valid_leader_id(&self, region_id: u64, leader_id: u64) -> bool {
-        let store_ids = self.store_ids_of_region(region_id);
+        let store_ids = match self.store_ids_of_region(region_id) {
+            None => return false,
+            Some(ids) => ids,
+        };
         let node_ids = self.sim.rl().get_node_ids();
         store_ids.contains(&leader_id) && node_ids.contains(&leader_id)
     }
 
-    fn store_ids_of_region(&self, region_id: u64) -> Vec<u64> {
-        let peers = self.pd_client
+    fn store_ids_of_region(&self, region_id: u64) -> Option<Vec<u64>> {
+        self.pd_client
             .get_region_by_id(region_id)
             .unwrap()
-            .take_peers();
-        peers.iter().map(|peer| peer.get_store_id()).collect()
+            .map(|region| region.get_peers().into_iter().map(|p| p.get_store_id()).collect())
     }
 
     fn query_leader(&self, store_id: u64, region_id: u64) -> Option<metapb::Peer> {
@@ -253,7 +255,10 @@ impl<T: Simulator> Cluster<T> {
     }
 
     pub fn leader_of_region(&mut self, region_id: u64) -> Option<metapb::Peer> {
-        let store_ids = self.store_ids_of_region(region_id);
+        let store_ids = match self.store_ids_of_region(region_id) {
+            None => return None,
+            Some(ids) => ids,
+        };
         if let Some(l) = self.leaders.get(&region_id) {
             // leader may be stopped in some tests.
             if self.valid_leader_id(region_id, l.get_store_id()) {
@@ -520,8 +525,8 @@ impl<T: Simulator> Cluster<T> {
         self.pd_client
             .get_region_by_id(region_id)
             .unwrap()
-            .get_region_epoch()
-            .clone()
+            .unwrap()
+            .take_region_epoch()
     }
 
     pub fn region_detail(&mut self, region_id: u64, peer_id: u64) -> RegionDetailResponse {


### PR DESCRIPTION
Currently get_region_by_id will return an empty region if not found, which is very easy to lead to mistake. An explicit Option should be returned instead.

@huachaohuang @siddontang PTAL