### PR TITLE
Check system parameters before startup

### DIFF
--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -207,7 +207,6 @@ fn initial_metric(matches: &Matches, config: &toml::Value, node_id: Option<u64>)
 }
 
 fn check_system_config(matches: &Matches, config: &toml::Value) {
-    // Panic when the maximum number of open file descriptors less than opts.max_open_files.
     let max_open_files = get_integer_value("",
                                            "rocksdb.max-open-files",
                                            matches,
@@ -215,7 +214,7 @@ fn check_system_config(matches: &Matches, config: &toml::Value) {
                                            Some(40960),
                                            |v| v.as_integer());
     if let Err(e) = util::config::check_max_open_fds(max_open_files as u64) {
-        panic!("{:?}", e);
+        panic!("check rocksdb max open files err {:?}", e)
     }
 
     if let Err(e) = util::config::check_kernel_params() {
@@ -937,7 +936,6 @@ fn main() {
         None => toml::Value::Integer(0),
     };
 
-
     initial_log(&matches, &config);
 
     // Print version information.
@@ -945,7 +943,7 @@ fn main() {
 
     panic_hook::set_exit_hook();
 
-    // Before any set up, check system configuration.
+    // Before any startup, check system configuration.
     check_system_config(&matches, &config);
 
     let addr = get_string_value("A",

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -206,8 +206,6 @@ fn initial_metric(matches: &Matches, config: &toml::Value, node_id: Option<u64>)
                          &push_job);
 }
 
-const SOMAXCONN: u64 = 32768;
-
 fn check_system_config(matches: &Matches, config: &toml::Value) {
     // Panic when the maximum number of open file descriptors less than opts.max_open_files.
     let max_open_files = get_integer_value("",
@@ -220,8 +218,8 @@ fn check_system_config(matches: &Matches, config: &toml::Value) {
         panic!("{:?}", e);
     }
 
-    if let Err(e) = util::config::check_net_max_conn(SOMAXCONN) {
-        panic!("{:?}", e);
+    if let Err(e) = util::config::check_kernel_params() {
+        warn!("{:?}", e);
     }
     // TODO: swap
 }

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -221,7 +221,6 @@ fn check_system_config(matches: &Matches, config: &toml::Value) {
     if let Err(e) = util::config::check_kernel_params() {
         warn!("{:?}", e);
     }
-    // TODO: swap
 }
 
 fn get_rocksdb_option(matches: &Matches, config: &toml::Value) -> RocksdbOptions {

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -217,7 +217,7 @@ fn check_system_config(matches: &Matches, config: &toml::Value) {
         panic!("check rocksdb max open files err {:?}", e)
     }
 
-    if let Err(e) = util::config::check_kernel_params() {
+    for e in util::config::check_kernel() {
         warn!("{:?}", e);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@
 #![feature(slice_patterns)]
 #![feature(box_syntax)]
 #![feature(const_fn)]
-#![feature(slice_concat_ext)]
 #![cfg_attr(feature = "dev", plugin(clippy))]
 #![cfg_attr(not(feature = "dev"), allow(unknown_lints))]
 #![recursion_limit="100"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 #![feature(slice_patterns)]
 #![feature(box_syntax)]
 #![feature(const_fn)]
+#![feature(slice_concat_ext)]
 #![cfg_attr(feature = "dev", plugin(clippy))]
 #![cfg_attr(not(feature = "dev"), allow(unknown_lints))]
 #![recursion_limit="100"]

--- a/src/util/config.rs
+++ b/src/util/config.rs
@@ -173,7 +173,8 @@ pub fn check_kernel_params() -> Result<(), ConfigError> {
     const SWAP_PATH: &'static str = "/proc/sys/vm/swappiness";
     const SWAP_SUGGEST: &'static str = "0";
 
-    let params: Vec<(&str, Box<Fn(&str) -> Result<(), ConfigError>>)> = vec![
+    type Checker = Fn(&str) -> Result<(), ConfigError>;
+    let params: Vec<(&str, Box<Checker>)> = vec![
         (SOMAXCONN_PATH,
         box |s| {
             match s.parse::<u64>() {

--- a/src/util/config.rs
+++ b/src/util/config.rs
@@ -165,7 +165,8 @@ mod check_kernel {
 
     use super::ConfigError;
 
-    type Checker = Fn(i64, i64) -> bool;
+    // pub for tests.
+    pub type Checker = Fn(i64, i64) -> bool;
 
     // pub for tests.
     pub fn check_kernel_params(param_path: &str,
@@ -347,18 +348,18 @@ mod test {
     #[test]
     fn test_check_kernel() {
         use std::i64;
+        use super::check_kernel::{check_kernel_params, Checker};
 
         // The range of vm.swappiness is from 0 to 100.
-        assert_eq!(super::check_kernel::check_kernel_params("/proc/sys/vm/swappiness",
-                                                            i64::MAX,
-                                                            box |got, expect| got == expect)
-                       .is_ok(),
-                   false);
-        assert_eq!(super::check_kernel::check_kernel_params("/proc/sys/vm/swappiness",
-                                                            i64::MAX,
-                                                            box |got, expect| got < expect)
-                       .is_ok(),
-                   true);
+        let table: Vec<(&str, i64, Box<Checker>, bool)> = vec![
+            ("/proc/sys/vm/swappiness", i64::MAX, Box::new(|got, expect| got == expect), false),
+
+            ("/proc/sys/vm/swappiness", i64::MAX, Box::new(|got, expect| got < expect), true),
+        ];
+
+        for (path, expect, checker, is_ok) in table {
+            assert_eq!(check_kernel_params(path, expect, checker).is_ok(), is_ok);
+        }
     }
 
     #[test]

--- a/src/util/config.rs
+++ b/src/util/config.rs
@@ -155,7 +155,7 @@ pub fn check_max_open_fds(expect: u64) -> Result<(), ConfigError> {
 ///   - `net.ipv4.tcp_syncookies` should be 0
 ///   - `vm.swappiness` shoud be 0
 ///
-/// Note that: It only works **Linux** platform.
+/// Note that: It works on **Linux** only.
 #[cfg(target_os = "linux")]
 pub fn check_kernel_params() -> Result<(), ConfigError> {
     use std::fs;
@@ -198,7 +198,6 @@ pub fn check_kernel_params() -> Result<(), ConfigError> {
             }
             Ok(())
         }),
-
         (SWAP_PATH,
         box |s| {
             if s != SWAP_SUGGEST {

--- a/src/util/config.rs
+++ b/src/util/config.rs
@@ -191,10 +191,10 @@ pub fn check_kernel_params() -> Result<(), ConfigError> {
         (TCP_SYNCOOKIES_PATH,
         box |s| {
             if s != TCP_SYNCOOKIES_SUGGEST {
-                return Err(ConfigError::Limits(format!("net.ipv4.tcp_syncookies expect to be {}, \
-                                                        got {}",
-                                                        TCP_SYNCOOKIES_SUGGEST,
-                                                        s)));
+                return Err(ConfigError::Limits(format!("net.ipv4.tcp_syncookies, got {}, expect \
+                                                        to be {}",
+                                                        s,
+                                                        TCP_SYNCOOKIES_SUGGEST)));
             }
             Ok(())
         }),
@@ -202,9 +202,9 @@ pub fn check_kernel_params() -> Result<(), ConfigError> {
         (SWAP_PATH,
         box |s| {
             if s != SWAP_SUGGEST {
-                return Err(ConfigError::Limits(format!("vm.swappiness expect to be {}, got {}",
-                                                        SWAP_SUGGEST,
-                                                        s)));
+                return Err(ConfigError::Limits(format!("vm.swappiness got {}, expect to be {}",
+                                                        s,
+                                                        SWAP_SUGGEST)));
             }
             Ok(())
         }),

--- a/src/util/config.rs
+++ b/src/util/config.rs
@@ -182,19 +182,22 @@ mod check_kernel {
             .parse::<i64>()
             .map_err(|e| ConfigError::Limit(format!("check_kernel_params failed {}", e))));
 
+        let mut param = String::new();
+        // skip 3, ["", "proc", "sys", ...]
+        for path in param_path.split('/').skip(3) {
+            param.push_str(path);
+            param.push('.');
+        }
+        param.pop();
+
         if !checker(got, expect) {
-            let mut param = String::new();
-
-            // skip 3, ["", "proc", "sys", ...]
-            for path in param_path.split('/').skip(3) {
-                param.push_str(path);
-                param.push('.');
-            }
-            param.pop();
-
-            return Err(ConfigError::Limit(format!("{} got {}, expect {}", param, got, expect)));
+            return Err(ConfigError::Limit(format!("kernel parameters {} got {}, expect {}",
+                                                  param,
+                                                  got,
+                                                  expect)));
         }
 
+        info!("kernel parameters {}: {}", param, got);
         Ok(())
     }
 


### PR DESCRIPTION
This PR check various system parameters before TiKV startup.

Panic when those check failed:

 * the maximum number of open file descriptors

Warn when those check failed:

 * net.core.somaxconn
 * net.ipv4.tcp_syncookies
 * vm.swappiness


Close #1263 

PTAL @siddontang  @BusyJay  @ngaut 