### PR TITLE
bin: check listen address and advertise address

### DIFF
--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -186,24 +186,18 @@ fn listen_address(matches: &Matches, config: &toml::Value) -> String {
                         "server.addr",
                         Some(DEFAULT_LISTENING_ADDR.to_owned()))
     });
-
     util::config::check_addr(&addr)
         .map_err(|e| exit_with_err(format!("{:?}", e)))
         .unwrap();
 
-    let all_addr = "0.0.0.0";
-    match addr.find(all_addr) {
-        Some(_) => {
-            info!("Start listening on {}... advertise-addr is required", addr);
+    let adv_addr = get_flag_string(matches, "advertise-addr")
+        .unwrap_or_else(|| get_toml_string(config, "server.advertise-addr", Some(addr.clone())));
+    util::config::check_addr(&adv_addr)
+        .map_err(|e| exit_with_err(format!("{:?}", e)))
+        .unwrap();
 
-            let adv_addr = get_flag_string(matches, "advertise-addr")
-                .unwrap_or_else(|| get_toml_string(config, "server.advertise-addr", None));
-
-            if let Some(_) = adv_addr.find(all_addr) {
-                exit_with_err(format!("{} is not allowed in advertise-addr", all_addr));
-            }
-        }
-        None => info!("Start listening on {}...", addr),
+    if let Some(_) = adv_addr.find("0.0.0.0") {
+        exit_with_err("0.0.0.0 is not allowed in advertise-addr".to_owned());
     }
 
     addr
@@ -664,6 +658,7 @@ fn main() {
     check_system_config(&config);
 
     let addr = listen_address(&matches, &config);
+    info!("Start listening on {}...", addr);
     let listener = bind(&addr).unwrap();
 
     let pd_endpoints = get_flag_string(&matches, "pd")


### PR DESCRIPTION
If `addr` is `0.0.0.0` then `advertise-addr` is required.
Also `0.0.0.0` is not allowed in `advertise-addr`.

Close #1332 

PTAL @siddontang @BusyJay 