### PR TITLE
ci: fix compile error with old nightly rustc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,21 @@ matrix:
   include:
     - os: linux
       rust: nightly
-      compiler: g++
-      env: COMPILER=g++-4.8
+      env: COMPILER=g++-4.8 RUSTC_DATE=2016-10-06
+      addons:
+         apt:
+            sources: ['ubuntu-toolchain-r-test']
+            packages: ['g++-4.8', 'zlib1g-dev', 'libbz2-dev', 'libsnappy-dev', 'curl', 'libdw-dev', 'libelf-dev', 'elfutils', 'binutils-dev']
+    - os: linux
+      rust: nightly
+      env: COMPILER=g++-4.8 RUSTC_DATE=2016-08-06 ENABLE_FEATURES=default SKIP_TESTS=true
       addons:
          apt:
             sources: ['ubuntu-toolchain-r-test']
             packages: ['g++-4.8', 'zlib1g-dev', 'libbz2-dev', 'libsnappy-dev', 'curl', 'libdw-dev', 'libelf-dev', 'elfutils', 'binutils-dev']
     - os: osx
-      compiler: clang++
-      env: COMPILER=clang++
       rust: nightly
+      env: COMPILER=clang++ RUSTC_DATE=2016-10-06
 
 install:
   - export LOCAL_DIR=$HOME/.cache/

--- a/benches/bin/bench-tikv.rs
+++ b/benches/bin/bench-tikv.rs
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(stable_features)]
+#![feature(mpsc_recv_timeout)]
 #![feature(plugin)]
 #![feature(test)]
 #![feature(fnbox)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@
 // limitations under the License.
 
 #![crate_type = "lib"]
+#![allow(stable_features)]
+#![feature(mpsc_recv_timeout)]
 #![feature(test)]
 #![feature(optin_builtin_traits)]
 #![feature(btree_range, collections_bound)]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(stable_features)]
+#![feature(mpsc_recv_timeout)]
 #![feature(plugin)]
 #![feature(test)]
 #![cfg_attr(feature = "dev", plugin(clippy))]

--- a/travis-build/Makefile
+++ b/travis-build/Makefile
@@ -53,7 +53,7 @@ ${LOCAL_DIR}/bin/pd-server:
 	cp bin/pd-server ${LOCAL_DIR}/bin/pd-server
 
 prepare_rust:
-	sh ~/rust/lib/rustlib/uninstall.sh && sh ~/rust-installer/rustup.sh --date=2016-10-06 --prefix=~/rust --disable-sudo --channel=nightly
+	sh ~/rust/lib/rustlib/uninstall.sh && sh ~/rust-installer/rustup.sh --date=${RUSTC_DATE} --prefix=~/rust --disable-sudo --channel=nightly
 
 prepare-rustfmt: | prepare_rust
 	cargo install rustfmt || exit 0

--- a/travis-build/test.sh
+++ b/travis-build/test.sh
@@ -32,11 +32,18 @@ if [ $? -eq 0 ]; then
     export PD_ENDPOINTS=127.0.0.1:2379
 fi
 
-export ENABLE_FEATURES=dev
+if [[ "$ENABLE_FEATURES" = "" ]]; then
+    export ENABLE_FEATURES=dev
+fi
 export LOG_FILE=tests.log
 export RUST_TEST_THREADS=1
 export RUSTFLAGS=-Dwarnings
-make test 2>&1 | tee tests.out
+if [[ "$SKIP_TESTS" = "" ]]; then
+    make test 2>&1 | tee tests.out
+else
+    make build
+    exit $?
+fi
 status=$?
 for case in `cat tests.out | python -c "import sys
 import re


### PR DESCRIPTION
`recv_timeout` is not stable in old nightly rustc, so we need to enable the feature explicitly. This pr also add a CI entry to make sure new code should work with old nightly rustc.

@siddontang @zhangjinpeng1987 PTAL