### PR TITLE
record last compacted position

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::rc::Rc;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -174,7 +174,7 @@ pub struct Peer {
 
     pub tag: String,
 
-    pub last_compacted: Arc<RwLock<u64>>,
+    pub last_compacted: u64,
 }
 
 impl Peer {
@@ -260,7 +260,7 @@ impl Peer {
             pending_remove: false,
             leader_missing_time: Some(Instant::now()),
             tag: tag,
-            last_compacted: Arc::new(RwLock::new(0)),
+            last_compacted: 0,
         };
 
         peer.load_all_coprocessors();

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -174,7 +174,7 @@ pub struct Peer {
 
     pub tag: String,
 
-    pub last_compacted: u64,
+    pub last_compacted_idx: u64,
 }
 
 impl Peer {
@@ -260,7 +260,7 @@ impl Peer {
             pending_remove: false,
             leader_missing_time: Some(Instant::now()),
             tag: tag,
-            last_compacted: 0,
+            last_compacted_idx: 0,
         };
 
         peer.load_all_coprocessors();

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::rc::Rc;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -173,6 +173,8 @@ pub struct Peer {
     leader_missing_time: Option<Instant>,
 
     pub tag: String,
+
+    pub last_compacted: Arc<RwLock<u64>>,
 }
 
 impl Peer {
@@ -258,6 +260,7 @@ impl Peer {
             pending_remove: false,
             leader_missing_time: Some(Instant::now()),
             tag: tag,
+            last_compacted: Arc::new(RwLock::new(0)),
         };
 
         peer.load_all_coprocessors();

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -841,6 +841,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         let task = CompactTask::CompactRaftLog {
             engine: peer.get_store().get_engine().clone(),
             region_id: peer.get_store().get_region_id(),
+            last_compacted: peer.last_compacted.clone(),
             compact_idx: state.get_index() + 1,
         };
         if let Err(e) = self.compact_worker.schedule(task) {

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -841,7 +841,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         let task = CompactTask::CompactRaftLog {
             engine: peer.get_store().get_engine().clone(),
             region_id: peer.get_store().get_region_id(),
-            last_compacted: peer.last_compacted.clone(),
+            start_idx: peer.last_compacted,
             compact_idx: state.get_index() + 1,
         };
         if let Err(e) = self.compact_worker.schedule(task) {

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -841,10 +841,10 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         let task = CompactTask::CompactRaftLog {
             engine: peer.get_store().get_engine().clone(),
             region_id: peer.get_store().get_region_id(),
-            start_idx: peer.last_compacted,
+            start_idx: peer.last_compacted_idx,
             compact_idx: state.get_index() + 1,
         };
-        peer.last_compacted = state.get_index() + 1;
+        peer.last_compacted_idx = state.get_index() + 1;
         if let Err(e) = self.compact_worker.schedule(task) {
             error!("[region {}] failed to schedule compact task: {}",
                    region_id,

--- a/src/raftstore/store/worker/compact.rs
+++ b/src/raftstore/store/worker/compact.rs
@@ -84,14 +84,6 @@ impl Runner {
         }
     }
 
-    fn update_compacted(&mut self, region_id: u64, compacted: u64) {
-        if let Some(last_compacted) = self.raft_compacted_ctx.get_mut(&region_id) {
-            *last_compacted = compacted;
-            return;
-        }
-        self.raft_compacted_ctx.insert(region_id, compacted);
-    }
-
     /// Do the compact job and return the count of log compacted.
     fn compact_raft_log(&mut self,
                         engine: Arc<DB>,
@@ -121,7 +113,7 @@ impl Runner {
         }
         // It's not safe to disable WAL here. We may lost data after crashed for unknown reason.
         box_try!(engine.write(wb));
-        self.update_compacted(region_id, compact_idx);
+        self.raft_compacted_ctx.insert(region_id, compact_idx);
         Ok(compact_idx - first_idx)
     }
 

--- a/src/raftstore/store/worker/compact.rs
+++ b/src/raftstore/store/worker/compact.rs
@@ -85,18 +85,14 @@ impl Runner {
                         start_idx: u64,
                         compact_idx: u64)
                         -> Result<u64, Error> {
-        let first_idx = {
-            if start_idx == 0 {
-                let start_key = keys::raft_log_key(region_id, 0);
-                let mut first_idx = compact_idx;
-                if let Some((k, _)) = box_try!(engine.seek_cf(CF_RAFT, &start_key)) {
-                    first_idx = box_try!(keys::raft_log_index(&k));
-                }
-                first_idx
-            } else {
-                start_idx
+        let mut first_idx = start_idx;
+        if first_idx == 0 {
+            let start_key = keys::raft_log_key(region_id, 0);
+            first_idx = compact_idx;
+            if let Some((k, _)) = box_try!(engine.seek_cf(CF_RAFT, &start_key)) {
+                first_idx = box_try!(keys::raft_log_index(&k));
             }
-        };
+        }
         if first_idx >= compact_idx {
             info!("[region {}] no need to compact", region_id);
             return Ok(0);

--- a/tests/raftstore/test_compact_log.rs
+++ b/tests/raftstore/test_compact_log.rs
@@ -144,6 +144,58 @@ fn test_compact_limit<T: Simulator>(cluster: &mut Cluster<T>) {
     }
 }
 
+fn test_compact_many_times<T: Simulator>(cluster: &mut Cluster<T>) {
+    let gc_limit: u64 = 100;
+    cluster.cfg.raft_store.raft_log_gc_limit = gc_limit;
+    cluster.cfg.raft_store.raft_log_gc_threshold = 50;
+    cluster.cfg.raft_store.raft_log_gc_tick_interval = 100; // 100 ms
+    cluster.run();
+
+    cluster.must_put(b"k1", b"v1");
+
+    let mut before_states = HashMap::new();
+
+    for (&id, engine) in &cluster.engines {
+        must_get_equal(engine, b"k1", b"v1");
+        let mut state: RaftApplyState =
+        get_msg_cf_or_default(engine, CF_RAFT, &keys::apply_state_key(1));
+        let state = state.take_truncated_state();
+        // compact should not start
+        assert_eq!(RAFT_INIT_LOG_INDEX, state.get_index());
+        assert_eq!(RAFT_INIT_LOG_TERM, state.get_term());
+        before_states.insert(id, state);
+    }
+
+    for i in 1..500 {
+        let k = i.to_string().into_bytes();
+        let v = k.clone();
+        cluster.must_put(&k, &v);
+        let v2 = cluster.get(&k);
+        assert_eq!(v2, Some(v));
+    }
+
+    // wait log gc.
+    sleep_ms(1000);
+
+    // Every peer must have compacted logs, so the truncate log state index/term must > than before.
+    for (&id, engine) in &cluster.engines {
+        let mut state: RaftApplyState =
+        get_msg_cf_or_default(engine, CF_RAFT, &keys::apply_state_key(1));
+        let after_state = state.take_truncated_state();
+
+        let before_state = before_states.get(&id).unwrap();
+        let idx = after_state.get_index();
+        // Compact raft log at least 2 times.
+        assert!(idx - before_state.get_index() >= gc_limit * 2);
+
+        let handle = get_cf_handle(engine, CF_RAFT).unwrap();
+        for i in 0..idx {
+            let key = keys::raft_log_key(1, i);
+            assert!(engine.get_cf(handle, &key).unwrap().is_none());
+        }
+    }
+}
+
 #[test]
 fn test_node_compact_log() {
     let count = 5;
@@ -170,4 +222,18 @@ fn test_server_compact_limit() {
     let count = 5;
     let mut cluster = new_server_cluster(0, count);
     test_compact_limit(&mut cluster);
+}
+
+#[test]
+fn test_node_compact_many_times() {
+    let count = 5;
+    let mut cluster = new_node_cluster(0, count);
+    test_compact_many_times(&mut cluster);
+}
+
+#[test]
+fn test_server_compact_many_times() {
+    let count = 5;
+    let mut cluster = new_server_cluster(0, count);
+    test_compact_many_times(&mut cluster);
 }

--- a/tests/raftstore/test_compact_log.rs
+++ b/tests/raftstore/test_compact_log.rs
@@ -158,7 +158,7 @@ fn test_compact_many_times<T: Simulator>(cluster: &mut Cluster<T>) {
     for (&id, engine) in &cluster.engines {
         must_get_equal(engine, b"k1", b"v1");
         let mut state: RaftApplyState =
-        get_msg_cf_or_default(engine, CF_RAFT, &keys::apply_state_key(1));
+            get_msg_cf_or_default(engine, CF_RAFT, &keys::apply_state_key(1));
         let state = state.take_truncated_state();
         // compact should not start
         assert_eq!(RAFT_INIT_LOG_INDEX, state.get_index());
@@ -180,7 +180,7 @@ fn test_compact_many_times<T: Simulator>(cluster: &mut Cluster<T>) {
     // Every peer must have compacted logs, so the truncate log state index/term must > than before.
     for (&id, engine) in &cluster.engines {
         let mut state: RaftApplyState =
-        get_msg_cf_or_default(engine, CF_RAFT, &keys::apply_state_key(1));
+            get_msg_cf_or_default(engine, CF_RAFT, &keys::apply_state_key(1));
         let after_state = state.take_truncated_state();
 
         let before_state = before_states.get(&id).unwrap();


### PR DESCRIPTION
Record last compacted position for last raft compact task, so the later compact task no need to seek to first raft entry.
Maybe we need more discussion, @siddontang what's your suggestion? 
@ngaut @siddontang @BusyJay @disksing  PTAL