### PR TITLE
storage: skip value when possible

### DIFF
--- a/src/storage/mvcc/reader.rs
+++ b/src/storage/mvcc/reader.rs
@@ -25,6 +25,7 @@ pub struct MvccReader<'a> {
     write_cursor: Option<Cursor<'a>>,
 
     scan_mode: Option<ScanMode>,
+    key_only: bool,
 }
 
 impl<'a> MvccReader<'a> {
@@ -35,19 +36,27 @@ impl<'a> MvccReader<'a> {
             lock_cursor: None,
             write_cursor: None,
             scan_mode: scan_mode,
+            key_only: false,
         }
     }
 
-    pub fn load_data(&mut self, key: &Key, ts: u64) -> Result<Option<Value>> {
-        if self.scan_mode.is_some() {
-            try!(self.create_data_cursor());
+    pub fn set_key_only(&mut self, key_only: bool) {
+        self.key_only = key_only;
+    }
+
+    pub fn load_data(&mut self, key: &Key, ts: u64) -> Result<Value> {
+        if self.key_only {
+            return Ok(vec![]);
+        }
+        if self.scan_mode.is_some() && self.data_cursor.is_none() {
+            self.data_cursor = Some(try!(self.snapshot.iter(None, self.scan_mode.unwrap())));
         }
 
         let k = key.append_ts(ts);
         if let Some(ref mut cursor) = self.data_cursor {
-            cursor.get(&k).map(|x| x.map(|x| x.to_vec())).map_err(Error::from)
+            cursor.get(&k).map(|x| x.unwrap().to_vec()).map_err(Error::from)
         } else {
-            self.snapshot.get(&k).map_err(Error::from)
+            self.snapshot.get(&k).map(|x| x.unwrap()).map_err(Error::from)
         }
     }
 
@@ -130,7 +139,7 @@ impl<'a> MvccReader<'a> {
             match try!(self.seek_write(key, ts)) {
                 Some((commit_ts, write)) => {
                     match write.write_type {
-                        WriteType::Put => return self.load_data(key, write.start_ts),
+                        WriteType::Put => return self.load_data(key, write.start_ts).map(Some),
                         WriteType::Delete => return Ok(None),
                         WriteType::Lock | WriteType::Rollback => ts = commit_ts - 1,
                     }
@@ -154,24 +163,62 @@ impl<'a> MvccReader<'a> {
         Ok(None)
     }
 
-    fn create_data_cursor(&mut self) -> Result<()> {
-        if self.data_cursor.is_none() {
-            self.data_cursor = Some(try!(self.snapshot
-                .iter(None, self.scan_mode.unwrap_or(ScanMode::Mixed))));
+    fn create_write_cursor(&mut self) -> Result<()> {
+        if self.write_cursor.is_none() {
+            self.write_cursor = Some(try!(self.snapshot
+                .iter_cf(CF_WRITE, None, self.scan_mode.unwrap_or(ScanMode::Mixed))));
+        }
+        Ok(())
+    }
+
+    fn create_lock_cursor(&mut self) -> Result<()> {
+        if self.lock_cursor.is_none() {
+            self.lock_cursor = Some(try!(self.snapshot
+                .iter_cf(CF_LOCK, None, self.scan_mode.unwrap_or(ScanMode::Mixed))));
         }
         Ok(())
     }
 
     pub fn seek(&mut self, mut key: Key, ts: u64) -> Result<Option<(Key, Value)>> {
-        try!(self.create_data_cursor());
+        assert!(self.scan_mode.is_some());
+        try!(self.create_write_cursor());
+        try!(self.create_lock_cursor());
+
+        let (mut write_valid, mut lock_valid) = (true, true);
 
         loop {
             key = {
-                let mut cursor = self.data_cursor.as_mut().unwrap();
-                if !try!(cursor.near_seek(&key)) {
-                    return Ok(None);
+                let mut w_cur = self.write_cursor.as_mut().unwrap();
+                let mut l_cur = self.lock_cursor.as_mut().unwrap();
+                let (mut w_key, mut l_key) = (None, None);
+                if write_valid {
+                    if try!(w_cur.near_seek(&key)) {
+                        w_key = Some(w_cur.key());
+                    } else {
+                        w_key = None;
+                        write_valid = false;
+                    }
                 }
-                try!(Key::from_encoded(cursor.key().to_vec()).truncate_ts())
+                if lock_valid {
+                    if try!(l_cur.near_seek(&key)) {
+                        l_key = Some(l_cur.key());
+                    } else {
+                        l_key = None;
+                        lock_valid = false;
+                    }
+                }
+                match (w_key, l_key) {
+                    (None, None) => return Ok(None),
+                    (None, Some(k)) => Key::from_encoded(k.to_vec()),
+                    (Some(k), None) => try!(Key::from_encoded(k.to_vec()).truncate_ts()),
+                    (Some(wk), Some(lk)) => {
+                        if wk < lk {
+                            try!(Key::from_encoded(wk.to_vec()).truncate_ts())
+                        } else {
+                            Key::from_encoded(lk.to_vec())
+                        }
+                    }
+                }
             };
             if let Some(v) = try!(self.get(&key, ts)) {
                 return Ok(Some((key, v)));
@@ -181,15 +228,45 @@ impl<'a> MvccReader<'a> {
     }
 
     pub fn reverse_seek(&mut self, mut key: Key, ts: u64) -> Result<Option<(Key, Value)>> {
-        try!(self.create_data_cursor());
+        assert!(self.scan_mode.is_some());
+        try!(self.create_write_cursor());
+        try!(self.create_lock_cursor());
+
+        let (mut write_valid, mut lock_valid) = (true, true);
 
         loop {
             key = {
-                let mut cursor = self.data_cursor.as_mut().unwrap();
-                if !try!(cursor.near_reverse_seek(&key)) {
-                    return Ok(None);
+                let mut w_cur = self.write_cursor.as_mut().unwrap();
+                let mut l_cur = self.lock_cursor.as_mut().unwrap();
+                let (mut w_key, mut l_key) = (None, None);
+                if write_valid {
+                    if try!(w_cur.near_reverse_seek(&key)) {
+                        w_key = Some(w_cur.key());
+                    } else {
+                        w_key = None;
+                        write_valid = false;
+                    }
                 }
-                try!(Key::from_encoded(cursor.key().to_vec()).truncate_ts())
+                if lock_valid {
+                    if try!(l_cur.near_reverse_seek(&key)) {
+                        l_key = Some(l_cur.key());
+                    } else {
+                        l_key = None;
+                        lock_valid = false;
+                    }
+                }
+                match (w_key, l_key) {
+                    (None, None) => return Ok(None),
+                    (None, Some(k)) => Key::from_encoded(k.to_vec()),
+                    (Some(k), None) => try!(Key::from_encoded(k.to_vec()).truncate_ts()),
+                    (Some(wk), Some(lk)) => {
+                        if wk < lk {
+                            Key::from_encoded(lk.to_vec())
+                        } else {
+                            try!(Key::from_encoded(wk.to_vec()).truncate_ts())
+                        }
+                    }
+                }
             };
             if let Some(v) = try!(self.get(&key, ts)) {
                 return Ok(Some((key, v)));
@@ -200,10 +277,7 @@ impl<'a> MvccReader<'a> {
     pub fn scan_lock<F>(&mut self, filter: F) -> Result<Vec<(Key, Lock)>>
         where F: Fn(&Lock) -> bool
     {
-        if self.lock_cursor.is_none() {
-            self.lock_cursor = Some(try!(self.snapshot
-                .iter_cf(CF_LOCK, None, self.scan_mode.unwrap_or(ScanMode::Mixed))));
-        }
+        try!(self.create_lock_cursor());
         let mut cursor = self.lock_cursor.as_mut().unwrap();
         cursor.seek_to_first();
         let mut locks = vec![];

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -262,7 +262,7 @@ fn process_read(cid: u64, mut cmd: Command, ch: SendCh<Msg>, snapshot: Box<Snaps
         // Scans a range starting with `start_key` up to `limit` rows from the snapshot.
         Command::Scan { ref start_key, limit, start_ts, .. } => {
             let snap_store = SnapshotStore::new(snapshot.as_ref(), start_ts);
-            let res = snap_store.scanner(ScanMode::Forward)
+            let res = snap_store.scanner(ScanMode::Forward, false)
                 .and_then(|mut scanner| scanner.scan(start_key.clone(), limit))
                 .and_then(|mut results| {
                     Ok(results.drain(..).map(|x| x.map_err(StorageError::from)).collect())

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -44,9 +44,13 @@ impl<'a> SnapshotStore<'a> {
         Ok(results)
     }
 
-    pub fn scanner(&self, mode: ScanMode) -> Result<StoreScanner> {
+    /// Create a scanner.
+    /// when key_only is true, all the returned value will be empty.
+    pub fn scanner(&self, mode: ScanMode, key_only: bool) -> Result<StoreScanner> {
+        let mut reader = MvccReader::new(self.snapshot, Some(mode));
+        reader.set_key_only(key_only);
         Ok(StoreScanner {
-            reader: MvccReader::new(self.snapshot, Some(mode)),
+            reader: reader,
             start_ts: self.start_ts,
         })
     }


### PR DESCRIPTION
Sometimes values can be too large to do efficient scan. So if we don't need values when doing scan (like just want to get all the handles, naive count or index scan), it will be more efficient to skip fetching values and just scan the WRITE and LOCK cf.

@disksing @zhangjinpeng1987 PTAL