### PR TITLE
raftstore: manually compact region after delete a lot of keys.

### DIFF
--- a/src/bin/tikv-ctl.rs
+++ b/src/bin/tikv-ctl.rs
@@ -37,55 +37,55 @@ fn main() {
         .author("PingCAP")
         .about("Distributed transactional key value database powered by Rust and Raft")
         .arg(Arg::with_name("db")
-             .short("d")
-             .takes_value(true)
-             .help("set rocksdb path, required"))
+            .short("d")
+            .takes_value(true)
+            .help("set rocksdb path, required"))
         .subcommand(SubCommand::with_name("raft")
-                    .about("print raft log entry")
-                    .subcommand(SubCommand::with_name("log")
-                                .about("print the raft log entry info")
-                                .arg(Arg::with_name("region")
-                                     .short("r")
-                                     .takes_value(true)
-                                     .help("set the region id"))
-                                .arg(Arg::with_name("index")
-                                     .short("i")
-                                     .takes_value(true)
-                                     .help("set the raft log index")))
-                    .subcommand(SubCommand::with_name("region")
-                                .about("print region info")
-                                .arg(Arg::with_name("region")
-                                     .short("r")
-                                     .takes_value(true)
-                                     .help("set the region id"))))
+            .about("print raft log entry")
+            .subcommand(SubCommand::with_name("log")
+                .about("print the raft log entry info")
+                .arg(Arg::with_name("region")
+                    .short("r")
+                    .takes_value(true)
+                    .help("set the region id"))
+                .arg(Arg::with_name("index")
+                    .short("i")
+                    .takes_value(true)
+                    .help("set the raft log index")))
+            .subcommand(SubCommand::with_name("region")
+                .about("print region info")
+                .arg(Arg::with_name("region")
+                    .short("r")
+                    .takes_value(true)
+                    .help("set the region id"))))
         .subcommand(SubCommand::with_name("scan")
-                                .about("print the range db range")
-                                .arg(Arg::with_name("from")
-                                     .short("f")
-                                     .takes_value(true)
-                                     .help("set the scan from raw key, in escaped format"))
-                                .arg(Arg::with_name("to")
-                                     .short("t")
-                                     .takes_value(true)
-                                     .help("set the scan end raw key, in escaped format"))
-                                .arg(Arg::with_name("limit")
-                                     .short("l")
-                                     .takes_value(true)
-                                     .help("set the scan limit"))
-                                .arg(Arg::with_name("cf")
-                                     .short("c")
-                                     .takes_value(true)
-                                     .help("column family name")))
+            .about("print the range db range")
+            .arg(Arg::with_name("from")
+                .short("f")
+                .takes_value(true)
+                .help("set the scan from raw key, in escaped format"))
+            .arg(Arg::with_name("to")
+                .short("t")
+                .takes_value(true)
+                .help("set the scan end raw key, in escaped format"))
+            .arg(Arg::with_name("limit")
+                .short("l")
+                .takes_value(true)
+                .help("set the scan limit"))
+            .arg(Arg::with_name("cf")
+                .short("c")
+                .takes_value(true)
+                .help("column family name")))
         .subcommand(SubCommand::with_name("print")
-                    .about("print the raw value")
-                    .arg(Arg::with_name("cf")
-                         .short("c")
-                         .takes_value(true)
-                         .help("column family name"))
-                    .arg(Arg::with_name("key")
-                         .short("k")
-                         .takes_value(true)
-                         .help("set the query raw key, in escaped form")));
+            .about("print the raw value")
+            .arg(Arg::with_name("cf")
+                .short("c")
+                .takes_value(true)
+                .help("column family name"))
+            .arg(Arg::with_name("key")
+                .short("k")
+                .takes_value(true)
+                .help("set the query raw key, in escaped form")));
     let matches = app.clone().get_matches();
 
     let db_path = matches.value_of("db").unwrap();
