### PR TITLE
[DNM] check promotable() in MsgTimeoutNow handling

### DIFF
--- a/src/raft/raft.rs
+++ b/src/raft/raft.rs
@@ -1276,12 +1276,18 @@ impl<T: Storage> Raft<T> {
                 self.send(m);
             }
             MessageType::MsgTimeoutNow => {
-                info!("{} [term {}] received MsgTimeoutNow from {} and starts an election to \
-                       get leadership.",
-                      self.tag,
-                      self.term,
-                      m.get_from());
-                self.campaign(CAMPAIGN_TRANSFER);
+                if self.promotable() {
+                    info!("{} [term {}] received MsgTimeoutNow from {} and starts an election to \
+                           get leadership.",
+                          self.tag,
+                          self.term,
+                          m.get_from());
+                    self.campaign(CAMPAIGN_TRANSFER);
+                } else {
+                    info!("{} received MsgTimeoutNow from {} but is not promotable",
+                          self.id,
+                          m.get_from());
+                }
             }
             MessageType::MsgReadIndex => {
                 if self.leader_id == INVALID_ID {


### PR DESCRIPTION
#1283 
If MsgTimeoutNow arrived after a node was removed, the node could start and win an election, then panic in becomeLeader