### PR TITLE
shrink send buffer after a big query

### DIFF
--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -40,6 +40,7 @@ enum ConnType {
 const SNAPSHOT_PAYLOAD_BUF: usize = 4 * 1024 * 1024;
 const DEFAULT_SEND_BUFFER_SIZE: usize = 8 * 1024;
 const DEFAULT_RECV_BUFFER_SIZE: usize = 8 * 1024;
+const SEND_BUFFER_SHRINK_THRESHOLD: usize = 1024 * 1024;
 
 pub struct Conn {
     pub sock: TcpStream,
@@ -250,6 +251,9 @@ impl Conn {
         }
 
         // no data for writing, remove writable
+        if self.send_buffer.capacity() > SEND_BUFFER_SHRINK_THRESHOLD {
+            self.send_buffer.shrink_to(DEFAULT_SEND_BUFFER_SIZE);
+        }
         self.interest.remove(EventSet::writable());
         try!(self.reregister(event_loop));
 

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -40,7 +40,7 @@ enum ConnType {
 const SNAPSHOT_PAYLOAD_BUF: usize = 4 * 1024 * 1024;
 const DEFAULT_SEND_BUFFER_SIZE: usize = 8 * 1024;
 const DEFAULT_RECV_BUFFER_SIZE: usize = 8 * 1024;
-const SEND_BUFFER_SHRINK_THRESHOLD: usize = 1024 * 1024;
+const DEFAULT_BUFFER_SHRINK_THRESHOLD: usize = 1024 * 1024;
 
 pub struct Conn {
     pub sock: TcpStream,
@@ -62,6 +62,8 @@ pub struct Conn {
 
     send_buffer: PipeBuffer,
     recv_buffer: Option<PipeBuffer>,
+
+    pub buffer_shrink_threshold: usize,
 }
 
 impl Conn {
@@ -82,6 +84,7 @@ impl Conn {
             // TODO: Maybe we should need max size to shrink later.
             send_buffer: PipeBuffer::new(DEFAULT_SEND_BUFFER_SIZE),
             recv_buffer: Some(PipeBuffer::new(DEFAULT_RECV_BUFFER_SIZE)),
+            buffer_shrink_threshold: DEFAULT_BUFFER_SHRINK_THRESHOLD,
         }
     }
 
@@ -251,7 +254,7 @@ impl Conn {
         }
 
         // no data for writing, remove writable
-        if self.send_buffer.capacity() > SEND_BUFFER_SHRINK_THRESHOLD {
+        if self.send_buffer.capacity() > self.buffer_shrink_threshold {
             self.send_buffer.shrink_to(DEFAULT_SEND_BUFFER_SIZE);
         }
         self.interest.remove(EventSet::writable());

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -660,7 +660,8 @@ impl Scheduler {
     /// error to the callback, and releases the latches.
     fn on_write_prepare_failed(&mut self, cid: u64, e: Error) {
         debug!("write command(cid={}) failed at prewrite.", cid);
-        SCHED_STAGE_COUNTER_VEC.with_label_values(&[self.get_ctx_tag(cid), "prepare_write_err"]).inc();
+        SCHED_STAGE_COUNTER_VEC.with_label_values(&[self.get_ctx_tag(cid), "prepare_write_err"])
+            .inc();
         self.finish_with_err(cid, e);
     }
 


### PR DESCRIPTION
ref https://github.com/pingcap/tikv/issues/1203
Shrink send buffer to default size after a big query has returned.