### PR TITLE
raftstore: use atomic to control snapshot progress

### DIFF
--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -62,11 +62,6 @@ pub enum Msg {
 
     // For snapshot stats.
     SnapshotStats,
-    SnapApplyRes {
-        region_id: u64,
-        is_success: bool,
-        is_aborted: bool,
-    },
     SnapGenRes {
         region_id: u64,
         snap: Option<Snapshot>,
@@ -94,13 +89,6 @@ impl fmt::Debug for Msg {
                        region_id)
             }
             Msg::SnapshotStats => write!(fmt, "Snapshot stats"),
-            Msg::SnapApplyRes { region_id, is_success, is_aborted } => {
-                write!(fmt,
-                       "SnapApplyRes [region_id: {}, is_success: {}, is_aborted: {}]",
-                       region_id,
-                       is_success,
-                       is_aborted)
-            }
             Msg::SnapGenRes { region_id, ref snap } => {
                 write!(fmt,
                        "SnapGenRes [region_id: {}, is_success: {}]",

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -466,7 +466,7 @@ impl Peer {
                                            metrics: &mut RaftMetrics)
                                            -> Result<Option<ReadyResult>> {
         if self.mut_store().check_applying_snap() {
-            // If we continue handle all the messages, it may cause too many messages because
+            // If we continue to handle all the messages, it may cause too many messages because
             // leader will send all the remaining messages to this follower, which can lead
             // to full message queue under high load.
             debug!("{} still applying snapshot, skip further handling.",

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -46,7 +46,7 @@ const MAX_SNAP_TRY_CNT: usize = 5;
 pub const JOB_STATUS_PENDING: usize = 0;
 pub const JOB_STATUS_RUNNING: usize = 1;
 pub const JOB_STATUS_CANCELLING: usize = 2;
-pub const JOB_STATUS_CANCELED: usize = 3;
+pub const JOB_STATUS_CANCELLED: usize = 3;
 pub const JOB_STATUS_FINISHED: usize = 4;
 pub const JOB_STATUS_FAILED: usize = 5;
 
@@ -622,7 +622,7 @@ impl PeerStorage {
                 let s = status.load(Ordering::Relaxed);
                 if s == JOB_STATUS_FINISHED {
                     SnapState::Relax
-                } else if s == JOB_STATUS_CANCELED {
+                } else if s == JOB_STATUS_CANCELLED {
                     SnapState::ApplyAborted
                 } else if s == JOB_STATUS_FAILED {
                     // TODO: cleanup region and treat it as tombstone.
@@ -665,7 +665,7 @@ impl PeerStorage {
             }
             _ => return false,
         }
-        // now status can only be JOB_STATUS_CANCELLING, JOB_STATUS_CANCELED,
+        // now status can only be JOB_STATUS_CANCELLING, JOB_STATUS_CANCELLED,
         // JOB_STATUS_FAILED and JOB_STATUS_FINISHED.
         !self.check_applying_snap()
     }
@@ -1263,7 +1263,7 @@ mod test {
         assert!(!s.cancel_applying_snap());
 
         s.snap_state =
-            RefCell::new(SnapState::Applying(Arc::new(AtomicUsize::new(JOB_STATUS_CANCELED))));
+            RefCell::new(SnapState::Applying(Arc::new(AtomicUsize::new(JOB_STATUS_CANCELLED))));
         // canceled snapshot can be cancel directly.
         assert!(s.cancel_applying_snap());
         assert_eq!(*s.snap_state.borrow(), SnapState::ApplyAborted);
@@ -1298,7 +1298,7 @@ mod test {
         assert!(s.check_applying_snap());
         assert_eq!(*s.snap_state.borrow(), snap_state);
 
-        snap_state = SnapState::Applying(Arc::new(AtomicUsize::new(JOB_STATUS_CANCELED)));
+        snap_state = SnapState::Applying(Arc::new(AtomicUsize::new(JOB_STATUS_CANCELLED)));
         s.snap_state = RefCell::new(snap_state);
         assert!(!s.check_applying_snap());
         assert_eq!(*s.snap_state.borrow(), SnapState::ApplyAborted);

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -46,10 +46,13 @@ const MAX_SNAP_TRY_CNT: usize = 5;
 pub const JOB_STATUS_PENDING: usize = 0;
 pub const JOB_STATUS_RUNNING: usize = 1;
 pub const JOB_STATUS_CANCEL: usize = 2;
+pub const JOB_STATUS_CANCELED: usize = 3;
+pub const JOB_STATUS_FINISHED: usize = 4;
+pub const JOB_STATUS_FAILED: usize = 5;
 
 pub type Ranges = Vec<(Vec<u8>, Vec<u8>)>;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum SnapState {
     Relax,
     Generating,
@@ -613,11 +616,25 @@ impl PeerStorage {
 
     /// Check if the storage is applying a snapshot.
     #[inline]
-    pub fn is_applying_snap(&self) -> bool {
-        match *self.snap_state.borrow() {
-            SnapState::Applying(_) => true,
-            _ => false,
-        }
+    pub fn check_applying_snap(&mut self) -> bool {
+        let new_state = match *self.snap_state.borrow() {
+            SnapState::Applying(ref status) => {
+                let s = status.load(Ordering::Relaxed);
+                if s == JOB_STATUS_FINISHED {
+                    SnapState::Relax
+                } else if s == JOB_STATUS_CANCELED {
+                    SnapState::ApplyAborted
+                } else if s == JOB_STATUS_FAILED {
+                    // TODO: cleanup region and treat it as tombstone.
+                    panic!("{} applying snapshot failed", self.tag);
+                } else {
+                    return true;
+                }
+            }
+            _ => return false,
+        };
+        *self.snap_state.borrow_mut() = new_state;
+        false
     }
 
     #[inline]
@@ -628,14 +645,23 @@ impl PeerStorage {
         }
     }
 
-    /// Cancel applying snapshot, return true if the job can be considered actually cancelled.
+    /// Cancel applying snapshot, return true if the job can be considered not be run again.
     pub fn cancel_applying_snap(&mut self) -> bool {
         match *self.snap_state.borrow() {
             SnapState::Applying(ref status) => {
-                status.swap(JOB_STATUS_CANCEL, Ordering::Relaxed) == JOB_STATUS_PENDING
+                if status.compare_and_swap(JOB_STATUS_PENDING, JOB_STATUS_CANCEL,
+                                           Ordering::SeqCst) == JOB_STATUS_PENDING {
+                    return true;
+                } else if status.compare_and_swap(JOB_STATUS_RUNNING, JOB_STATUS_CANCEL,
+                                                  Ordering::SeqCst) == JOB_STATUS_RUNNING {
+                    return false;
+                }
             }
-            _ => false,
+            _ => return false,
         }
+        // now status can only be JOB_STATUS_CANCEL, JOB_STATUS_CANCELED,
+        // JOB_STATUS_FAILED and JOB_STATUS_FINISHED.
+        !self.check_applying_snap()
     }
 
     #[inline]
@@ -898,7 +924,9 @@ impl Storage for PeerStorage {
 #[cfg(test)]
 mod test {
     use std::sync::*;
+    use std::sync::atomic::*;
     use std::sync::mpsc::*;
+    use std::cell::RefCell;
     use std::io;
     use std::fs::File;
     use kvproto::eraftpb::{Entry, ConfState};
@@ -907,7 +935,7 @@ mod test {
     use tempdir::*;
     use protobuf;
     use raftstore;
-    use raftstore::store::*;
+    use raftstore::store::{Msg, bootstrap, new_snap_mgr, SnapKey};
     use raftstore::store::worker::{RegionRunner, MsgSender};
     use util::codec::number::NumberEncoder;
     use raftstore::store::worker::RegionTask;
@@ -917,7 +945,7 @@ mod test {
     use storage::{CF_DEFAULT, CF_RAFT};
     use kvproto::eraftpb::HardState;
 
-    use super::InvokeContext;
+    use super::*;
 
     impl MsgSender for Sender<Msg> {
         fn send(&self, msg: Msg) -> raftstore::Result<()> {
@@ -1205,5 +1233,84 @@ mod test {
         assert_eq!(ctx.apply_state.get_truncated_state().get_index(), 6);
         assert_eq!(ctx.apply_state.get_truncated_state().get_term(), 6);
         assert_eq!(s2.first_index(), s2.applied_index() + 1);
+    }
+
+    #[test]
+    fn test_canceling_snapshot() {
+        let td = TempDir::new("tikv-store-test").unwrap();
+        let worker = Worker::new("snap_manager");
+        let sched = worker.scheduler();
+        let mut s = new_storage(sched, &td);
+
+        // PENDING can be canceled directly.
+        s.snap_state =
+            RefCell::new(SnapState::Applying(Arc::new(AtomicUsize::new(JOB_STATUS_PENDING))));
+        assert!(s.cancel_applying_snap());
+
+        // RUNNING can't be canceled directly.
+        s.snap_state =
+            RefCell::new(SnapState::Applying(Arc::new(AtomicUsize::new(JOB_STATUS_RUNNING))));
+        assert!(!s.cancel_applying_snap());
+        assert_eq!(*s.snap_state.borrow(),
+                   SnapState::Applying(Arc::new(AtomicUsize::new(JOB_STATUS_CANCEL))));
+        // CANCEL can't be canceled again.
+        assert!(!s.cancel_applying_snap());
+
+        s.snap_state =
+            RefCell::new(SnapState::Applying(Arc::new(AtomicUsize::new(JOB_STATUS_CANCELED))));
+        // canceled snapshot can be cancel directly.
+        assert!(s.cancel_applying_snap());
+        assert_eq!(*s.snap_state.borrow(), SnapState::ApplyAborted);
+
+        s.snap_state =
+            RefCell::new(SnapState::Applying(Arc::new(AtomicUsize::new(JOB_STATUS_FINISHED))));
+        assert!(s.cancel_applying_snap());
+        assert_eq!(*s.snap_state.borrow(), SnapState::Relax);
+
+        s.snap_state =
+            RefCell::new(SnapState::Applying(Arc::new(AtomicUsize::new(JOB_STATUS_FAILED))));
+        let res = recover_safe!(|| s.cancel_applying_snap());
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_try_finish_snapshot() {
+        let td = TempDir::new("tikv-store-test").unwrap();
+        let worker = Worker::new("snap_manager");
+        let sched = worker.scheduler();
+        let mut s = new_storage(sched, &td);
+
+        // PENDING can be finished.
+        let mut snap_state = SnapState::Applying(Arc::new(AtomicUsize::new(JOB_STATUS_PENDING)));
+        s.snap_state = RefCell::new(snap_state.clone());
+        assert!(s.check_applying_snap());
+        assert_eq!(*s.snap_state.borrow(), snap_state);
+
+        // RUNNING can't be finished.
+        snap_state = SnapState::Applying(Arc::new(AtomicUsize::new(JOB_STATUS_RUNNING)));
+        s.snap_state = RefCell::new(snap_state.clone());
+        assert!(s.check_applying_snap());
+        assert_eq!(*s.snap_state.borrow(), snap_state);
+
+        snap_state = SnapState::Applying(Arc::new(AtomicUsize::new(JOB_STATUS_CANCELED)));
+        s.snap_state = RefCell::new(snap_state);
+        assert!(!s.check_applying_snap());
+        assert_eq!(*s.snap_state.borrow(), SnapState::ApplyAborted);
+        // ApplyAborted is not applying snapshot.
+        assert!(!s.check_applying_snap());
+        assert_eq!(*s.snap_state.borrow(), SnapState::ApplyAborted);
+
+        s.snap_state =
+            RefCell::new(SnapState::Applying(Arc::new(AtomicUsize::new(JOB_STATUS_FINISHED))));
+        assert!(!s.check_applying_snap());
+        assert_eq!(*s.snap_state.borrow(), SnapState::Relax);
+        // Relax is not applying snapshot.
+        assert!(!s.check_applying_snap());
+        assert_eq!(*s.snap_state.borrow(), SnapState::Relax);
+
+        s.snap_state =
+            RefCell::new(SnapState::Applying(Arc::new(AtomicUsize::new(JOB_STATUS_FAILED))));
+        let res = recover_safe!(|| s.check_applying_snap());
+        assert!(res.is_err());
     }
 }

--- a/src/raftstore/store/worker/region.rs
+++ b/src/raftstore/store/worker/region.rs
@@ -29,7 +29,7 @@ use util::{escape, HandyRwLock, rocksdb};
 use util::transport::SendCh;
 use raftstore;
 use raftstore::store::engine::{Mutable, Snapshot, Iterable};
-use raftstore::store::peer_storage::{JOB_STATUS_FINISHED, JOB_STATUS_CANCELED, JOB_STATUS_FAILED,
+use raftstore::store::peer_storage::{JOB_STATUS_FINISHED, JOB_STATUS_CANCELLED, JOB_STATUS_FAILED,
                                      JOB_STATUS_CANCELLING, JOB_STATUS_PENDING, JOB_STATUS_RUNNING};
 use raftstore::store::{self, SnapManager, SnapKey, SnapEntry, Msg, keys, Peekable};
 use storage::CF_RAFT;
@@ -298,7 +298,7 @@ impl<T: MsgSender> Runner<T> {
             }
             Err(Error::Abort) => {
                 warn!("applying snapshot for region {} is aborted.", region_id);
-                assert!(status.swap(JOB_STATUS_CANCELED, Ordering::SeqCst) ==
+                assert!(status.swap(JOB_STATUS_CANCELLED, Ordering::SeqCst) ==
                         JOB_STATUS_CANCELLING);
                 SNAP_COUNTER_VEC.with_label_values(&["apply", "abort"]).inc();
             }

--- a/src/raftstore/store/worker/region.rs
+++ b/src/raftstore/store/worker/region.rs
@@ -29,7 +29,8 @@ use util::{escape, HandyRwLock, rocksdb};
 use util::transport::SendCh;
 use raftstore;
 use raftstore::store::engine::{Mutable, Snapshot, Iterable};
-use raftstore::store::peer_storage::{JOB_STATUS_CANCEL, JOB_STATUS_PENDING, JOB_STATUS_RUNNING};
+use raftstore::store::peer_storage::{JOB_STATUS_FINISHED, JOB_STATUS_CANCELED, JOB_STATUS_FAILED,
+                                     JOB_STATUS_CANCEL, JOB_STATUS_PENDING, JOB_STATUS_RUNNING};
 use raftstore::store::{self, SnapManager, SnapKey, SnapEntry, Msg, keys, Peekable};
 use storage::CF_RAFT;
 
@@ -290,35 +291,23 @@ impl<T: MsgSender> Runner<T> {
         let apply_histogram = SNAP_HISTOGRAM.with_label_values(&["apply"]);
         let timer = apply_histogram.start_timer();
 
-        let (is_success, is_aborted) = match self.apply_snap(region_id, status) {
-            Ok(()) => (true, false),
+        match self.apply_snap(region_id, status.clone()) {
+            Ok(()) => {
+                status.swap(JOB_STATUS_FINISHED, Ordering::SeqCst);
+                SNAP_COUNTER_VEC.with_label_values(&["apply", "success"]).inc();
+            }
             Err(Error::Abort) => {
                 warn!("applying snapshot for region {} is aborted.", region_id);
-                (false, true)
+                assert!(status.swap(JOB_STATUS_CANCELED, Ordering::SeqCst) == JOB_STATUS_CANCEL);
+                SNAP_COUNTER_VEC.with_label_values(&["apply", "abort"]).inc();
             }
             Err(e) => {
                 error!("failed to apply snap: {:?}!!!", e);
-                (false, false)
+                status.swap(JOB_STATUS_FAILED, Ordering::SeqCst);
+                SNAP_COUNTER_VEC.with_label_values(&["apply", "fail"]).inc();
             }
-        };
-        let msg = Msg::SnapApplyRes {
-            region_id: region_id,
-            is_success: is_success,
-            is_aborted: is_aborted,
-        };
-        if let Err(e) = self.ch.send(msg) {
-            panic!("failed to notify snap apply result of {}: {:?}",
-                   region_id,
-                   e);
         }
 
-        if is_aborted {
-            SNAP_COUNTER_VEC.with_label_values(&["apply", "abort"]).inc();
-        } else if is_success {
-            SNAP_COUNTER_VEC.with_label_values(&["apply", "success"]).inc();
-        } else {
-            SNAP_COUNTER_VEC.with_label_values(&["apply", "fail"]).inc();
-        }
         timer.observe_duration();
     }
 

--- a/tests/raftstore/test_stale_peer.rs
+++ b/tests/raftstore/test_stale_peer.rs
@@ -147,7 +147,7 @@ fn test_stale_peer_without_data<T: Simulator>(cluster: &mut Cluster<T>) {
 
     let new_region = cluster.get_region(b"k3");
     let new_region_id = new_region.get_id();
-    // Block peer (new_region_id, 4) at receiving snapshot, but not the heartbeat
+    // Block peer (3, 4) at receiving snapshot, but not the heartbeat
     cluster.add_send_filter(CloneFilterFactory(RegionPacketFilter::new(new_region_id, 3)
         .msg_type(MessageType::MsgSnapshot)));
 

--- a/tests/raftstore/test_stale_peer.rs
+++ b/tests/raftstore/test_stale_peer.rs
@@ -148,13 +148,13 @@ fn test_stale_peer_without_data<T: Simulator>(cluster: &mut Cluster<T>) {
     let new_region = cluster.get_region(b"k3");
     let new_region_id = new_region.get_id();
     // Block peer (new_region_id, 4) at receiving snapshot, but not the heartbeat
-    cluster.add_send_filter(CloneFilterFactory(RegionPacketFilter::new(new_region_id, 4)
+    cluster.add_send_filter(CloneFilterFactory(RegionPacketFilter::new(new_region_id, 3)
         .msg_type(MessageType::MsgSnapshot)));
 
     pd_client.must_add_peer(new_region_id, new_peer(3, 4));
 
     // Wait for the heartbeat broadcasted from peer (1, 1000) to peer (3, 4).
-    thread::sleep(Duration::from_millis(60));
+    cluster.must_region_exist(new_region_id, 3);
 
     // And then isolate peer (3, 4) from peer (1, 1000).
     cluster.add_send_filter(IsolationFilterFactory::new(3));


### PR DESCRIPTION
When snapshot is applied successfully asynchronously, it will send back a notification to store. If store is blocked by some work, it will fail to push the notification to queue, which can lead to panic. This pr use atomic flag to control the snapshot progress instead, so snapshot report doesn't have to join the crowded raftstore message queue.

@siddontang @hhkbp2 PTAL