### PR TITLE
server: add tags and start time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,7 +261,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto#c116b306b81b1af7ffa149944dd50473a0242188"
+source = "git+https://github.com/pingcap/kvproto#f1868dde6860d51ff5d0822d720cb88e01a94373"
 dependencies = [
  "protobuf 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -28,6 +28,9 @@ const DEFAULT_RECV_BUFFER_SIZE: usize = 128 * 1024;
 pub struct Config {
     pub cluster_id: u64,
 
+    // Server tags.
+    pub tags: Vec<String>,
+
     // Server listening address.
     pub addr: String,
 
@@ -47,6 +50,7 @@ impl Default for Config {
     fn default() -> Config {
         Config {
             cluster_id: DEFAULT_CLUSTER_ID,
+            tags: Vec::new(),
             addr: DEFAULT_LISTENING_ADDR.to_owned(),
             advertise_addr: DEFAULT_ADVERTISE_LISTENING_ADDR.to_owned(),
             notify_capacity: DEFAULT_NOTIFY_CAPACITY,

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 
 use mio::EventLoop;
 use rocksdb::DB;
+use protobuf::RepeatedField;
 
 use pd::{INVALID_ID, PdClient, Error as PdError};
 use kvproto::raft_serverpb::StoreIdent;
@@ -63,6 +64,7 @@ impl<C> Node<C>
     {
         let mut store = metapb::Store::new();
         store.set_id(INVALID_ID);
+        store.set_tags(RepeatedField::from_vec(cfg.tags.to_owned()));
         if cfg.advertise_addr.is_empty() {
             store.set_address(cfg.addr.clone());
         } else {


### PR DESCRIPTION
Report server tags and start time to PD for replica constraints and
uptime monitor.

Closes https://github.com/pingcap/tikv/issues/1207.