### PR TITLE
fill cache

### DIFF
--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -35,7 +35,7 @@ impl<'a> fmt::Debug for MvccTxn<'a> {
 impl<'a> MvccTxn<'a> {
     pub fn new(snapshot: &'a Snapshot, start_ts: u64, mode: Option<ScanMode>) -> MvccTxn<'a> {
         MvccTxn {
-            /* Todo: use session variable to indicate fill cache or not */
+            // Todo: use session variable to indicate fill cache or not
             reader: MvccReader::new(snapshot, mode, true /* fill_cache */),
             start_ts: start_ts,
             writes: vec![],

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -282,7 +282,7 @@ fn process_read(cid: u64, mut cmd: Command, ch: SendCh<Msg>, snapshot: Box<Snaps
         }
         // Scans locks with timestamp <= `max_ts`
         Command::ScanLock { max_ts, .. } => {
-            let mut reader = MvccReader::new(snapshot.as_ref(), Some(ScanMode::Forward));
+            let mut reader = MvccReader::new(snapshot.as_ref(), Some(ScanMode::Forward), true);
             let res = reader.scan_lock(None, |lock| lock.ts <= max_ts, None)
                 .map_err(Error::from)
                 .and_then(|(v, _)| {
@@ -304,7 +304,7 @@ fn process_read(cid: u64, mut cmd: Command, ch: SendCh<Msg>, snapshot: Box<Snaps
         // Scan the locks with timestamp `start_ts`, then either commit them if the command has
         // commit timestamp populated or rollback otherwise.
         Command::ResolveLock { ref ctx, start_ts, commit_ts, ref mut scan_key, .. } => {
-            let mut reader = MvccReader::new(snapshot.as_ref(), Some(ScanMode::Forward));
+            let mut reader = MvccReader::new(snapshot.as_ref(), Some(ScanMode::Forward), true);
             let res = reader.scan_lock(scan_key.take(),
                            |lock| lock.ts == start_ts,
                            Some(RESOLVE_LOCK_BATCH_SIZE))
@@ -331,7 +331,7 @@ fn process_read(cid: u64, mut cmd: Command, ch: SendCh<Msg>, snapshot: Box<Snaps
         }
         // Collects garbage.
         Command::Gc { ref ctx, safe_point, ref mut scan_key, .. } => {
-            let mut reader = MvccReader::new(snapshot.as_ref(), Some(ScanMode::Forward));
+            let mut reader = MvccReader::new(snapshot.as_ref(), Some(ScanMode::Forward), true);
             let res = reader.scan_keys(scan_key.take(), GC_BATCH_SIZE)
                 .map_err(Error::from)
                 .and_then(|(keys, next_start)| {

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -29,14 +29,14 @@ impl<'a> SnapshotStore<'a> {
     }
 
     pub fn get(&self, key: &Key) -> Result<Option<Value>> {
-        let mut reader = MvccReader::new(self.snapshot, None);
+        let mut reader = MvccReader::new(self.snapshot, None, true);
         let v = try!(reader.get(key, self.start_ts));
         Ok(v)
     }
 
     pub fn batch_get(&self, keys: &[Key]) -> Result<Vec<Result<Option<Value>>>> {
         // TODO: sort the keys and use ScanMode::Forward
-        let mut reader = MvccReader::new(self.snapshot, None);
+        let mut reader = MvccReader::new(self.snapshot, None, true);
         let mut results = Vec::with_capacity(keys.len());
         for k in keys {
             results.push(reader.get(k, self.start_ts).map_err(Error::from));
@@ -47,7 +47,7 @@ impl<'a> SnapshotStore<'a> {
     /// Create a scanner.
     /// when key_only is true, all the returned value will be empty.
     pub fn scanner(&self, mode: ScanMode, key_only: bool) -> Result<StoreScanner> {
-        let mut reader = MvccReader::new(self.snapshot, Some(mode));
+        let mut reader = MvccReader::new(self.snapshot, Some(mode), true);
         reader.set_key_only(key_only);
         Ok(StoreScanner {
             reader: reader,


### PR DESCRIPTION
ref https://github.com/pingcap/tikv/issues/1244
InnoDB use LRU list to cache pages, the LRU list is split into old list and new list two parts, when a page is read from disk, it will be added to the new list, when the page is readed again it will be moved to the old list, SQL like `select * from t` will just flush the new part of LRU, this will not decrease the cache hit rate a lot.
RocksDB use a LRU list to cache blocks, and use `ReadOptions.fill_cache` to control the behavior of fill cache or not. MyRocks has a session variable named `skip_fill_cache`, the default value is false, it means always fill cache, when user set `skip_fill_cache=true`(eg. dump the database), blocks will not fill cache.
Currently we fill cache just depend on the operation's type, if it is a scan operation we don't fill cache, and the otherwise we fill cache, this is too rough. We should support configure the behavior of fill cache or not by set session variable.

PTAL @siddontang @ngaut @BusyJay 