### PR TITLE
Disable data sync when loading data

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -113,6 +113,14 @@ enable-statistics = false
 # Same as rocksdb's default value (10 min).
 stats-dump-period-sec = 600
 
+# If true, then the contents of manifest and data files are not synced
+# to stable storage. Their contents remain in the OS buffers till the
+# OS decides to flush them. This option is good for bulk-loading
+# of data. Once the bulk-loading is complete, please issue a
+# sync to the OS to flush all dirty buffers to stable storage.
+# Default false.
+# disable-data-sync = false
+
 # Column Family default used to store actual data of the database.
 [rocksdb.defaultcf]
 # compression method (if any) is used to compress a block.

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -221,6 +221,9 @@ fn get_rocksdb_db_option(config: &toml::Value) -> RocksdbOptions {
     let create_if_missing = get_toml_boolean(config, "rocksdb.create-if-missing", Some(true));
     opts.create_if_missing(create_if_missing);
 
+    let disable_data_sync = get_toml_boolean(config, "rocksdb.disable-data-sync", Some(false));
+    opts.set_disable_data_sync(disable_data_sync);
+
     let max_open_files = get_toml_int(config, "rocksdb.max-open-files", Some(40960));
     opts.set_max_open_files(max_open_files as i32);
 


### PR DESCRIPTION
Disable data sync when loading data. The contents of manifest and data files are not synced to stable storage when disable-data-sync is true.
@siddontang @ngaut PTAL