### PR TITLE
raftstore: include snap size into used_size

### DIFF
--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -179,10 +179,10 @@ impl SnapFile {
         if let Some((mut f, path)) = self.tmp_file.take() {
             try!(f.write_u32::<BigEndian>(self.digest.sum32()));
             try!(f.flush());
-            let file_len = try!(f.seek(SeekFrom::End(0)));
+            let file_len = try!(fs::metadata(&path)).len();
             let mut size_track = self.size_track.wl();
-            *size_track = size_track.saturating_add(file_len);
             try!(fs::rename(path, self.file.as_path()));
+            *size_track = size_track.saturating_add(file_len);
         }
         Ok(())
     }

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -1349,6 +1349,8 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             used_size += cf_used_size;
         }
 
+        used_size += self.snap_mgr.rl().get_total_snap_size();
+
         let mut available = if capacity > used_size {
             capacity - used_size
         } else {


### PR DESCRIPTION
Snapshot directory's size should be included in used size too. Hence the capacity limit won't be violate.

@siddontang @huachaohuang PTAL