### PR TITLE
raftstore/store: calibrate tick with mono clock time

### DIFF
--- a/src/raft/raft.rs
+++ b/src/raft/raft.rs
@@ -320,7 +320,8 @@ impl<T: Storage> Raft<T> {
     }
 
     pub fn in_lease(&self) -> bool {
-        self.state == StateRole::Leader && self.check_quorum
+        self.state == StateRole::Leader && self.check_quorum &&
+        self.election_elapsed < self.election_timeout
     }
 
     fn quorum(&self) -> usize {

--- a/src/raftstore/store/clocktime.rs
+++ b/src/raftstore/store/clocktime.rs
@@ -26,20 +26,19 @@ mod inner {
 
 #[cfg(not(any(target_os = "macos")))]
 mod inner {
+    use std::io;
     use time::Timespec;
     use libc;
 
-    fn now_monotonic_raw_time() -> Timespec {
+    pub fn now_monotonic_raw_clocktime() -> Timespec {
         let mut t = libc::timespec {
             tv_sec: 0,
             tv_nsec: 0,
         };
-        let res = unsafe {
-            libc::clock_gettime(libc::CLOCK_MONOTONIC_RAW, &mut t);
-        };
+        let res = unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC_RAW, &mut t) };
         if res == -1 {
-            panic!(io::Error::last_os_error().description());
+            panic!(io::Error::last_os_error());
         }
-        Timespec::new(t.tv_sec, t.tv_nsec)
+        Timespec::new(t.tv_sec, t.tv_nsec as i32)
     }
 }

--- a/src/raftstore/store/clocktime.rs
+++ b/src/raftstore/store/clocktime.rs
@@ -1,0 +1,45 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub use self::inner::now_monotonic_raw_clocktime;
+
+#[cfg(any(target_os = "macos"))]
+mod inner {
+    use time::{self, Timespec};
+
+    pub fn now_monotonic_raw_clocktime() -> Timespec {
+        // TODO Add monotonic raw clock time impl for macos
+        // Currently use the `time::get_time()` instead.
+        time::get_time()
+    }
+}
+
+#[cfg(not(any(target_os = "macos")))]
+mod inner {
+    use time::Timespec;
+    use libc;
+
+    fn now_monotonic_raw_time() -> Timespec {
+        let mut t = libc::timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        let res = unsafe {
+            libc::clock_gettime(libc::CLOCK_MONOTONIC_RAW, &mut t);
+        };
+        if res == -1 {
+            panic!(io::Error::last_os_error().description());
+        }
+        Timespec::new(t.tv_sec, t.tv_nsec)
+    }
+}

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -43,6 +43,7 @@ const DEFAULT_LOCK_CF_COMPACT_INTERVAL_SECS: u64 = 60 * 10; // 10 min
 // a peer should consider itself as a stale peer that is out of region.
 const DEFAULT_MAX_LEADER_MISSING_SECS: u64 = 2 * 60 * 60;
 const DEFAULT_SNAPSHOT_APPLY_BATCH_SIZE: usize = 1024 * 1024 * 10; // 10m
+const DEFAULT_CALIBRATE_TICK_WITH_CLOCKTIME: bool = true;
 
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -99,6 +100,13 @@ pub struct Config {
     pub max_leader_missing_duration: Duration,
 
     pub snap_apply_batch_size: usize,
+
+    /// It uses ticks as software clock in Raft implementation.
+    /// The system load and process/thread scheduling will impact the ticks.
+    /// If `calibrate_tick_with_clocktime` is set to `true`, the system's monotonic raw clocktime
+    /// would be used to calibrate the ticks, in order to improve the preciseness of leader lease,
+    /// which is important for doing lease reads in Raft leader.
+    pub calibrate_tick_with_clocktime: bool,
 }
 
 impl Default for Config {
@@ -129,6 +137,7 @@ impl Default for Config {
             max_leader_missing_duration: Duration::from_secs(DEFAULT_MAX_LEADER_MISSING_SECS),
             snap_apply_batch_size: DEFAULT_SNAPSHOT_APPLY_BATCH_SIZE,
             lock_cf_compact_interval_secs: DEFAULT_LOCK_CF_COMPACT_INTERVAL_SECS,
+            calibrate_tick_with_clocktime: DEFAULT_CALIBRATE_TICK_WITH_CLOCKTIME,
         }
     }
 }

--- a/src/raftstore/store/mod.rs
+++ b/src/raftstore/store/mod.rs
@@ -19,6 +19,7 @@ pub mod transport;
 pub mod bootstrap;
 pub mod cmd_resp;
 pub mod util;
+pub mod clocktime;
 
 mod store;
 mod peer;

--- a/src/raftstore/store/util.rs
+++ b/src/raftstore/store/util.rs
@@ -13,6 +13,7 @@
 
 use std::option::Option;
 
