### PR TITLE
tunning scheduler latches size

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -175,7 +175,7 @@ scheduler-notify-capacity = 10240
 # maximum number of messages can be processed in one tick
 scheduler-messages-per-tick = 1024
 
-scheduler-concurrency = 1024
+scheduler-concurrency = 10240
 
 # scheduler's worker pool size
 scheduler-worker-pool-size = 4

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -14,7 +14,7 @@
 const DEFAULT_STORE_PATH: &'static str = "";
 const DEFAULT_SCHED_CAPACITY: usize = 10240;
 const DEFAULT_SCHED_MSG_PER_TICK: usize = 1024;
-const DEFAULT_SCHED_CONCURRENCY: usize = 1024;
+const DEFAULT_SCHED_CONCURRENCY: usize = 10240;
 const DEFAULT_SCHED_WORKER_POOL_SIZE: usize = 4;
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
When drop a table, TiDB will delete all keys in a background worker, every delete task generated by the bg worker contains 1024 keys. Currently the default scheduler's latches size is 1024, this is a bit too small, a delete task might hold all the latches and would block the others write commands.