### PR TITLE
config: increase default pd-heartbeat-tick-interval

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -44,10 +44,10 @@ notify-capacity = 40960
 # maximum number of messages can be processed in one tick.
 messages-per-tick = 4096
 
-# Region heartbeat tick interval (ms) for reporting to pd. 
-pd-heartbeat-tick-interval = "5000ms"
-# Store heartbeat tick interval (ms) for reporting to pd.
-pd-store-heartbeat-tick-interval = "10000ms"
+# Region heartbeat tick interval for reporting to pd. 
+pd-heartbeat-tick-interval = "60s"
+# Store heartbeat tick interval for reporting to pd.
+pd-store-heartbeat-tick-interval = "10s"
 
 # When the region's size exceeds region-max-size, we will split the region 
 # into two which the left region's size will be region-split-size or a little 

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -640,7 +640,7 @@ fn build_cfg(matches: &Matches, config: &toml::Value, cluster_id: u64, addr: &st
                           "raftstore.pd-heartbeat-tick-interval",
                           matches,
                           config,
-                          Some(5000),
+                          Some(60_000),
                           |v| v.as_integer()) as u64;
 
     cfg.raft_store.pd_store_heartbeat_tick_interval =
@@ -648,7 +648,7 @@ fn build_cfg(matches: &Matches, config: &toml::Value, cluster_id: u64, addr: &st
                           "raftstore.pd-store-heartbeat-tick-interval",
                           matches,
                           config,
-                          Some(10000),
+                          Some(10_000),
                           |v| v.as_integer()) as u64;
 
     cfg.storage.sched_notify_capacity =


### PR DESCRIPTION
1. Split/ChangePeer will be reported to PD immediately.
2. PD's balancer will not schedule the same region in 2 minutes.

So, increase the heartbeat interval to 60s should not affect
the current behavior.