+use time::{self, Timespec};
 use uuid::Uuid;
 
 use kvproto::metapb;
@@ -85,6 +86,12 @@ pub fn conf_change_type_str(conf_type: &eraftpb::ConfChangeType) -> &'static str
 pub fn is_epoch_stale(epoch: &metapb::RegionEpoch, check_epoch: &metapb::RegionEpoch) -> bool {
     epoch.get_version() < check_epoch.get_version() ||
     epoch.get_conf_ver() < check_epoch.get_conf_ver()
+}
+
+pub fn format_clocktime(ts: Timespec) -> String {
+    let tm = time::at(ts);
+    let res = time::strftime("%Y-%m-%d %H:%M:%S", &tm).unwrap();
+    res + &format!("{}", tm.tm_nsec)
 }
 
 #[cfg(test)]

--- a/src/raftstore/store/util.rs
+++ b/src/raftstore/store/util.rs
@@ -142,8 +142,9 @@ mod tests {
     #[test]
     fn test_format_clocktime() {
         let s = String::from("+0800 2016-11-10 15:01:37");
-        let ts = time::strptime(&s, "%z %Y-%m-%d %H:%M:%S").unwrap().to_timespec();
-        let expect = s + " 0";
+        let tm = time::strptime(&s, "%z %Y-%m-%d %H:%M:%S").unwrap();
+        let ts = tm.to_timespec();
+        let expect = time::strftime("%z %Y-%m-%d %H:%M:%S", &tm).unwrap() + " 0";
         assert_eq!(expect, format_clocktime(ts));
     }
 }

--- a/src/raftstore/store/util.rs
+++ b/src/raftstore/store/util.rs
@@ -142,9 +142,8 @@ mod tests {
     #[test]
     fn test_format_clocktime() {
         let s = String::from("+0800 2016-11-10 15:01:37");
-        let tm = time::strptime(&s, "%z %Y-%m-%d %H:%M:%S").unwrap();
-        let ts = tm.to_timespec();
-        let expect = time::strftime("%z %Y-%m-%d %H:%M:%S", &tm).unwrap() + " 0";
+        let ts = time::strptime(&s, "%z %Y-%m-%d %H:%M:%S").unwrap().to_timespec();
+        let expect = time::strftime("%z %Y-%m-%d %H:%M:%S", &time::at(ts)).unwrap() + " 0";
         assert_eq!(expect, format_clocktime(ts));
     }
 }

--- a/src/raftstore/store/util.rs
+++ b/src/raftstore/store/util.rs
@@ -90,12 +90,13 @@ pub fn is_epoch_stale(epoch: &metapb::RegionEpoch, check_epoch: &metapb::RegionE
 
 pub fn format_clocktime(ts: Timespec) -> String {
     let tm = time::at(ts);
-    let res = time::strftime("%Y-%m-%d %H:%M:%S", &tm).unwrap();
-    res + &format!("{}", tm.tm_nsec)
+    let res = time::strftime("%z %Y-%m-%d %H:%M:%S", &tm).unwrap();
+    res + &format!(" {}", tm.tm_nsec)
 }
 
 #[cfg(test)]
 mod tests {
+    use time;
     use kvproto::metapb;
 
     use super::*;
@@ -136,5 +137,13 @@ mod tests {
         assert!(remove_peer(&mut region, 1).is_none());
         assert!(find_peer(&region, 1).is_none());
 
+    }
+
+    #[test]
+    fn test_format_clocktime() {
+        let s = String::from("+0800 2016-11-10 15:01:37");
+        let ts = time::strptime(&s, "%z %Y-%m-%d %H:%M:%S").unwrap().to_timespec();
+        let expect = s + " 0";
+        assert_eq!(expect, format_clocktime(ts));
     }
 }

--- a/tests/raftstore/mod.rs
+++ b/tests/raftstore/mod.rs
@@ -33,3 +33,4 @@ mod test_stats;
 mod test_snap;
 mod test_down_peers;
 mod test_stale_peer;
+mod test_lease_read;

--- a/tests/raftstore/test_lease_read.rs
+++ b/tests/raftstore/test_lease_read.rs
@@ -61,6 +61,8 @@ fn test_lease_read<T: Simulator>(cluster: &mut Cluster<T>, calibrate_tick: bool)
     // Disable default max peer number check.
     pd_client.disable_default_rule();
 
+    cluster.cfg.raft_store.raft_base_tick_interval = 20;
+
     if !calibrate_tick {
         // Disable calibrating tick with clocktime.
         cluster.cfg.raft_store.calibrate_tick_with_clocktime = false;
@@ -109,7 +111,7 @@ fn test_lease_read<T: Simulator>(cluster: &mut Cluster<T>, calibrate_tick: bool)
             }
         };
         if start_time.elapsed() >= timeout {
-            panic!("failed to elect leader in time");
+            panic!("failed to elect new leader in time");
         }
     }
 