@@ -95,7 +95,7 @@ fn main() {
         let key = String::from(matches.value_of("key").unwrap());
         dump_raw_value(db, cf_name, key);
     } else if let Some(matches) = matches.subcommand_matches("raft") {
-        if let Some(matches) = matches.subcommand_matches("log"){
+        if let Some(matches) = matches.subcommand_matches("log") {
             let region = String::from(matches.value_of("region").unwrap());
             let index = String::from(matches.value_of("index").unwrap());
             dump_raft_log_entry(db, region, index);
@@ -116,8 +116,7 @@ fn main() {
             }
         }
         dump_range(db, from, to, limit, cf_name);
-    }
-    else {
+    } else {
         let _ = app.print_help();
     }
 

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -28,6 +28,8 @@ const SPLIT_REGION_CHECK_TICK_INTERVAL: u64 = 10000;
 const REGION_SPLIT_SIZE: u64 = 64 * 1024 * 1024;
 const REGION_MAX_SIZE: u64 = 80 * 1024 * 1024;
 const REGION_CHECK_DIFF: u64 = 8 * 1024 * 1024;
+const REGION_COMPACT_CHECK_TICK_INTERVAL: u64 = 30000;
+const REGION_COMPACT_DELETE_KEYS_COUNT: u64 = 100000;
 const PD_HEARTBEAT_TICK_INTERVAL_MS: u64 = 5000;
 const PD_STORE_HEARTBEAT_TICK_INTERVAL_MS: u64 = 10000;
 const STORE_CAPACITY: u64 = u64::MAX;
@@ -73,6 +75,11 @@ pub struct Config {
     /// When size change of region exceed the diff since last check, it
     /// will be checked again whether it should be split.
     pub region_check_size_diff: u64,
+    /// Interval (ms) to check whether start compaction for a region.
+    pub region_compact_check_tick_interval: u64,
+    /// When delete keys of a region exceeds the size, a compaction will
+    /// be started.
+    pub region_compact_delete_keys_count: u64,
     pub pd_heartbeat_tick_interval: u64,
     pub pd_store_heartbeat_tick_interval: u64,
     pub snap_mgr_gc_tick_interval: u64,
@@ -110,6 +117,8 @@ impl Default for Config {
             region_max_size: REGION_MAX_SIZE,
             region_split_size: REGION_SPLIT_SIZE,
             region_check_size_diff: REGION_CHECK_DIFF,
+            region_compact_check_tick_interval: REGION_COMPACT_CHECK_TICK_INTERVAL,
+            region_compact_delete_keys_count: REGION_COMPACT_DELETE_KEYS_COUNT,
             pd_heartbeat_tick_interval: PD_HEARTBEAT_TICK_INTERVAL_MS,
             pd_store_heartbeat_tick_interval: PD_STORE_HEARTBEAT_TICK_INTERVAL_MS,
             notify_capacity: DEFAULT_NOTIFY_CAPACITY,

--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -28,6 +28,7 @@ pub enum Tick {
     Raft,
     RaftLogGc,
     SplitRegionCheck,
+    CompactCheck,
     PdHeartbeat,
     PdStoreHeartbeat,
     SnapGc,

--- a/src/raftstore/store/worker/compact.rs
+++ b/src/raftstore/store/worker/compact.rs
@@ -21,6 +21,7 @@ use rocksdb::{DB, WriteBatch, Writable};
 use std::sync::Arc;
 use std::fmt::{self, Formatter, Display};
 use std::error;
+use std::time::Instant;
 use super::metrics::COMPACT_RANGE_CF;
 
 pub enum Task {
@@ -133,11 +134,14 @@ impl Runnable<Task> for Runner {
                 }
             }
             Task::CompactRangeCF { cf_name, start_key, end_key } => {
+                let t = Instant::now();
                 let cf = cf_name.clone();
                 if let Err(e) = self.compact_range_cf(cf_name, start_key, end_key) {
                     error!("execute compact range for cf {} failed, err {}", &cf, e);
                 } else {
-                    info!("compact range for cf {} finished", &cf)
+                    info!("compact range for cf {} finished, use time: {:?}",
+                          &cf,
+                          t.elapsed());
                 }
             }
         }

--- a/src/raftstore/store/worker/compact.rs
+++ b/src/raftstore/store/worker/compact.rs
@@ -21,7 +21,6 @@ use rocksdb::{DB, WriteBatch, Writable};
 use std::sync::Arc;
 use std::fmt::{self, Formatter, Display};
 use std::error;
-use std::time::Instant;
 use super::metrics::COMPACT_RANGE_CF;
 
 pub enum Task {
@@ -134,14 +133,11 @@ impl Runnable<Task> for Runner {
                 }
             }
             Task::CompactRangeCF { cf_name, start_key, end_key } => {
-                let t = Instant::now();
                 let cf = cf_name.clone();
                 if let Err(e) = self.compact_range_cf(cf_name, start_key, end_key) {
                     error!("execute compact range for cf {} failed, err {}", &cf, e);
                 } else {
-                    info!("compact range for cf {} finished, use time: {:?}",
-                          &cf,
-                          t.elapsed());
+                    info!("compact range for cf {} finished", &cf);
                 }
             }
         }

--- a/tests/raftstore/mod.rs
+++ b/tests/raftstore/mod.rs
@@ -23,6 +23,7 @@ mod test_multi;
 mod test_conf_change;
 mod test_compact_log;
 mod test_compact_lock_cf;
+mod test_compact_after_delete;
 mod test_split_region;
 mod test_status_command;
 mod test_tombstone;

--- a/tests/raftstore/test_compact_after_delete.rs
+++ b/tests/raftstore/test_compact_after_delete.rs
@@ -1,0 +1,65 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+use tikv::storage::{CF_DEFAULT, CF_WRITE};
+use tikv::util::rocksdb::get_cf_handle;
+use rocksdb::Range;
+
+use super::util::*;
+use super::cluster::{Cluster, Simulator};
+use super::node::new_node_cluster;
+use super::server::new_server_cluster;
+
+fn test_compact_after_delete<T: Simulator>(cluster: &mut Cluster<T>) {
+    cluster.cfg.raft_store.region_compact_check_tick_interval = 500;
+    cluster.cfg.raft_store.region_compact_delete_keys_count = 5;
+    cluster.run();
+
+    for i in 1..9 {
+        let (k, v) = (format!("k{}", i), format!("value{}", i));
+        cluster.must_put_cf(CF_DEFAULT, k.as_bytes(), v.as_bytes());
+        cluster.must_put_cf(CF_WRITE, k.as_bytes(), v.as_bytes());
+        cluster.must_delete_cf(CF_DEFAULT, k.as_bytes());
+        cluster.must_delete_cf(CF_WRITE, k.as_bytes());
+    }
+
+    // wait for compaction.
+    sleep_ms(1000);
+
+    for engine in cluster.engines.values() {
+        let cf_handle = get_cf_handle(engine, CF_DEFAULT).unwrap();
+        let approximate_size =
+            engine.get_approximate_sizes_cf(cf_handle, &[Range::new(b"", b"k9")])[0];
+        assert_eq!(approximate_size, 0);
+
+        let cf_handle = get_cf_handle(engine, CF_WRITE).unwrap();
+        let approximate_size =
+            engine.get_approximate_sizes_cf(cf_handle, &[Range::new(b"", b"k9")])[0];
+        assert_eq!(approximate_size, 0);
+    }
+}
+
+#[test]
+fn test_server_compact_after_delete() {
+    let count = 1;
+    let mut cluster = new_server_cluster(0, count);
+    test_compact_after_delete(&mut cluster);
+}
+
+#[test]
+fn test_node_compact_after_delete() {
+    let count = 1;
+    let mut cluster = new_node_cluster(0, count);
+    test_compact_after_delete(&mut cluster);
+}


### PR DESCRIPTION
For issue https://github.com/pingcap/tikv/issues/1179

Note: 
This PR does not count deleted keys when GC executes,  but count it when the raft command applies.
A counter is managed for each Peer and it is checked periodically by RaftStore.

@zhangjinpeng1987 @siddontang @BusyJay 