### PR TITLE
set max-open-files

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -99,6 +99,16 @@ max-background-compactions = 6
 # Control maximum total data size for base level (level 1).
 max-bytes-for-level-base = "64MB"
 
+# Number of open files that can be used by the DB.  You may need to
+# increase this if your database has a large working set. Value -1 means
+# files opened are always kept open. You can estimate number of files based
+# on target_file_size_base and target_file_size_multiplier for level-based
+# compaction.
+# If max-open-files = -1, RocksDB will prefetch index and filter blocks into
+# block cache at startup, so if your database has a large working set, it will
+# take several minutes to open the db.
+max-open-files = 40960
+
 # Target file size for compaction.
 target-file-size-base = "16MB"
 

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -361,6 +361,14 @@ fn get_rocksdb_default_cf_option(matches: &Matches, config: &toml::Value) -> Roc
                                                            |v| v.as_integer());
     opts.set_level_zero_stop_writes_trigger(level_zero_stop_writes_trigger as i32);
 
+    let max_open_files = get_integer_value("",
+                                           "rocksdb.max-open-files",
+                                           matches,
+                                           config,
+                                           Some(40960),
+                                           |v| v.as_integer());
+    opts.set_max_open_files(max_open_files as i32);
+
     opts
 }
 


### PR DESCRIPTION
ref https://github.com/pingcap/tikv/issues/1214
If RocksDB's max-open-files is -1 (the default value), RocksDB will prefetch index and filter blocks into block cache when open db, this may takes several minutes to startup TiKV when the database has a large working set.
https://github.com/facebook/rocksdb/blob/master/table/block_based_table_reader.h#L88
https://github.com/facebook/rocksdb/blob/master/db/version_set.cc#L2296