### PR TITLE
reset raft term to self.term in initial, not 0

### DIFF
--- a/tests/test_raft.rs
+++ b/tests/test_raft.rs
@@ -153,7 +153,8 @@ impl Interface {
             for id in ids {
                 self.prs.insert(*id, Progress { ..Default::default() });
             }
-            self.reset(0);
+            let term = self.term;
+            self.reset(term);
         }
     }
 }


### PR DESCRIPTION
When creating a network in test, the raft's term should not be set to 0 if it has some initial state.
Corresponding code in [etcd](https://github.com/coreos/etcd/blob/master/raft/raft_test.go#L2904)
