### PR TITLE
enlarge scheduler latches bucket

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -184,7 +184,7 @@ scheduler-notify-capacity = 10240
 # maximum number of messages can be processed in one tick
 scheduler-messages-per-tick = 1024
 
-scheduler-concurrency = 10240
+scheduler-concurrency = 102400
 
 # scheduler's worker pool size
 scheduler-worker-pool-size = 4

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -604,7 +604,7 @@ fn build_cfg(matches: &Matches, config: &toml::Value, cluster_id: u64, addr: &st
                           "storage.scheduler-concurrency",
                           matches,
                           config,
-                          Some(10240),
+                          Some(102400),
                           |v| v.as_integer()) as usize;
     cfg.storage.sched_worker_pool_size =
         get_integer_value("",


### PR DESCRIPTION
Enlarge scheduler latches bucket. Large bucket is more friendly for load data.