### PR TITLE
server: remove local rocksdb dsn.

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -10,8 +10,6 @@
 addr = "127.0.0.1:20160"
 # if not set, use addr instead. set advertise listening address for client communication.
 advertise-addr = ""
-# set which dsn to use, warning: default is rocksdb without persistent.
-dsn = "rocksdb"
 # set the path to rocksdb directory.
 store = "/tmp/tikv/store"
 # log level: trace, debug, info, warn, error, off.

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -48,15 +48,12 @@ use tikv::util::{self, logger, file_log, panic_hook, rocksdb as rocksdb_util};
 use tikv::util::transport::SendCh;
 use tikv::server::{DEFAULT_LISTENING_ADDR, DEFAULT_CLUSTER_ID, Server, Node, Config, bind,
                    create_event_loop, create_raft_storage, Msg};
-use tikv::server::{ServerTransport, ServerRaftStoreRouter, MockRaftStoreRouter};
+use tikv::server::{ServerTransport, ServerRaftStoreRouter};
 use tikv::server::transport::RaftStoreRouter;
 use tikv::server::{MockStoreAddrResolver, PdStoreAddrResolver, StoreAddrResolver};
 use tikv::raftstore::store::{self, SnapManager};
 use tikv::pd::RpcClient;
 use tikv::util::time_monitor::TimeMonitor;