--- a/tests/raftstore/test_lease_read.rs
+++ b/tests/raftstore/test_lease_read.rs
@@ -1,0 +1,177 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A module contains test cases for lease read on Raft leader.
+
+use std::thread;
+use std::time::{Instant, Duration};
+
+use kvproto::metapb::{Peer, Region};
+use kvproto::raft_cmdpb::CmdType;
+use tikv::raftstore::{Error, Result};
+use tikv::util::escape;
+
+use super::cluster::{Cluster, Simulator};
+use super::node::new_node_cluster;
+use super::server::new_server_cluster;
+use super::transport_simulate::*;
+use super::util::*;
+
+// Perform a local read on the specified peer.
+fn do_local_read_on_peer<T: Simulator>(cluster: &mut Cluster<T>,
+                                       peer: Peer,
+                                       region: Region,
+                                       key: &[u8],
+                                       timeout: Duration)
+                                       -> Result<Vec<u8>> {
+    let mut request = new_request(region.get_id(),
+                                  region.get_region_epoch().clone(),
+                                  vec![new_get_cmd(key)],
+                                  false);
+    request.mut_header().set_peer(peer);
+    let mut resp = try!(cluster.call_command(request, timeout));
+    if resp.get_header().has_error() {
+        return Err(Error::Other(box_err!(resp.mut_header().take_error().take_message())));
+    }
+    assert_eq!(resp.get_responses().len(), 1);
+    assert_eq!(resp.get_responses()[0].get_cmd_type(), CmdType::Get);
+    let mut get = resp.mut_responses()[0].take_get();
+    assert!(get.has_value());
+    Ok(get.take_value())
+}
+
+// A helper function for testing the lease reads on a raft leader with slow ticks.
+// The leader with slow ticks could not tell that its lease has expired without delay.
+// It will still serve the lease read, and cause external inconsistency.
+// When `calibrate_tick` is set to `true`, the system's monotonic clocktime is used to
+// calibrate ticks. So the leader could reject lease read when the time passes its lease,
+// even when it has slow ticks.
+fn test_lease_read<T: Simulator>(cluster: &mut Cluster<T>, calibrate_tick: bool) {
+    let pd_client = cluster.pd_client.clone();
+    // Disable default max peer number check.
+    pd_client.disable_default_rule();
+
+    if !calibrate_tick {
+        // Disable calibrating tick with clocktime.
+        cluster.cfg.raft_store.calibrate_tick_with_clocktime = false;
+    }
+    let election_timeout = Duration::from_millis(cluster.cfg.raft_store.raft_base_tick_interval) *
+                           cluster.cfg.raft_store.raft_election_timeout_ticks as u32;
+    let mut slow_tick_config = cluster.cfg.clone();
+    // Increase tick interval to simulate the slow tick.
+    slow_tick_config.raft_store.raft_base_tick_interval = 100;
+    let slow_election_timeout = Duration::from_millis(slow_tick_config.raft_store
+        .raft_base_tick_interval) *
+                                slow_tick_config.raft_store.raft_election_timeout_ticks as u32;
+    let slow_node_id = 3u64;
+    let slow_store_id = 3u64;
+    let slow_peer = new_peer(slow_store_id, slow_node_id);
+    cluster.set_node_config(slow_node_id, slow_tick_config);
+    cluster.run();
+
+    // Write the initial value for a key.
+    let key = b"k";
+    cluster.must_put(key, b"v1");
+    // Force `slow_peer` to become leader.
+    let region = cluster.get_region(key);
+    let region_id = region.get_id();
+    cluster.must_transfer_leader(region_id, slow_peer.clone());
+    assert_eq!(cluster.leader_of_region(region_id), Some(slow_peer.clone()));
+
+    // Isolate `slow_peer` from other peers.
+    cluster.add_send_filter(IsolationFilterFactory::new(slow_store_id));
+
+    // After a long time passed, a new leader should be elected.
+    if calibrate_tick {
+        thread::sleep(slow_election_timeout * 2);
+    } else {
+        thread::sleep(election_timeout * 2);
+    }
+    let leader_store_id;
+    let timeout = Duration::from_secs(3);
+    let start_time = Instant::now();
+    loop {
+        cluster.reset_leader_of_region(region_id);
+        if let Some(p) = cluster.leader_of_region(region_id) {
+            if p != slow_peer {
+                leader_store_id = p.get_store_id();
+                break;
+            }
+        };
+        if start_time.elapsed() >= timeout {
+            panic!("failed to elect leader in time");
+        }
+    }
+
+    // Write a new value for `key`, and verify it takes effect.
+    let engine = cluster.get_engine(leader_store_id);
+    must_get_equal(&engine, key, b"v1");
+    cluster.must_put(key, b"v2");
+    assert_eq!(b"v2".to_vec(), cluster.must_get(b"k").unwrap());
+    must_get_equal(&engine, b"k", b"v2");
+
+    // Check that the value for `key` in `slow_peer` db doesn't change by previous modify.
+    let slow_peer_engine = cluster.get_engine(slow_store_id);
+    must_get_equal(&slow_peer_engine, b"k", b"v1");
+
+    // And then ensure the local read returns the stale value.
+    match do_local_read_on_peer(cluster, slow_peer.clone(), region, key, timeout) {
+        Ok(value) => {
+            if calibrate_tick {
+                panic!("should not read out value {} for key {} if calibrating ticks",
+                       escape(&value),
+                       escape(key))
+            } else if value != b"v1" {
+                panic!("key {}, expect value {}, got {}",
+                       escape(key),
+                       escape(b"v1"),
+                       escape(&value))
+            }
+        }
+        Err(e) => {
+            if !calibrate_tick {
+                panic!("failed to do local read for key {}, err {:?}",
+                       escape(key),
+                       e)
+            }
+        }
+    }
+}
+
+#[test]
+fn test_node_stale_lease_read() {
+    let count = 3;
+    let mut cluster = new_node_cluster(0, count);
+    test_lease_read(&mut cluster, false);
+}
+
+#[test]
+fn test_server_stale_lease_read() {
+    let count = 3;
+    let mut cluster = new_server_cluster(0, count);
+    test_lease_read(&mut cluster, false);
+}
+
+#[test]
+fn test_node_consistent_lease_read() {
+    let count = 3;
+    let mut cluster = new_node_cluster(0, count);
+    test_lease_read(&mut cluster, true);
+}
+
+#[test]
+fn test_server_consistent_lease_read() {
+    let count = 3;
+    let mut cluster = new_server_cluster(0, count);
+    test_lease_read(&mut cluster, true);
+}

