### PR TITLE
pd: validate PD list

### DIFF
--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -242,6 +242,7 @@ impl RpcClient {
             match validate_endpoints(&endpoints) {
                 Ok(id) => {
                     cluster_id = id;
+                    break;
                 }
                 Err(e) => {
                     warn!("failed to get cluster id from pd: {:?}", e);

--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -17,15 +17,16 @@ use std::time::Duration;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
+use std::collections::HashSet;
 use util::codec::rpc;
 use util::make_std_tcp_conn;
 
 use rand::{self, Rng};
 
-use kvproto::pdpb::{Request, Response};
+use kvproto::pdpb::{self, Request, Response};
 use kvproto::msgpb::{Message, MessageType};
 
-use super::{Result, PdClient};
+use super::{Result, PdClient, protocol};
 use super::metrics::*;
 
 const MAX_PD_SEND_RETRY_COUNT: usize = 100;
@@ -34,9 +35,70 @@ const SOCKET_WRITE_TIMEOUT: u64 = 3;
 
 const PD_RPC_PREFIX: &'static str = "/pd/rpc";
 
+// `validate_endpoints` validates pd members, make sure they are in the same cluster.
+// Notice that it ignores failed pd nodes.
+fn validate_endpoints(cluster_id: u64, endpoints: &[String]) -> Result<()> {
+    if endpoints.is_empty() {
+        return Err(box_err!("empty PD list"));
+    }
+
+    let len = endpoints.len();
+    let mut endpoints_set = HashSet::with_capacity(len);
+    let mut members_resps = Vec::with_capacity(len);
+
+    for ep in endpoints {
+        let mut stream = match rpc_connect(ep.as_str()) {
+            Ok(stream) => stream,
+            // Ignore failed pd node.
+            Err(_) => continue,
+        };
+
+        let mut req = protocol::new_request(cluster_id, pdpb::CommandType::GetPDMembers);
+        req.set_get_pd_members(pdpb::GetPDMembersRequest::new());
+        let (id, mut resp) = match send_msg(&mut stream, cluster_id, &req) {
+            Ok((id, resp)) => (id, resp),
+            // Ignore failed pd node.
+            Err(_) => continue,
+        };
+
+        if id != cluster_id {
+            return Err(box_err!("PD response msg_id not match, want {}, got {}",
+                                cluster_id,
+                                id));
+        }
+
+        let members = resp.take_get_pd_members().take_members();
+
+        if (members.len() < len) || (!endpoints_set.insert(ep)) {
+            return Err(box_err!("inconsistent PD list, a duplicate PD url or an invalid PD url"));
+        }
+
+        let mut members_array = members.into_vec();
+
+        members_array.sort_by(|a, b| a.get_name().cmp(b.get_name()));
+        members_resps.push(members_array);
+    }
+
+    // Check all fields.
+    match members_resps.pop() {
+        Some(sample) => {
+            for members in members_resps {
+                if sample != members {
+                    return Err(box_err!("inconsistent PD list, expect: {:?}, got: {:?}",
+                                        sample,
+                                        members));
+                }
+            }
+
+            Ok(())
+        }
+        None => Err(box_err!("PD cluster stop responding")),
+    }
+}
+
 #[derive(Debug)]
 struct RpcClientCore {
-    endpoints: String,
+    endpoints: Vec<String>,
     stream: Option<TcpStream>,
 }
 
@@ -44,6 +106,7 @@ fn send_msg(stream: &mut TcpStream, msg_id: u64, message: &Request) -> Result<(u
     let timer = PD_SEND_MSG_HISTOGRAM.start_timer();
 
     let mut req = Message::new();
+
     req.set_msg_type(MessageType::PdReq);
     // TODO: optimize clone later in HTTP refactor.
     req.set_pd_req(message.clone());
@@ -62,42 +125,50 @@ fn send_msg(stream: &mut TcpStream, msg_id: u64, message: &Request) -> Result<(u
     Ok((id, resp.take_pd_resp()))
 }
 
-fn rpc_connect(endpoints: &str) -> Result<TcpStream> {
-    // Randomize hosts.
-    let mut hosts: Vec<String> = endpoints.split(',').map(|s| s.into()).collect();
-    rand::thread_rng().shuffle(&mut hosts);
+fn rpc_connect(endpoint: &str) -> Result<TcpStream> {
+    let mut stream = try!(make_std_tcp_conn(endpoint));
+    try!(stream.set_write_timeout(Some(Duration::from_secs(SOCKET_WRITE_TIMEOUT))));
 
-    for host in &hosts {
-        let mut stream = match make_std_tcp_conn(host.as_str()) {
-            Ok(stream) => stream,
-            Err(_) => continue,
-        };
-        try!(stream.set_write_timeout(Some(Duration::from_secs(SOCKET_WRITE_TIMEOUT))));
-
-        // Send a HTTP header to tell PD to hijack this connection for RPC.
-        let header_str = format!("GET {} HTTP/1.0\r\n\r\n", PD_RPC_PREFIX);
-        let header = header_str.as_bytes();
-        match stream.write_all(header) {
-            Ok(_) => return Ok(stream),
-            Err(_) => continue,
-        }
+    // Send a HTTP header to tell PD to hijack this connection for RPC.
+    let header_str = format!("GET {} HTTP/1.0\r\n\r\n", PD_RPC_PREFIX);
+    let header = header_str.as_bytes();
+    match stream.write_all(header) {
+        Ok(_) => Ok(stream),
+        Err(err) => Err(box_err!("failed to connect to {} error: {:?}", endpoint, err)),
     }
-
-    Err(box_err!("failed to connect to {:?}", hosts))
 }
 
 impl RpcClientCore {
-    fn new(endpoints: &str) -> RpcClientCore {
+    fn new(endpoints: Vec<String>) -> RpcClientCore {
         RpcClientCore {
-            endpoints: endpoints.into(),
+            endpoints: endpoints,
             stream: None,
         }
     }
 
     fn try_connect(&mut self) -> Result<()> {
-        let stream = try!(rpc_connect(&self.endpoints));
-        self.stream = Some(stream);
-        Ok(())
+        // Randomize endpoints.
+        let len = self.endpoints.len();
+        let mut indexes: Vec<usize> = (0..len).collect();
+        rand::thread_rng().shuffle(&mut indexes);
+
+        for i in indexes {
+            let ep = &self.endpoints[i];
+            match rpc_connect(ep.as_str()) {
+                Ok(stream) => {
+                    info!("PD client connects to {}", ep);
+                    self.stream = Some(stream);
+                    return Ok(());
+                }
+
+                Err(_) => {
+                    error!("failed to connect to {}, try next", ep);
+                    continue;
+                }
+            }
+        }
+
+        Err(box_err!("failed to connect to {:?}", self.endpoints))
     }
 
     fn send(&mut self, msg_id: u64, req: &Request) -> Result<Response> {
@@ -147,15 +218,21 @@ pub struct RpcClient {
 
 impl RpcClient {
     pub fn new(endpoints: &str) -> Result<RpcClient> {
+        let endpoints: Vec<String> = endpoints.split(',')
+            .map(|s| s.trim().to_owned())
+            .filter(|s| !s.is_empty())
+            .collect();
+
         let mut client = RpcClient {
             msg_id: AtomicUsize::new(0),
-            core: Mutex::new(RpcClientCore::new(endpoints)),
+            core: Mutex::new(RpcClientCore::new(endpoints.clone())),
             cluster_id: 0,
         };
 
         for _ in 0..MAX_PD_SEND_RETRY_COUNT {
             match client.get_cluster_id() {
                 Ok(id) => {
+                    try!(validate_endpoints(id, &endpoints));
                     client.cluster_id = id;
                     return Ok(client);
                 }

--- a/src/pd/protocol.rs
+++ b/src/pd/protocol.rs
@@ -22,7 +22,7 @@ impl super::PdClient for RpcClient {
         // can send this request with any cluster ID, then PD will return its
         // cluster ID in the response header.
         let get_pd_members = pdpb::GetPDMembersRequest::new();
-        let mut req = self.new_request(pdpb::CommandType::GetPDMembers);
+        let mut req = new_request(self.cluster_id, pdpb::CommandType::GetPDMembers);
         req.set_get_pd_members(get_pd_members);
 
         let mut resp = try!(self.send(&req));
@@ -35,7 +35,7 @@ impl super::PdClient for RpcClient {
         bootstrap.set_store(store);
         bootstrap.set_region(region);
 
-        let mut req = self.new_request(pdpb::CommandType::Bootstrap);
+        let mut req = new_request(self.cluster_id, pdpb::CommandType::Bootstrap);
         req.set_bootstrap(bootstrap);
 
         let resp = try!(self.send(&req));
@@ -43,7 +43,7 @@ impl super::PdClient for RpcClient {
     }
 
     fn is_cluster_bootstrapped(&self) -> Result<bool> {
-        let mut req = self.new_request(pdpb::CommandType::IsBootstrapped);
+        let mut req = new_request(self.cluster_id, pdpb::CommandType::IsBootstrapped);
         req.set_is_bootstrapped(pdpb::IsBootstrappedRequest::new());
 
         let resp = try!(self.send(&req));
@@ -52,7 +52,7 @@ impl super::PdClient for RpcClient {
     }
 
     fn alloc_id(&self) -> Result<u64> {
-        let mut req = self.new_request(pdpb::CommandType::AllocId);
+        let mut req = new_request(self.cluster_id, pdpb::CommandType::AllocId);
         req.set_alloc_id(pdpb::AllocIdRequest::new());
 
         let resp = try!(self.send(&req));
@@ -64,7 +64,7 @@ impl super::PdClient for RpcClient {
         let mut put_store = pdpb::PutStoreRequest::new();
         put_store.set_store(store);
 
-        let mut req = self.new_request(pdpb::CommandType::PutStore);
+        let mut req = new_request(self.cluster_id, pdpb::CommandType::PutStore);
         req.set_put_store(put_store);
 
         let resp = try!(self.send(&req));
@@ -75,7 +75,7 @@ impl super::PdClient for RpcClient {
         let mut get_store = pdpb::GetStoreRequest::new();
         get_store.set_store_id(store_id);
 
-        let mut req = self.new_request(pdpb::CommandType::GetStore);
+        let mut req = new_request(self.cluster_id, pdpb::CommandType::GetStore);
         req.set_get_store(get_store);
 
         let mut resp = try!(self.send(&req));
@@ -84,7 +84,7 @@ impl super::PdClient for RpcClient {
     }
 
     fn get_cluster_config(&self) -> Result<metapb::Cluster> {
-        let mut req = self.new_request(pdpb::CommandType::GetClusterConfig);
+        let mut req = new_request(self.cluster_id, pdpb::CommandType::GetClusterConfig);
         req.set_get_cluster_config(pdpb::GetClusterConfigRequest::new());
 
         let mut resp = try!(self.send(&req));
@@ -96,7 +96,7 @@ impl super::PdClient for RpcClient {
         let mut get_region = pdpb::GetRegionRequest::new();
         get_region.set_region_key(key.to_vec());
 
-        let mut req = self.new_request(pdpb::CommandType::GetRegion);
+        let mut req = new_request(self.cluster_id, pdpb::CommandType::GetRegion);
         req.set_get_region(get_region);
 
         let mut resp = try!(self.send(&req));
@@ -108,7 +108,7 @@ impl super::PdClient for RpcClient {
         let mut get_region_by_id = pdpb::GetRegionByIDRequest::new();
         get_region_by_id.set_region_id(region_id);
 
-        let mut req = self.new_request(pdpb::CommandType::GetRegionByID);
+        let mut req = new_request(self.cluster_id, pdpb::CommandType::GetRegionByID);
         req.set_get_region_by_id(get_region_by_id);
 
         let mut resp = try!(self.send(&req));
@@ -130,7 +130,7 @@ impl super::PdClient for RpcClient {
         heartbeat.set_leader(leader);
         heartbeat.set_down_peers(RepeatedField::from_vec(down_peers));
 
-        let mut req = self.new_request(pdpb::CommandType::RegionHeartbeat);
+        let mut req = new_request(self.cluster_id, pdpb::CommandType::RegionHeartbeat);
         req.set_region_heartbeat(heartbeat);
 
         let mut resp = try!(self.send(&req));
@@ -142,7 +142,7 @@ impl super::PdClient for RpcClient {
         let mut ask_split = pdpb::AskSplitRequest::new();
         ask_split.set_region(region);
 
-        let mut req = self.new_request(pdpb::CommandType::AskSplit);
+        let mut req = new_request(self.cluster_id, pdpb::CommandType::AskSplit);
         req.set_ask_split(ask_split);
 
         let mut resp = try!(self.send(&req));
@@ -154,7 +154,7 @@ impl super::PdClient for RpcClient {
         let mut heartbeat = pdpb::StoreHeartbeatRequest::new();
         heartbeat.set_stats(stats);
 
-        let mut req = self.new_request(pdpb::CommandType::StoreHeartbeat);
+        let mut req = new_request(self.cluster_id, pdpb::CommandType::StoreHeartbeat);
         req.set_store_heartbeat(heartbeat);
 
         let resp = try!(self.send(&req));
@@ -166,7 +166,7 @@ impl super::PdClient for RpcClient {
         report_split.set_left(left);
         report_split.set_right(right);
 
-        let mut req = self.new_request(pdpb::CommandType::ReportSplit);
+        let mut req = new_request(self.cluster_id, pdpb::CommandType::ReportSplit);
         req.set_report_split(report_split);
 
         let resp = try!(self.send(&req));
@@ -174,18 +174,15 @@ impl super::PdClient for RpcClient {
     }
 }
 
-impl RpcClient {
-    fn new_request(&self, cmd_type: pdpb::CommandType) -> pdpb::Request {
-        let mut header = pdpb::RequestHeader::new();
-        header.set_cluster_id(self.cluster_id);
-        header.set_uuid(Uuid::new_v4().as_bytes().to_vec());
-        let mut req = pdpb::Request::new();
-        req.set_header(header);
-        req.set_cmd_type(cmd_type);
-        req
-    }
+pub fn new_request(cluster_id: u64, cmd_type: pdpb::CommandType) -> pdpb::Request {
+    let mut header = pdpb::RequestHeader::new();
+    header.set_cluster_id(cluster_id);
+    header.set_uuid(Uuid::new_v4().as_bytes().to_vec());
+    let mut req = pdpb::Request::new();
+    req.set_header(header);
+    req.set_cmd_type(cmd_type);
+    req
 }
-
 
 fn check_resp(resp: &pdpb::Response) -> Result<()> {
     if !resp.has_header() {

--- a/tests/pd/test_rpc_client.rs
+++ b/tests/pd/test_rpc_client.rs
@@ -75,5 +75,5 @@ fn test_rpc_client_safely_new() {
     };
     let endpoints = [endpoints_1, endpoints_2];
 
-    assert_eq!(RpcClient::validate_endpoints(&endpoints).is_err(), true);
+    RpcClient::validate_endpoints(&endpoints).unwrap();
 }

--- a/tests/pd/test_rpc_client.rs
+++ b/tests/pd/test_rpc_client.rs
@@ -62,3 +62,18 @@ fn test_rpc_client() {
         prev_id = alloc_id;
     }
 }
+
+#[test]
+fn test_rpc_client_safely_new() {
+    let endpoints_1 = match env::var("PD_ENDPOINTS") {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    let endpoints_2 = match env::var("PD_ENDPOINTS_SEP") {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    let endpoints = [endpoints_1, endpoints_2];
+
+    assert_eq!(RpcClient::validate_endpoints(&endpoints).is_err(), true);
+}

--- a/tests/pd/test_rpc_client.rs
+++ b/tests/pd/test_rpc_client.rs
@@ -75,5 +75,5 @@ fn test_rpc_client_safely_new() {
     };
     let endpoints = [endpoints_1, endpoints_2];
 
-    RpcClient::validate_endpoints(&endpoints).unwrap();
+    assert!(RpcClient::validate_endpoints(&endpoints).is_err());
 }

--- a/travis-build/test.sh
+++ b/travis-build/test.sh
@@ -27,9 +27,18 @@ trap 'kill $(jobs -p) &> /dev/null || true' EXIT
 # start pd
 which pd-server
 if [ $? -eq 0 ]; then
-    pd-server &
+    # Separate PD clusters.
+    pd-server --name="pd1" \
+        --data-dir="default.pd1" \
+        --client-urls="http://:12379" \
+        --peer-urls="http://:12380" &
+    pd-server --name="pd2" \
+        --data-dir="default.pd2" \
+        --client-urls="http://:22379" \
+        --peer-urls="http://:22380" &
     sleep 3s
-    export PD_ENDPOINTS=127.0.0.1:2379
+    export PD_ENDPOINTS=127.0.0.1:12379
+    export PD_ENDPOINTS_SEP=127.0.0.1:22379
 fi
 
 if [[ "$ENABLE_FEATURES" = "" ]]; then


### PR DESCRIPTION
`validate_pd_list` only accepts PD endpoints that are in the same PD cluster. It treats a removed PD as an invalied PD node. ~~It only validates once at the beginning of raftkv startup.~~ It validates the list every time when the tikv trys to connect a PD.

---

Let's say there are two PD clusters, one consists three nodes, and the other is a standlone node. Details: 

```
cluster-id: 1
pd1 client urls: "127.0.0.1:12379"
pd2 client urls: "127.0.0.1:22379"
pd3 client urls: "127.0.0.1:32379"
```

```
cluster-id: 1
pd1 client urls: "127.0.0.1:42379"
```

Following are cases tested so far:

``` rust
("127.0.0.1:12379,127.0.0.1:22379,127.0.0.1:32379".to_owned(), true),
("127.0.0.1:12379, 127.0.0.1:22379, 127.0.0.1:32379".to_owned(), true),
("127.0.0.1:12379, 127.0.0.1:22379, 127.0.0.1:32379,".to_owned(), true),
("127.0.0.1:12379, 127.0.0.1:22379, 127.0.0.1:32379, ,".to_owned(), true),
("127.0.0.1:12379, 127.0.0.1:32379".to_owned(), true),
("127.0.0.1:12379, 127.0.0.1:32379,".to_owned(), true),
("127.0.0.1:12379, 127.0.0.1:32379,127.0.0.1:42379".to_owned(), false), // separate clusters
("127.0.0.1:12379, 127.0.0.1:12379, 127.0.0.1:32379,".to_owned(), false), // duplicate endpoints
("127.0.0.1:12379, 127.0.0.1:12379, 127.0.0.1:32379, 127.0.0.1:42379".to_owned(), false), // invalid endpoints
("127.0.0.1:12379, 127.0.0.1:12379, 127.0.0.1:32379, 127.0.0.1:22379".to_owned(), false), // duplicate endpoints
```

Explanation: 
- A tuple stands for a case
- `tuple.0` is the command line argument `--pd`
- `tuple.1` is the result of `validate_pd_list`
  - true -> Ok(_)
  - false -> Err(_)

PTAL @siddontang @BusyJay 

Close #1186 