-
-const ROCKSDB_DSN: &'static str = "rocksdb";
-const RAFTKV_DSN: &'static str = "raftkv";
 
 fn print_usage(program: &str, opts: Options) {
     let brief = format!("Usage: {} [options]", program);
@@ -781,26 +778,6 @@ fn handle_signal(ch: SendCh<Msg>) {
 #[cfg(not(unix))]
 fn handle_signal(ch: SendCh<Msg>) {}
 
-fn run_local_server(listener: TcpListener, config: &Config) {
-    let mut event_loop = create_event_loop(config).unwrap();
-    let snap_mgr = store::new_snap_mgr(TEMP_DIR, None);
-
-    let mut store = Storage::new(&config.storage).unwrap();
-    if let Err(e) = store.start(&config.storage) {
-        panic!("failed to start storage, error = {:?}", e);
-    }
-
-    let svr = Server::new(&mut event_loop,
-                          config,
-                          listener,
-                          store,
-                          MockRaftStoreRouter,
-                          MockStoreAddrResolver,
-                          snap_mgr)
-        .unwrap();
-    start_server(svr, event_loop);
-}
-
 fn run_raft_server(listener: TcpListener, matches: &Matches, config: &toml::Value, cfg: &Config) {
     let mut event_loop = create_event_loop(cfg).unwrap();
     let ch = SendCh::new(event_loop.channel());
@@ -875,10 +852,6 @@ fn main() {
                 "capacity",
                 "set the store capacity",
                 "default: 0 (unlimited)");
-    opts.optopt("S",
-                "dsn",
-                "set which dsn to use, warning: default is rocksdb without persistent",
-                "dsn: rocksdb, raftkv");
     opts.optopt("I",
                 "cluster-id",
                 "set cluster id",
@@ -915,12 +888,6 @@ fn main() {
                                 |v| v.as_str().map(|s| s.to_owned()));
     info!("Start listening on {}...", addr);
     let listener = bind(&addr).unwrap();
-    let dsn_name = get_string_value("S",
-                                    "server.dsn",
-                                    &matches,
-                                    &config,
-                                    Some(ROCKSDB_DSN.to_owned()),
-                                    |v| v.as_str().map(|s| s.to_owned()));
     panic_hook::set_exit_hook();
     let cluster_id = get_integer_value("I",
                                        "raft.cluster-id",
@@ -933,18 +900,10 @@ fn main() {
                             cluster_id,
                             &format!("{}", listener.local_addr().unwrap()));
     cfg.storage.path = get_store_path(&matches, &config);
-    match dsn_name.as_ref() {
-        ROCKSDB_DSN => {
-            initial_metric(&matches, &config, None);
-            run_local_server(listener, &cfg);
-        }
-        RAFTKV_DSN => {
-            if cluster_id == DEFAULT_CLUSTER_ID {
-                panic!("in raftkv, cluster_id must greater than 0");
-            }
-            let _m = TimeMonitor::default();
-            run_raft_server(listener, &matches, &config, &cfg);
-        }
-        n => panic!("unrecognized dns name: {}", n),
-    };
+
+    if cluster_id == DEFAULT_CLUSTER_ID {
+        panic!("in raftkv, cluster_id must greater than 0");
+    }
+    let _m = TimeMonitor::default();
+    run_raft_server(listener, &matches, &config, &cfg);
 }

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -855,7 +855,7 @@ fn main() {
     opts.optopt("S",
                 "dsn",
                 "[deprecated] set which dsn to use, warning: now only support raftkv",
-                "dsn: rocksdb, raftkv");
+                "dsn: raftkv");
     opts.optopt("I",
                 "cluster-id",
                 "set cluster id",

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -50,7 +50,7 @@ use tikv::server::{DEFAULT_LISTENING_ADDR, DEFAULT_CLUSTER_ID, Server, Node, Con
                    create_event_loop, create_raft_storage, Msg};
 use tikv::server::{ServerTransport, ServerRaftStoreRouter};
 use tikv::server::transport::RaftStoreRouter;
-use tikv::server::{MockStoreAddrResolver, PdStoreAddrResolver, StoreAddrResolver};
+use tikv::server::{PdStoreAddrResolver, StoreAddrResolver};
 use tikv::raftstore::store::{self, SnapManager};
 use tikv::pd::RpcClient;
 use tikv::util::time_monitor::TimeMonitor;

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -852,6 +852,10 @@ fn main() {
                 "capacity",
                 "set the store capacity",
                 "default: 0 (unlimited)");
+    opts.optopt("S",
+                "dsn",
+                "[deprecated] set which dsn to use, warning: now only support raftkv",
+                "dsn: rocksdb, raftkv");
     opts.optopt("I",
                 "cluster-id",
                 "set cluster id",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ pub mod util;
 pub mod raft;
 pub mod storage;
 
-pub use storage::{Storage, Dsn};
+pub use storage::Storage;
 pub mod raftstore;
 pub mod pd;
 pub mod server;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -39,7 +39,7 @@ pub use self::errors::{Result, Error};
 pub use self::server::{Server, create_event_loop, bind};
 pub use self::transport::{ServerTransport, ServerRaftStoreRouter, MockRaftStoreRouter};
 pub use self::node::{Node, create_raft_storage};
-pub use self::resolve::{StoreAddrResolver, PdStoreAddrResolver, MockStoreAddrResolver};
+pub use self::resolve::{StoreAddrResolver, PdStoreAddrResolver};
 
 pub type OnResponse = Box<FnBox(msgpb::Message) + Send>;
 

--- a/src/server/resolve.rs
+++ b/src/server/resolve.rs
@@ -143,14 +143,6 @@ impl Drop for PdStoreAddrResolver {
     }
 }
 
-pub struct MockStoreAddrResolver;
-
-impl StoreAddrResolver for MockStoreAddrResolver {
-    fn resolve(&self, _: u64, _: Callback) -> Result<()> {
-        unimplemented!();
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -29,7 +29,7 @@ mod types;
 mod metrics;
 
 pub use self::config::Config;
-pub use self::engine::{Engine, Snapshot, Dsn, TEMP_DIR, new_engine, Modify, Cursor,
+pub use self::engine::{Engine, Snapshot, TEMP_DIR, new_local_engine, Modify, Cursor,
                        Error as EngineError, ScanMode};
 pub use self::engine::raftkv::RaftKv;
 pub use self::txn::{SnapshotStore, Scheduler, Msg};
@@ -257,7 +257,7 @@ impl Storage {
     }
 
     pub fn new(config: &Config) -> Result<Storage> {
-        let engine = try!(engine::new_engine(Dsn::RocksDBPath(&config.path), ALL_CFS));
+        let engine = try!(engine::new_local_engine(&config.path, ALL_CFS));
         Storage::from_engine(engine, config)
     }
 
@@ -658,7 +658,7 @@ mod tests {
     fn test_put_with_err() {
         let config = Config::new();
         // New engine lack of some column families.
-        let engine = engine::new_engine(Dsn::RocksDBPath(&config.path), &["default"]).unwrap();
+        let engine = engine::new_local_engine(&config.path, &["default"]).unwrap();
         let mut storage = Storage::from_engine(engine, &config).unwrap();
         storage.start(&config).unwrap();
         let (tx, rx) = channel();

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -180,11 +180,11 @@ mod tests {
     use super::super::MvccReader;
     use super::super::write::{Write, WriteType};
     use storage::{make_key, Mutation, ALL_CFS, CF_WRITE, ScanMode};
-    use storage::engine::{self, Engine, Dsn, TEMP_DIR};
+    use storage::engine::{self, Engine, TEMP_DIR};
 
     #[test]
     fn test_mvcc_txn_read() {
-        let engine = engine::new_engine(Dsn::RocksDBPath(TEMP_DIR), ALL_CFS).unwrap();
+        let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
 
         must_get_none(engine.as_ref(), b"x", 1);
 
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn test_mvcc_txn_prewrite() {
-        let engine = engine::new_engine(Dsn::RocksDBPath(TEMP_DIR), ALL_CFS).unwrap();
+        let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
 
         must_prewrite_put(engine.as_ref(), b"x", b"x5", b"x", 5);
         // Key is locked.
@@ -239,7 +239,7 @@ mod tests {
 
     #[test]
     fn test_mvcc_txn_commit_ok() {
-        let engine = engine::new_engine(Dsn::RocksDBPath(TEMP_DIR), ALL_CFS).unwrap();
+        let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
         must_prewrite_put(engine.as_ref(), b"x", b"x10", b"x", 10);
         must_prewrite_lock(engine.as_ref(), b"y", b"x", 10);
         must_prewrite_delete(engine.as_ref(), b"z", b"x", 10);
@@ -260,7 +260,7 @@ mod tests {
 
     #[test]
     fn test_mvcc_txn_commit_err() {
-        let engine = engine::new_engine(Dsn::RocksDBPath(TEMP_DIR), ALL_CFS).unwrap();
+        let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
 
         // Not prewrite yet
         must_commit_err(engine.as_ref(), b"x", 1, 2);
@@ -274,7 +274,7 @@ mod tests {
 
     #[test]
     fn test_mvcc_txn_rollback() {
-        let engine = engine::new_engine(Dsn::RocksDBPath(TEMP_DIR), ALL_CFS).unwrap();
+        let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
 
         must_prewrite_put(engine.as_ref(), b"x", b"x5", b"x", 5);
         must_rollback(engine.as_ref(), b"x", 5);
@@ -290,7 +290,7 @@ mod tests {
 
     #[test]
     fn test_mvcc_txn_rollback_err() {
-        let engine = engine::new_engine(Dsn::RocksDBPath(TEMP_DIR), ALL_CFS).unwrap();
+        let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
 
         must_prewrite_put(engine.as_ref(), b"x", b"x5", b"x", 5);
         must_commit(engine.as_ref(), b"x", 5, 10);
@@ -300,7 +300,7 @@ mod tests {
 
     #[test]
     fn test_gc() {
-        let engine = engine::new_engine(Dsn::RocksDBPath(TEMP_DIR), ALL_CFS).unwrap();
+        let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
 
         must_prewrite_put(engine.as_ref(), b"x", b"x5", b"x", 5);
         must_commit(engine.as_ref(), b"x", 5, 10);
@@ -357,7 +357,7 @@ mod tests {
 
     #[test]
     fn test_write() {
-        let engine = engine::new_engine(Dsn::RocksDBPath(TEMP_DIR), ALL_CFS).unwrap();
+        let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
 
         must_prewrite_put(engine.as_ref(), b"x", b"x5", b"x", 5);
         must_seek_write_none(engine.as_ref(), b"x", 5);
@@ -400,7 +400,7 @@ mod tests {
 
     #[test]
     fn test_scan_keys() {
-        let engine = engine::new_engine(Dsn::RocksDBPath(TEMP_DIR), ALL_CFS).unwrap();
+        let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
         must_prewrite_put(engine.as_ref(), b"a", b"a", b"a", 1);
         must_commit(engine.as_ref(), b"a", 1, 10);
         must_prewrite_lock(engine.as_ref(), b"c", b"c", 1);

--- a/tests/coprocessor/test_select.rs
+++ b/tests/coprocessor/test_select.rs
@@ -3,7 +3,7 @@ use tikv::server::coprocessor;
 use kvproto::kvrpcpb::Context;
 use tikv::util::codec::{table, Datum, datum};
 use tikv::util::codec::number::*;
-use tikv::storage::{Dsn, Mutation, Key, ALL_CFS};
+use tikv::storage::{Mutation, Key, ALL_CFS};
 use tikv::storage::engine::{self, Engine, TEMP_DIR};
 use tikv::util::event::Event;
 use tikv::util::worker::Worker;
@@ -518,7 +518,7 @@ impl ProductTable {
 fn init_with_data(tbl: &ProductTable,
                   vals: &[(i64, Option<&str>, i64)])
                   -> (Store, Worker<EndPointTask>) {
-    let engine = engine::new_engine(Dsn::RocksDBPath(TEMP_DIR), ALL_CFS).unwrap();
+    let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
     let mut store = Store::new(engine);
 
     store.begin();


### PR DESCRIPTION
Fix #1206 

PTAL @siddontang @BusyJay 

Note:
After this PR, we should update tikv startup script by removing `-S raftkv`. But you don't have to make changes if use a config file before. @iamxy @nolouch @shenli 