### PR TITLE
raftstore: slow down heartbeat and election

### DIFF
--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -17,8 +17,8 @@ use std::time::Duration;
 use raftstore::Result;
 
 const RAFT_BASE_TICK_INTERVAL: u64 = 100;
-const RAFT_HEARTBEAT_TICKS: usize = 3;
-const RAFT_ELECTION_TIMEOUT_TICKS: usize = 15;
+const RAFT_HEARTBEAT_TICKS: usize = 10;
+const RAFT_ELECTION_TIMEOUT_TICKS: usize = 50;
 const RAFT_MAX_SIZE_PER_MSG: u64 = 1024 * 1024;
 const RAFT_MAX_INFLIGHT_MSGS: usize = 256;
 const RAFT_LOG_GC_INTERVAL: u64 = 5000;


### PR DESCRIPTION
Default election timeout is too small. When some peer is slow at some point, an election will occur very quickly, which makes the system not very stable.

@siddontang @hhkbp2 PTAL