### PR TITLE
scheduler, mvcc: limit writebatch size for ResolveLock and GC command.

### DIFF
--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -18,7 +18,7 @@ mod write;
 mod metrics;
 
 use std::io;
-pub use self::txn::MvccTxn;
+pub use self::txn::{MvccTxn, MAX_TXN_WRITE_SIZE};
 pub use self::reader::MvccReader;
 pub use self::lock::{Lock, LockType};
 pub use self::write::{Write, WriteType};

--- a/tests/storage/test_storage.rs
+++ b/tests/storage/test_storage.rs
@@ -20,6 +20,7 @@ use super::sync_storage::SyncStorage;
 use kvproto::kvrpcpb::{Context, LockInfo};
 use tikv::storage::{Mutation, Key, KvPair, make_key};
 use tikv::storage::txn::{GC_BATCH_SIZE, RESOLVE_LOCK_BATCH_SIZE};
+use tikv::storage::mvcc::MAX_TXN_WRITE_SIZE;
 
 #[derive(Clone)]
 struct AssertionStorage(SyncStorage);
@@ -467,19 +468,20 @@ fn test_txn_store_resolve_lock() {
     store.scan_lock_ok(30, vec![]);
 }
 
-fn test_txn_store_resolve_lock_batch(n: usize) {
+fn test_txn_store_resolve_lock_batch(key_prefix_len: usize, n: usize) {
+    let prefix = String::from_utf8(vec![b'k'; key_prefix_len]).unwrap();
+    let keys: Vec<String> = (0..n).map(|i| format!("{}{}", prefix, i)).collect();
+
     let store = new_assertion_storage();
-    for i in 0..n {
-        let key = format!("k{}", i);
-        store.prewrite_ok(vec![Mutation::Put((make_key(&key.as_bytes()), b"v".to_vec()))],
+    for k in &keys {
+        store.prewrite_ok(vec![Mutation::Put((make_key(&k.as_bytes()), b"v".to_vec()))],
                           b"k1",
                           5);
     }
     store.resolve_lock_ok(5, Some(10));
-    for i in 0..n {
-        let key = format!("k{}", i);
-        store.get_ok(key.as_bytes(), 30, b"v");
-        store.get_none(key.as_bytes(), 8);
+    for k in &keys {
+        store.get_ok(k.as_bytes(), 30, b"v");
+        store.get_none(k.as_bytes(), 8);
     }
 }
 
@@ -491,7 +493,11 @@ fn test_txn_store_resolve_lock2() {
                 RESOLVE_LOCK_BATCH_SIZE,
                 RESOLVE_LOCK_BATCH_SIZE + 1,
                 RESOLVE_LOCK_BATCH_SIZE * 2] {
-        test_txn_store_resolve_lock_batch(i);
+        test_txn_store_resolve_lock_batch(1, i);
+    }
+
+    for &i in &[1, MAX_TXN_WRITE_SIZE / 2, MAX_TXN_WRITE_SIZE + 1] {
+        test_txn_store_resolve_lock_batch(i, 3);
     }
 }
 
@@ -505,19 +511,29 @@ fn test_txn_store_gc() {
     store.get_ok(b"k", 25, b"v2");
 }
 
-fn test_txn_store_gc_multiple_keys(n: usize) {
+fn test_txn_store_gc_multiple_keys(key_prefix_len: usize, n: usize) {
+    let prefix = String::from_utf8(vec![b'k'; key_prefix_len]).unwrap();
+    let keys: Vec<String> = (0..n).map(|i| format!("{}{}", prefix, i)).collect();
+
     let store = new_assertion_storage();
-    for i in 0..n {
-        let key = format!("k{}", i);
-        store.put_ok(key.as_bytes(), b"value", 5, 10);
+    for k in &keys {
+        store.put_ok(k.as_bytes(), b"v1", 5, 10);
+        store.put_ok(k.as_bytes(), b"v2", 15, 20);
     }
-    store.gc_ok(20);
+    store.gc_ok(30);
+    for k in &keys {
+        store.get_none(k.as_bytes(), 15);
+    }
 }
 
 #[test]
 fn test_txn_store_gc2() {
     for &i in &[0, 1, GC_BATCH_SIZE - 1, GC_BATCH_SIZE, GC_BATCH_SIZE + 1, GC_BATCH_SIZE * 2] {
-        test_txn_store_gc_multiple_keys(i);
+        test_txn_store_gc_multiple_keys(1, i);
+    }
+
+    for &i in &[1, MAX_TXN_WRITE_SIZE / 2, MAX_TXN_WRITE_SIZE + 1] {
+        test_txn_store_gc_multiple_keys(i, 3);
     }
 }
 


### PR DESCRIPTION
To prevent creating a too big raftlog entry.

@siddontang @zhangjinpeng1987 