### PR TITLE
raftstore: fix potential data inconsistency

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -1042,15 +1042,6 @@ impl Peer {
         // if pending remove, apply should be aborted already.
         assert!(!self.pending_remove);
 
-        let last_applied_index = self.get_store().applied_index();
-        if last_applied_index >= index {
-            // How can it happen?
-            panic!("{} applied index moved backwards, {} >= {}",
-                   self.tag,
-                   last_applied_index,
-                   index);
-        }
-
         let mut ctx = ExecContext::new(self, index, term, req);
         let (resp, exec_result) = self.exec_raft_cmd(&mut ctx).unwrap_or_else(|e| {
             error!("{} execute raft command err: {:?}", self.tag, e);

--- a/tests/raftstore/pd.rs
+++ b/tests/raftstore/pd.rs
@@ -409,14 +409,17 @@ impl TestPdClient {
         panic!("region {:?} has peer {:?}", region, peer);
     }
 
-    pub fn must_add_peer(&self, region_id: u64, peer: metapb::Peer) {
-        let peer2 = peer.clone();
+    pub fn add_peer(&self, region_id: u64, peer: metapb::Peer) {
         self.set_rule(box move |region: &metapb::Region, _: &metapb::Peer| {
             if region.get_id() != region_id {
                 return None;
             }
-            new_pd_add_change_peer(region, peer2.clone())
+            new_pd_add_change_peer(region, peer.clone())
         });
+    }
+
+    pub fn must_add_peer(&self, region_id: u64, peer: metapb::Peer) {
+        self.add_peer(region_id, peer.clone());
         self.must_have_peer(region_id, peer);
     }
 

--- a/tests/raftstore/test_snap.rs
+++ b/tests/raftstore/test_snap.rs
@@ -13,11 +13,13 @@
 
 
 use std::fs;
+use std::time::Duration;
 use std::sync::{Arc, RwLock, Mutex};
 use std::sync::mpsc::{self, Sender};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use tikv::raftstore::Result;
+use tikv::raftstore::store::Msg;
 use tikv::util::HandyRwLock;
 use kvproto::eraftpb::{Message, MessageType};
 use kvproto::raft_serverpb::RaftMessage;
@@ -343,4 +345,90 @@ fn test_node_stale_snap() {
     must_get_none(&cluster.get_engine(3), b"k3");
     cluster.clear_send_filters();
     must_get_equal(&cluster.get_engine(3), b"k3", b"v3");
+}
+
+/// Pause Snap and wait till first append message arrives.
+pub struct SnapshotApendFilter {
+    stale: AtomicBool,
+    pending_msg: Mutex<Vec<Msg>>,
+    notifier: Mutex<Sender<()>>,
+}
+
+impl SnapshotApendFilter {
+    pub fn new(notifier: Sender<()>) -> SnapshotApendFilter {
+        SnapshotApendFilter {
+            stale: AtomicBool::new(false),
+            pending_msg: Mutex::new(vec![]),
+            notifier: Mutex::new(notifier),
+        }
+    }
+}
+
+impl Filter<Msg> for SnapshotApendFilter {
+    fn before(&self, msgs: &mut Vec<Msg>) -> Result<()> {
+        if self.stale.load(Ordering::Relaxed) {
+            return Ok(());
+        }
+        let mut to_send = vec![];
+        let mut pending_msg = self.pending_msg.lock().unwrap();
+        let mut stale = false;
+        for m in msgs.drain(..) {
+            let mut should_collect = false;
+            if let Msg::RaftMessage(ref msg) = m {
+                should_collect = !stale &&
+                                 msg.get_message().get_msg_type() == MessageType::MsgSnapshot;
+                stale = !pending_msg.is_empty() &&
+                        msg.get_message().get_msg_type() == MessageType::MsgAppend;
+            }
+            if should_collect {
+                pending_msg.push(m);
+                self.notifier.lock().unwrap().send(()).unwrap();
+            } else {
+                if stale {
+                    to_send.extend(pending_msg.drain(..));
+                }
+                to_send.push(m);
+            }
+        }
+        self.stale.store(stale, Ordering::SeqCst);
+        msgs.extend(to_send);
+        Ok(())
+    }
+}
+
+fn test_snapshot_with_append<T: Simulator>(cluster: &mut Cluster<T>) {
+    // truncate the log quickly so that we can force sending snapshot.
+    cluster.cfg.raft_store.raft_log_gc_tick_interval = 20;
+    cluster.cfg.raft_store.raft_log_gc_limit = 2;
+    cluster.cfg.raft_store.snap_mgr_gc_tick_interval = 50;
+    cluster.cfg.raft_store.snap_gc_timeout = 2;
+
+    let pd_client = cluster.pd_client.clone();
+    // Disable default max peer count check.
+    pd_client.disable_default_rule();
+    let r1 = cluster.run_conf_change();
+    pd_client.must_add_peer(r1, new_peer(2, 2));
+    pd_client.must_add_peer(r1, new_peer(3, 3));
+
+    let (tx, rx) = mpsc::channel();
+    cluster.sim.wl().add_recv_filter(4, box SnapshotApendFilter::new(tx));
+    pd_client.add_peer(r1, new_peer(4, 4));
+    rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    cluster.must_put(b"k1", b"v1");
+    cluster.must_put(b"k2", b"v2");
+    let engine1 = cluster.get_engine(4);
+    must_get_equal(&engine1, b"k1", b"v1");
+    must_get_equal(&engine1, b"k2", b"v2");
+}
+
+#[test]
+fn test_node_snapshot_with_append() {
+    let mut cluster = new_node_cluster(0, 4);
+    test_snapshot_with_append(&mut cluster);
+}
+
+#[test]
+fn test_server_snapshot_with_append() {
+    let mut cluster = new_server_cluster(0, 4);
+    test_snapshot_with_append(&mut cluster);
 }

--- a/tests/raftstore/test_snap.rs
+++ b/tests/raftstore/test_snap.rs
@@ -348,15 +348,15 @@ fn test_node_stale_snap() {
 }
 
 /// Pause Snap and wait till first append message arrives.
-pub struct SnapshotApendFilter {
+pub struct SnapshotAppendFilter {
     stale: AtomicBool,
     pending_msg: Mutex<Vec<Msg>>,
     notifier: Mutex<Sender<()>>,
 }
 
-impl SnapshotApendFilter {
-    pub fn new(notifier: Sender<()>) -> SnapshotApendFilter {
-        SnapshotApendFilter {
+impl SnapshotAppendFilter {
+    pub fn new(notifier: Sender<()>) -> SnapshotAppendFilter {
+        SnapshotAppendFilter {
             stale: AtomicBool::new(false),
             pending_msg: Mutex::new(vec![]),
             notifier: Mutex::new(notifier),
@@ -364,7 +364,7 @@ impl SnapshotApendFilter {
     }
 }
 
-impl Filter<Msg> for SnapshotApendFilter {
+impl Filter<Msg> for SnapshotAppendFilter {
     fn before(&self, msgs: &mut Vec<Msg>) -> Result<()> {
         if self.stale.load(Ordering::Relaxed) {
             return Ok(());
@@ -411,14 +411,14 @@ fn test_snapshot_with_append<T: Simulator>(cluster: &mut Cluster<T>) {
     pd_client.must_add_peer(r1, new_peer(3, 3));
 
     let (tx, rx) = mpsc::channel();
-    cluster.sim.wl().add_recv_filter(4, box SnapshotApendFilter::new(tx));
+    cluster.sim.wl().add_recv_filter(4, box SnapshotAppendFilter::new(tx));
     pd_client.add_peer(r1, new_peer(4, 4));
     rx.recv_timeout(Duration::from_secs(3)).unwrap();
     cluster.must_put(b"k1", b"v1");
     cluster.must_put(b"k2", b"v2");
-    let engine1 = cluster.get_engine(4);
-    must_get_equal(&engine1, b"k1", b"v1");
-    must_get_equal(&engine1, b"k2", b"v2");
+    let engine4 = cluster.get_engine(4);
+    must_get_equal(&engine4, b"k1", b"v1");
+    must_get_equal(&engine4, b"k2", b"v2");
 }
 
 #[test]


### PR DESCRIPTION
In some rare cases, a snapshot and following committed entries will arrived at follower at once. Because we didn't check whether the peer is applying a snapshot when applying committed entries, it may lead to data inconsistency.

@siddontang @hhkbp2 PTAL