### PR TITLE
tikv-ctl: mvcc support both encoded/unencoded key.

### DIFF
--- a/src/bin/tikv-ctl.rs
+++ b/src/bin/tikv-ctl.rs
@@ -205,10 +205,10 @@ pub struct MvccKv<T> {
 
 pub fn gen_mvcc_iter<T: MvccDeserializable>(db: &DB,
                                             key_prefix: &str,
-                                            prefix_encoded: bool,
+                                            prefix_is_encoded: bool,
                                             mvcc_type: CfName)
                                             -> Vec<MvccKv<T>> {
-    let encoded_prefix = if prefix_encoded {
+    let encoded_prefix = if prefix_is_encoded {
         unescape(key_prefix)
     } else {
         encode_bytes(unescape(key_prefix).as_slice())

--- a/src/storage/mvcc/lock.rs
+++ b/src/storage/mvcc/lock.rs
@@ -55,6 +55,7 @@ impl LockType {
     }
 }
 
+#[derive(PartialEq, Debug)]
 pub struct Lock {
     pub lock_type: LockType,
     pub primary: Vec<u8>,

--- a/src/storage/mvcc/write.rs
+++ b/src/storage/mvcc/write.rs
@@ -58,6 +58,7 @@ impl WriteType {
     }
 }
 
+#[derive(PartialEq, Debug)]
 pub struct Write {
     pub write_type: WriteType,
     pub start_ts: u64,


### PR DESCRIPTION
Sometimes the key we want to use is from the tikv log or rocksdb, add a new flag to support both encoded/unencoded key.

@mrmiywj @BusyJay 