### PR TITLE
raftstore: split handle ready to append + apply

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -515,7 +515,7 @@ impl Peer {
         if self.is_leader() {
             self.send(trans, ready.messages.drain(..), &mut metrics.message).unwrap_or_else(|e| {
                 // We don't care that the message is sent failed, so here just log this error.
-                info!("{} leader send messages err {:?}", self.tag, e);
+                warn!("{} leader send messages err {:?}", self.tag, e);
             })
         }
 
@@ -536,7 +536,7 @@ impl Peer {
 
         if !self.is_leader() {
             self.send(trans, ready.messages.drain(..), &mut metrics.message).unwrap_or_else(|e| {
-                info!("{} follower send messages err {:?}", self.tag, e);
+                warn!("{} follower send messages err {:?}", self.tag, e);
             })
         }
 
@@ -556,9 +556,7 @@ impl Peer {
         }))
     }
 
-    pub fn handle_raft_ready_apply(&mut self,
-                                   mut ready_result: ReadyResult)
-                                   -> Result<ReadyResult> {
+    pub fn handle_raft_ready_apply(&mut self, ready_result: &mut ReadyResult) -> Result<()> {
         let mut ready = ready_result.ready.take().unwrap_or_else(|| {
             panic!("{} must have a ready in ReadyResult", self.tag);
         });
@@ -581,7 +579,7 @@ impl Peer {
         };
 
         self.raft_group.advance(ready);
-        Ok(ready_result)
+        Ok(())
     }
 
     /// Propose a request.

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -96,6 +96,7 @@ pub enum ExecResult {
 // We can save these intermediate results in ready result.
 // We only need to care administration commands now.
 pub struct ReadyResult {
+    pub ready: Option<Ready>,
     // We can execute multi commands like 1, conf change, 2 split region, ...
     // in one ready, and outer store should handle these results sequentially too.
     pub exec_results: Vec<ExecResult>,
@@ -484,10 +485,10 @@ impl Peer {
         StaleState::Valid
     }
 
-    pub fn handle_raft_ready<T: Transport>(&mut self,
-                                           trans: &T,
-                                           metrics: &mut RaftMetrics)
-                                           -> Result<Option<ReadyResult>> {
+    pub fn handle_raft_ready_append<T: Transport>(&mut self,
+                                                  trans: &T,
+                                                  metrics: &mut RaftMetrics)
+                                                  -> Result<Option<ReadyResult>> {
         if self.mut_store().check_applying_snap() {
             // If we continue to handle all the messages, it may cause too many messages because
             // leader will send all the remaining messages to this follower, which can lead
@@ -534,6 +535,26 @@ impl Peer {
             try!(self.send(trans, ready.messages.drain(..), &mut metrics.message));
         }
 
+        slow_log!(t,
+                  "{} append {} logs, send {} messages",
+                  self.tag,
+                  ready.entries.len(),
+                  ready.messages.len());
+
+        Ok(Some(ReadyResult {
+            ready: Some(ready),
+            apply_snap_result: apply_result,
+            exec_results: vec![],
+        }))
+    }
+
+    pub fn handle_raft_ready_apply(&mut self,
+                                   mut ready_result: ReadyResult)
+                                   -> Result<ReadyResult> {
+        let mut ready = ready_result.ready.take().unwrap_or_else(|| {
+            panic!("{} must have a ready in ReadyResult", self.tag);
+        });
+
         // Call `handle_raft_commit_entries` directly here may lead to inconsistency.
         // In some cases, there will be some pending committed entries when applying a
         // snapshot. If we call `handle_raft_commit_entries` directly, these updates
@@ -541,7 +562,7 @@ impl Peer {
         // updates will soon be removed. But the soft state of raft is still be updated
         // in memory. Hence when handle ready next time, these updates won't be included
         // in `ready.committed_entries` again, which will lead to inconsistency.
-        let exec_results = if self.is_applying() {
+        ready_result.exec_results = if self.is_applying() {
             if let Some(ref mut hs) = ready.hs {
                 // Snapshot's metadata has been applied.
                 hs.set_commit(self.get_store().truncated_index());
@@ -551,21 +572,8 @@ impl Peer {
             try!(self.handle_raft_commit_entries(&ready.committed_entries))
         };
 
-        slow_log!(t,
-                  "{} handle ready, entries {}, committed entries {}, messages \
-                   {}, snapshot {}, hard state changed {}",
-                  self.tag,
-                  ready.entries.len(),
-                  ready.committed_entries.len(),
-                  ready.messages.len(),
-                  apply_result.is_some(),
-                  ready.hs.is_some());
-
         self.raft_group.advance(ready);
-        Ok(Some(ReadyResult {
-            apply_snap_result: apply_result,
-            exec_results: exec_results,
-        }))
+        Ok(ready_result)
     }
 
     /// Propose a request.

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -803,24 +803,24 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                         error!("{} handle raft ready append err: {:?}", peer.tag, e);
                         continue;
                     }
-                    Ok(Some(ready_result)) => ready_results.push((region_id, ready_result)),
+                    Ok(Some(res)) => ready_results.push((region_id, res)),
                     Ok(None) => {}
                 }
             }
         }
 
-        for (region_id, mut ready_result) in ready_results {
+        for (region_id, mut res) in ready_results {
             {
                 let peer = self.region_peers.get_mut(&region_id).unwrap();
 
-                if let Err(e) = peer.handle_raft_ready_apply(&mut ready_result) {
+                if let Err(e) = peer.handle_raft_ready_apply(&mut res) {
                     // TODO: should we panic or shutdown the store?
                     error!("{} handle raft ready err: {:?}", peer.tag, e);
                     continue;
                 }
             };
 
-            self.on_ready_result(region_id, ready_result)
+            self.on_ready_result(region_id, res)
         }
 
         PEER_RAFT_PROCESS_NANOS_COUNTER_VEC.with_label_values(&["ready"])

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -809,17 +809,14 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             }
         }
 
-        for (region_id, ready_result) in ready_results {
-            let ready_result = {
+        for (region_id, mut ready_result) in ready_results {
+            {
                 let peer = self.region_peers.get_mut(&region_id).unwrap();
 
-                match peer.handle_raft_ready_apply(ready_result) {
-                    Err(e) => {
-                        // TODO: should we panic or shutdown the store?
-                        error!("{} handle raft ready err: {:?}", peer.tag, e);
-                        continue;
-                    }
-                    Ok(ready_result) => ready_result,
+                if let Err(e) = peer.handle_raft_ready_apply(&mut ready_result) {
+                    // TODO: should we panic or shutdown the store?
+                    error!("{} handle raft ready err: {:?}", peer.tag, e);
+                    continue;
                 }
             };
 


### PR DESCRIPTION
So we can let all peers send raft message first, then do raft apply.

PTAL @ngaut @BusyJay @hhkbp2 @zhangjinpeng1987 