--- a/tests/raftstore/test_lease_read.rs
+++ b/tests/raftstore/test_lease_read.rs
@@ -99,16 +99,18 @@ fn test_lease_read<T: Simulator>(cluster: &mut Cluster<T>, calibrate_tick: bool)
     } else {
         thread::sleep(election_timeout * 2);
     }
+
+    // Remove `slow_peer` from the other peers for the test codes to get new leader easily.
+    // It's not part of the logic for this test case.
+    pd_client.must_remove_peer(region_id, slow_peer.clone());
+
     let leader_store_id;
     let timeout = Duration::from_secs(5);
     let start_time = Instant::now();
     loop {
-        cluster.reset_leader_of_region(region_id);
         if let Some(p) = cluster.leader_of_region(region_id) {
-            if p != slow_peer {
-                leader_store_id = p.get_store_id();
-                break;
-            }
+            leader_store_id = p.get_store_id();
+            break;
         };
         if start_time.elapsed() >= timeout {
             panic!("failed to elect new leader in time");

--- a/tests/raftstore/test_lease_read.rs
+++ b/tests/raftstore/test_lease_read.rs
@@ -98,7 +98,7 @@ fn test_lease_read<T: Simulator>(cluster: &mut Cluster<T>, calibrate_tick: bool)
         thread::sleep(election_timeout * 2);
     }
     let leader_store_id;
-    let timeout = Duration::from_secs(3);
+    let timeout = Duration::from_secs(5);
     let start_time = Instant::now();
     loop {
         cluster.reset_leader_of_region(region_id);

--- a/tests/raftstore/transport_simulate.rs
+++ b/tests/raftstore/transport_simulate.rs
@@ -500,15 +500,15 @@ pub struct RandomLatencyFilter {
 }
 
 impl RandomLatencyFilter {
-    pub fn new(rate: u32) -> RandomLatencyFilter {
+    pub fn new(delay_rate: u32) -> RandomLatencyFilter {
         RandomLatencyFilter {
-            delay_rate: rate,
+            delay_rate: delay_rate,
             delayed_msgs: Mutex::new(vec![]),
         }
     }
 
     fn will_delay(&self, _: &RaftMessage) -> bool {
-        rand::random::<u32>() % 100u32 >= self.delay_rate
+        rand::random::<u32>() % 100u32 <= self.delay_rate
     }
 }
 


### PR DESCRIPTION
Fix issue #964.

This PR adds tick calibration using the system's monotonic raw clock time. 
Everytime when `Store::tick()` triggers, the monotonic raw clock time will be used to calculate the passed time and the actual tick number it should run.
A config option is added for turning on/off this calibration.

PTAL @siddontang @BusyJay 