### PR TITLE
[DNM] raftstore, storage: check key range when region epoch is stale.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto#a592aad4c54759db9263eda94cf30dfcd515a260"
+source = "git+https://github.com/pingcap/kvproto#d850e91a125bd4c11b9ac03b3aa000abc371b6ca"
 dependencies = [
  "protobuf 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto#d850e91a125bd4c11b9ac03b3aa000abc371b6ca"
+source = "git+https://github.com/pingcap/kvproto#6a322fe1c8c107177ec436c2d66fa6d191bb4312"
 dependencies = [
  "protobuf 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/raftstore/errors.rs
+++ b/src/raftstore/errors.rs
@@ -18,7 +18,7 @@ use std::io;
 use std::net;
 use std::vec::Vec;
 
-use protobuf::{ProtobufError, RepeatedField};
+use protobuf::ProtobufError;
 
 use util::codec;
 use pd;
@@ -110,7 +110,7 @@ quick_error!{
             description("request timeout")
             display("Timeout {}", msg)
         }
-        StaleEpoch(msg: String, new_regions: Vec<metapb::Region>) {
+        StaleEpoch(msg: String) {
             description("region is stale")
             display("StaleEpoch {}", msg)
         }
@@ -156,10 +156,8 @@ impl Into<errorpb::Error> for Error {
                 errorpb.mut_key_not_in_region().set_start_key(region.get_start_key().to_vec());
                 errorpb.mut_key_not_in_region().set_end_key(region.get_end_key().to_vec());
             }
-            Error::StaleEpoch(_, new_regions) => {
-                let mut e = errorpb::StaleEpoch::new();
-                e.set_new_regions(RepeatedField::from_vec(new_regions));
-                errorpb.set_stale_epoch(e);
+            Error::StaleEpoch(_) => {
+                errorpb.set_stale_epoch(errorpb::StaleEpoch::new());
             }
             Error::StaleCommand => {
                 errorpb.set_stale_command(errorpb::StaleCommand::new());

--- a/src/raftstore/store/cmd_resp.rs
+++ b/src/raftstore/store/cmd_resp.rs
@@ -15,8 +15,7 @@ use std::boxed::Box;
 use std::error;
 
 use uuid::Uuid;
-
-use kvproto::raft_cmdpb::RaftCmdResponse;
+use kvproto::raft_cmdpb::{RaftCmdResponse, UpdatedRegion};
 use raftstore::Error;
 
 pub fn bind_uuid(resp: &mut RaftCmdResponse, uuid: Uuid) {
@@ -29,6 +28,12 @@ pub fn bind_term(resp: &mut RaftCmdResponse, term: u64) {
     }
 
     resp.mut_header().set_current_term(term);
+}
+
+pub fn bind_updated_regions(resp: &mut RaftCmdResponse, regions: Vec<UpdatedRegion>) {
+    for r in regions {
+        resp.mut_header().mut_updated_regions().push(r);
+    }
 }
 
 pub fn bind_error(resp: &mut RaftCmdResponse, err: Error) {

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -28,7 +28,7 @@ use kvproto::metapb;
 use kvproto::eraftpb::{self, ConfChangeType, MessageType};
 use kvproto::raft_cmdpb::{RaftCmdRequest, RaftCmdResponse, ChangePeerRequest, CmdType,
                           AdminCmdType, Request, Response, AdminRequest, AdminResponse,
-                          TransferLeaderRequest, TransferLeaderResponse};
+                          TransferLeaderRequest, TransferLeaderResponse, UpdatedRegion};
 use kvproto::raft_serverpb::{RaftMessage, RaftApplyState, RaftTruncatedState, PeerState};
 use kvproto::pdpb::PeerStats;
 use raft::{self, RawNode, StateRole, SnapshotStatus, Ready, ProgressState, INVALID_INDEX};
@@ -691,13 +691,16 @@ impl Peer {
 
             // Execute ready-only commands immediately in leader when doing local reads.
             let mut ctx = ExecContext::new(self, 0, 0, &req);
-            let (mut resp, _) = self.exec_raft_cmd(&mut ctx).unwrap_or_else(|e| {
-                error!("{} execute raft command err: {:?}", self.tag, e);
-                (cmd_resp::new_error(e), None)
-            });
+            let mut updated_regions = vec![];
+            let (mut resp, _) = self.exec_raft_cmd(&mut ctx, &mut updated_regions)
+                .unwrap_or_else(|e| {
+                    error!("{} execute raft command err: {:?}", self.tag, e);
+                    (cmd_resp::new_error(e), None)
+                });
 
             cmd_resp::bind_uuid(&mut resp, cmd.uuid);
             cmd_resp::bind_term(&mut resp, self.term());
+            cmd_resp::bind_updated_regions(&mut resp, updated_regions);
             cmd.call(resp);
             return false;
         } else if get_transfer_leader_cmd(&req).is_some() {
@@ -884,7 +887,10 @@ impl Peer {
         Ok(())
     }
 
-    pub fn check_epoch(&self, req: &RaftCmdRequest) -> Result<()> {
+    pub fn check_epoch(&self,
+                       req: &RaftCmdRequest,
+                       updated_regions: &mut Vec<UpdatedRegion>)
+                       -> Result<()> {
         let (mut check_ver, mut check_conf_ver) = (false, false);
         if req.has_admin_request() {
             match req.get_admin_request().get_cmd_type() {
@@ -923,12 +929,27 @@ impl Peer {
                    self.tag,
                    from_epoch,
                    latest_epoch);
+            let mut updated_region = UpdatedRegion::new();
+            updated_region.set_region(latest_region.clone());
+            updated_region.set_leader(self.peer.clone());
+            updated_regions.push(updated_region);
+
+            if req.get_header().has_key_range() {
+                let range = req.get_header().get_key_range();
+                if range.get_min_key() >= latest_region.get_start_key() &&
+                   range.get_max_key() < latest_region.get_end_key() {
+                    debug!("{} accept stale epoch {:?} after check key range",
+                           self.tag,
+                           from_epoch);
+                    return Ok(());
+                }
+            }
+
             return Err(Error::StaleEpoch(format!("latest_epoch of region {} is {:?}, but you \
                                                   sent {:?}",
                                                  self.region_id,
                                                  latest_epoch,
-                                                 from_epoch),
-                                         vec![self.region().to_owned()]));
+                                                 from_epoch)));
         }
 
         Ok(())
@@ -1151,9 +1172,11 @@ impl Peer {
         }
 
         let uuid = util::get_uuid_from_req(&cmd).unwrap();
+
         let cmd_cb = self.find_cb(uuid, term, &cmd);
+        let mut updated_regions = vec![];
         let timer = PEER_APPLY_LOG_HISTOGRAM.start_timer();
-        let (mut resp, exec_result) = self.apply_raft_cmd(index, term, &cmd);
+        let (mut resp, exec_result) = self.apply_raft_cmd(index, term, &cmd, &mut updated_regions);
         timer.observe_duration();
 
         debug!("{} applied command with uuid {:?} at log index {}",
@@ -1198,6 +1221,7 @@ impl Peer {
         // Bind uuid here.
         cmd_resp::bind_uuid(&mut resp, uuid);
         cmd_resp::bind_term(&mut resp, self.term());
+        cmd_resp::bind_updated_regions(&mut resp, updated_regions);
         cb.call_box((resp,));
 
         exec_result
@@ -1216,16 +1240,18 @@ impl Peer {
     fn apply_raft_cmd(&mut self,
                       index: u64,
                       term: u64,
-                      req: &RaftCmdRequest)
+                      req: &RaftCmdRequest,
+                      updated_regions: &mut Vec<UpdatedRegion>)
                       -> (RaftCmdResponse, Option<ExecResult>) {
         // if pending remove, apply should be aborted already.
         assert!(!self.pending_remove);
 
         let mut ctx = ExecContext::new(self, index, term, req);
-        let (resp, exec_result) = self.exec_raft_cmd(&mut ctx).unwrap_or_else(|e| {
-            error!("{} execute raft command err: {:?}", self.tag, e);
-            (cmd_resp::new_error(e), None)
-        });
+        let (resp, exec_result) = self.exec_raft_cmd(&mut ctx, updated_regions)
+            .unwrap_or_else(|e| {
+                error!("{} execute raft command err: {:?}", self.tag, e);
+                (cmd_resp::new_error(e), None)
+            });
 
         ctx.apply_state.set_applied_index(index);
         if !self.pending_remove {
@@ -1343,9 +1369,10 @@ impl<'a> ExecContext<'a> {
 impl Peer {
     // Only errors that will also occur on all other stores should be returned.
     fn exec_raft_cmd(&mut self,
-                     ctx: &mut ExecContext)
+                     ctx: &mut ExecContext,
+                     updated_regions: &mut Vec<UpdatedRegion>)
                      -> Result<(RaftCmdResponse, Option<ExecResult>)> {
-        try!(self.check_epoch(ctx.req));
+        try!(self.check_epoch(ctx.req, updated_regions));
         if ctx.req.has_admin_request() {
             self.exec_admin_cmd(ctx)
         } else {

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -35,7 +35,7 @@ use kvproto::pdpb::StoreStats;
 use util::{HandyRwLock, SlowTimer, duration_to_nanos, escape};
 use pd::PdClient;
 use kvproto::raft_cmdpb::{AdminCmdType, AdminRequest, StatusCmdType, StatusResponse,
-                          RaftCmdRequest, RaftCmdResponse};
+                          RaftCmdRequest, RaftCmdResponse, UpdatedRegion};
 use protobuf::Message;
 use raft::{SnapshotStatus, INVALID_INDEX};
 use raftstore::{Result, Error};
@@ -54,7 +54,7 @@ use super::config::Config;
 use super::peer::{Peer, PendingCmd, ReadyResult, ExecResult, StaleState, ConsistencyState};
 use super::peer_storage::{ApplySnapResult, SnapState};
 use super::msg::Callback;
-use super::cmd_resp::{bind_uuid, bind_term, bind_error};
+use super::cmd_resp::{bind_uuid, bind_term, bind_updated_regions, bind_error};
 use super::transport::Transport;
 use super::metrics::*;
 use super::local_metrics::RaftMetrics;
@@ -945,8 +945,10 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             return cb.call_box((resp,));
         }
 
-        if let Err(e) = self.validate_region(&msg) {
+        let mut updated_regions = vec![];
+        if let Err(e) = self.validate_region(&msg, &mut updated_regions) {
             bind_error(&mut resp, e);
+            bind_updated_regions(&mut resp, updated_regions);
             return cb.call_box((resp,));
         }
 
@@ -973,7 +975,10 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         // we will call the callback with timeout error.
     }
 
-    fn validate_region(&self, msg: &RaftCmdRequest) -> Result<()> {
+    fn validate_region(&self,
+                       msg: &RaftCmdRequest,
+                       updated_regions: &mut Vec<UpdatedRegion>)
+                       -> Result<()> {
         let region_id = msg.get_header().get_region_id();
         let peer_id = msg.get_header().get_peer().get_id();
 
@@ -994,8 +999,8 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             return Err(Error::StaleCommand);
         }
 
-        let res = peer.check_epoch(msg);
-        if let Err(Error::StaleEpoch(msg, mut new_regions)) = res {
+        let res = peer.check_epoch(msg, updated_regions);
+        if let Err(Error::StaleEpoch(msg)) = res {
             // Attach the next region which might be split from the current region. But it doesn't
             // matter if the next region is not split from the current region. If the region meta
             // received by the TiKV driver is newer than the meta cached in the driver, the meta is
@@ -1003,10 +1008,15 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             if let Some((_, &next_region_id)) = self.region_ranges
                 .range(Excluded(&enc_end_key(peer.region())), Unbounded::<&Key>)
                 .next() {
-                let next_region = self.region_peers[&next_region_id].region();
-                new_regions.push(next_region.to_owned());
+                let next_peer = &self.region_peers[&next_region_id];
+                let mut updated_region = UpdatedRegion::new();
+                updated_region.set_region(next_peer.region().to_owned());
+                if let Some(p) = next_peer.get_peer_from_cache(peer.leader_id()) {
+                    updated_region.set_leader(p);
+                }
+                updated_regions.push(updated_region);
             }
-            return Err(Error::StaleEpoch(msg, new_regions));
+            return Err(Error::StaleEpoch(msg));
         }
         res
     }

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -16,10 +16,11 @@ use std::fmt::Debug;
 use std::cmp::Ordering;
 use std::boxed::FnBox;
 use std::time::Duration;
+use std::default::Default;
 
 use self::rocksdb::EngineRocksdb;
 use storage::{Key, Value, CfName, CF_DEFAULT};
-use kvproto::kvrpcpb::Context;
+use kvproto::kvrpcpb::{Context, UpdatedRegion};
 use kvproto::errorpb::Error as ErrorHeader;
 
 mod rocksdb;
@@ -37,11 +38,15 @@ pub type Callback<T> = Box<FnBox((CbContext, Result<T>)) + Send>;
 
 pub struct CbContext {
     pub term: Option<u64>,
+    pub updated_regions: Vec<UpdatedRegion>,
 }
 
-impl CbContext {
-    fn new() -> CbContext {
-        CbContext { term: None }
+impl Default for CbContext {
+    fn default() -> CbContext {
+        CbContext {
+            term: None,
+            updated_regions: vec![],
+        }
     }
 }
 

--- a/src/storage/engine/rocksdb.rs
+++ b/src/storage/engine/rocksdb.rs
@@ -21,7 +21,7 @@ use util::escape;
 use util::rocksdb;
 use util::worker::{Runnable, Worker, Scheduler};
 use super::{Engine, Snapshot, Modify, Cursor, Iterator as EngineIterator, Callback, TEMP_DIR,
-            ScanMode, Result, Error, CbContext};
+            ScanMode, Result, Error};
 use tempdir::TempDir;
 
 enum Task {
@@ -43,9 +43,11 @@ struct Runner(Arc<DB>);
 impl Runnable<Task> for Runner {
     fn run(&mut self, t: Task) {
         match t {
-            Task::Write(modifies, cb) => cb((CbContext::new(), write_modifies(&self.0, modifies))),
+            Task::Write(modifies, cb) => {
+                cb((Default::default(), write_modifies(&self.0, modifies)))
+            }
             Task::Snapshot(cb) => {
-                cb((CbContext::new(), Ok(box RocksSnapshot::new(self.0.clone()))))
+                cb((Default::default(), Ok(box RocksSnapshot::new(self.0.clone()))))
             }
         }
     }

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -112,40 +112,41 @@ impl Debug for Msg {
 }
 
 /// Delivers the process result of a command to the storage callback.
-fn execute_callback(callback: StorageCb, pr: ProcessResult) {
+fn execute_callback(callback: StorageCb, cb_ctx: Option<CbContext>, pr: ProcessResult) {
+    let cb_ctx = cb_ctx.unwrap_or_default();
     match callback {
         StorageCb::Boolean(cb) => {
             match pr {
-                ProcessResult::Res => cb(Ok(())),
-                ProcessResult::Failed { err } => cb(Err(err)),
+                ProcessResult::Res => cb((cb_ctx, Ok(()))),
+                ProcessResult::Failed { err } => cb((cb_ctx, Err(err))),
                 _ => panic!("process result mismatch"),
             }
         }
         StorageCb::Booleans(cb) => {
             match pr {
-                ProcessResult::MultiRes { results } => cb(Ok(results)),
-                ProcessResult::Failed { err } => cb(Err(err)),
+                ProcessResult::MultiRes { results } => cb((cb_ctx, Ok(results))),
+                ProcessResult::Failed { err } => cb((cb_ctx, Err(err))),
                 _ => panic!("process result mismatch"),
             }
         }
         StorageCb::SingleValue(cb) => {
             match pr {
-                ProcessResult::Value { value } => cb(Ok(value)),
-                ProcessResult::Failed { err } => cb(Err(err)),
+                ProcessResult::Value { value } => cb((cb_ctx, Ok(value))),
+                ProcessResult::Failed { err } => cb((cb_ctx, Err(err))),
                 _ => panic!("process result mismatch"),
             }
         }
         StorageCb::KvPairs(cb) => {
             match pr {
-                ProcessResult::MultiKvpairs { pairs } => cb(Ok(pairs)),
-                ProcessResult::Failed { err } => cb(Err(err)),
+                ProcessResult::MultiKvpairs { pairs } => cb((cb_ctx, Ok(pairs))),
+                ProcessResult::Failed { err } => cb((cb_ctx, Err(err))),
                 _ => panic!("process result mismatch"),
             }
         }
         StorageCb::Locks(cb) => {
             match pr {
-                ProcessResult::Locks { locks } => cb(Ok(locks)),
-                ProcessResult::Failed { err } => cb(Err(err)),
+                ProcessResult::Locks { locks } => cb((cb_ctx, Ok(locks))),
+                ProcessResult::Failed { err } => cb((cb_ctx, Err(err))),
                 _ => panic!("process result mismatch"),
             }
         }
@@ -158,6 +159,7 @@ pub struct RunningCtx {
     cmd: Option<Command>,
     lock: Lock,
     callback: Option<StorageCb>,
+    cb_ctx: Option<CbContext>,
     tag: &'static str,
     latch_timer: Option<HistogramTimer>,
     _timer: HistogramTimer,
@@ -172,6 +174,7 @@ impl RunningCtx {
             cmd: Some(cmd),
             lock: lock,
             callback: Some(cb),
+            cb_ctx: None,
             tag: tag,
             latch_timer: Some(SCHED_LATCH_HISTOGRAM_VEC.with_label_values(&[tag]).start_timer()),
             _timer: SCHED_HISTOGRAM_VEC.with_label_values(&[tag]).start_timer(),
@@ -537,14 +540,16 @@ impl Scheduler {
     fn process_by_worker(&mut self, cid: u64, cb_ctx: CbContext, snapshot: Box<Snapshot>) {
         SCHED_STAGE_COUNTER_VEC.with_label_values(&[self.get_ctx_tag(cid), "process"]).inc();
         debug!("process cmd with snapshot, cid={}", cid);
-        let mut cmd = {
-            let ctx = &mut self.cmd_ctxs.get_mut(&cid).unwrap();
+        let cmd = {
+            let mut ctx = &mut self.cmd_ctxs.get_mut(&cid).unwrap();
             assert_eq!(ctx.cid, cid);
-            ctx.cmd.take().unwrap()
+            let mut cmd = ctx.cmd.take().unwrap();
+            if let Some(term) = cb_ctx.term {
+                cmd.mut_context().set_term(term);
+            }
+            ctx.cb_ctx = Some(cb_ctx);
+            cmd
         };
-        if let Some(term) = cb_ctx.term {
-            cmd.mut_context().set_term(term);
-        }
         let ch = self.schedch.clone();
         let readcmd = cmd.readonly();
         if readcmd {
@@ -561,8 +566,9 @@ impl Scheduler {
 
         let mut ctx = self.remove_ctx(cid);
         let cb = ctx.callback.take().unwrap();
+        let cb_ctx = ctx.cb_ctx.take();
         let pr = ProcessResult::Failed { err: StorageError::from(err) };
-        execute_callback(cb, pr);
+        execute_callback(cb, cb_ctx, pr);
 
         self.release_lock(&ctx.lock, cid);
     }
@@ -598,12 +604,18 @@ impl Scheduler {
         self.cmd_ctxs.len() >= self.sched_too_busy_threshold
     }
 
-    fn on_receive_new_cmd(&mut self, cmd: Command, callback: StorageCb) {
+    fn on_receive_new_cmd(&mut self, mut cmd: Command, callback: StorageCb) {
         // write flow control
         if !cmd.readonly() && self.too_busy() {
             execute_callback(callback,
+                             None,
                              ProcessResult::Failed { err: StorageError::SchedTooBusy });
         } else {
+            if let Some((min, max)) = cmd.key_range() {
+                let mut r = cmd.mut_context().mut_key_range();
+                r.set_min_key(min.encoded().to_owned());
+                r.set_max_key(max.encoded().to_owned());
+            }
             self.schedule_command(cmd, callback);
         }
     }
@@ -674,11 +686,12 @@ impl Scheduler {
         let mut ctx = self.remove_ctx(cid);
         SCHED_STAGE_COUNTER_VEC.with_label_values(&[ctx.tag, "read_finish"]).inc();
         let cb = ctx.callback.take().unwrap();
+        let cb_ctx = ctx.cb_ctx.take();
         if let ProcessResult::NextCommand { cmd } = pr {
             SCHED_STAGE_COUNTER_VEC.with_label_values(&[ctx.tag, "next_cmd"]).inc();
             self.schedule_command(cmd, cb);
         } else {
-            execute_callback(cb, pr);
+            execute_callback(cb, cb_ctx, pr);
         }
 
         self.release_lock(&ctx.lock, cid);
@@ -722,6 +735,7 @@ impl Scheduler {
         debug!("write finished for command, cid={}", cid);
         let mut ctx = self.remove_ctx(cid);
         let cb = ctx.callback.take().unwrap();
+        let cb_ctx = ctx.cb_ctx.take();
         let pr = match result {
             Ok(()) => pr,
             Err(e) => ProcessResult::Failed { err: ::storage::Error::from(e) },
@@ -730,7 +744,7 @@ impl Scheduler {
             SCHED_STAGE_COUNTER_VEC.with_label_values(&[ctx.tag, "next_cmd"]).inc();
             self.schedule_command(cmd, cb);
         } else {
-            execute_callback(cb, pr);
+            execute_callback(cb, cb_ctx, pr);
         }
 
         self.release_lock(&ctx.lock, cid);

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -40,7 +40,7 @@ pub type KvPair = (Vec<u8>, Value);
 /// Orthogonal to binary representation, keys may or may not embed a timestamp,
 /// but this information is transparent to this type, the caller must use it
 /// consistently.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialOrd, Ord)]
 pub struct Key(Vec<u8>);
 
 /// Core functions for `Key`.
@@ -128,6 +128,8 @@ impl PartialEq for Key {
         self.0 == other.0
     }
 }
+
+impl Eq for Key {}
 
 /// Creates a new key from raw bytes.
 pub fn make_key(k: &[u8]) -> Key {

--- a/tests/storage/sync_storage.rs
+++ b/tests/storage/sync_storage.rs
@@ -48,7 +48,7 @@ impl SyncStorage {
     }
 
     pub fn get(&self, ctx: Context, key: &Key, start_ts: u64) -> Result<Option<Value>> {
-        wait_op!(|cb| self.store.async_get(ctx, key.to_owned(), start_ts, cb).unwrap()).unwrap()
+        wait_op!(|cb| self.store.async_get(ctx, key.to_owned(), start_ts, cb).unwrap()).unwrap().1
     }
 
     #[allow(dead_code)]
@@ -59,6 +59,7 @@ impl SyncStorage {
                      -> Result<Vec<Result<KvPair>>> {
         wait_op!(|cb| self.store.async_batch_get(ctx, keys.to_owned(), start_ts, cb).unwrap())
             .unwrap()
+            .1
     }
 
     pub fn scan(&self,
@@ -70,6 +71,7 @@ impl SyncStorage {
                 -> Result<Vec<Result<KvPair>>> {
         wait_op!(|cb| self.store.async_scan(ctx, key, limit, key_only, start_ts, cb).unwrap())
             .unwrap()
+            .1
     }
 
     pub fn prewrite(&self,
@@ -80,6 +82,7 @@ impl SyncStorage {
                     -> Result<Vec<Result<()>>> {
         wait_op!(|cb| self.store.async_prewrite(ctx, mutations, primary, start_ts, 0, cb).unwrap())
             .unwrap()
+            .1
     }
 
     pub fn commit(&self,
@@ -88,39 +91,43 @@ impl SyncStorage {
                   start_ts: u64,
                   commit_ts: u64)
                   -> Result<()> {
-        wait_op!(|cb| self.store.async_commit(ctx, keys, start_ts, commit_ts, cb).unwrap()).unwrap()
+        wait_op!(|cb| self.store.async_commit(ctx, keys, start_ts, commit_ts, cb).unwrap())
+            .unwrap()
+            .1
     }
 
     pub fn cleanup(&self, ctx: Context, key: Key, start_ts: u64) -> Result<()> {
-        wait_op!(|cb| self.store.async_cleanup(ctx, key, start_ts, cb).unwrap()).unwrap()
+        wait_op!(|cb| self.store.async_cleanup(ctx, key, start_ts, cb).unwrap()).unwrap().1
     }
 
     pub fn rollback(&self, ctx: Context, keys: Vec<Key>, start_ts: u64) -> Result<()> {
-        wait_op!(|cb| self.store.async_rollback(ctx, keys, start_ts, cb).unwrap()).unwrap()
+        wait_op!(|cb| self.store.async_rollback(ctx, keys, start_ts, cb).unwrap()).unwrap().1
     }
 
     pub fn scan_lock(&self, ctx: Context, max_ts: u64) -> Result<Vec<LockInfo>> {
-        wait_op!(|cb| self.store.async_scan_lock(ctx, max_ts, cb).unwrap()).unwrap()
+        wait_op!(|cb| self.store.async_scan_lock(ctx, max_ts, cb).unwrap()).unwrap().1
     }
 
     pub fn resolve_lock(&self, ctx: Context, start_ts: u64, commit_ts: Option<u64>) -> Result<()> {
-        wait_op!(|cb| self.store.async_resolve_lock(ctx, start_ts, commit_ts, cb).unwrap()).unwrap()
+        wait_op!(|cb| self.store.async_resolve_lock(ctx, start_ts, commit_ts, cb).unwrap())
+            .unwrap()
+            .1
     }
 
     pub fn gc(&self, ctx: Context, safe_point: u64) -> Result<()> {
-        wait_op!(|cb| self.store.async_gc(ctx, safe_point, cb).unwrap()).unwrap()
+        wait_op!(|cb| self.store.async_gc(ctx, safe_point, cb).unwrap()).unwrap().1
     }
 
     pub fn raw_get(&self, ctx: Context, key: Vec<u8>) -> Result<Option<Vec<u8>>> {
-        wait_op!(|cb| self.store.async_raw_get(ctx, key, cb).unwrap()).unwrap()
+        wait_op!(|cb| self.store.async_raw_get(ctx, key, cb).unwrap()).unwrap().1
     }
 
     pub fn raw_put(&self, ctx: Context, key: Vec<u8>, value: Vec<u8>) -> Result<()> {
-        wait_op!(|cb| self.store.async_raw_put(ctx, key, value, cb).unwrap()).unwrap()
+        wait_op!(|cb| self.store.async_raw_put(ctx, key, value, cb).unwrap()).unwrap().1
     }
 
     pub fn raw_delete(&self, ctx: Context, key: Vec<u8>) -> Result<()> {
-        wait_op!(|cb| self.store.async_raw_delete(ctx, key, cb).unwrap()).unwrap()
+        wait_op!(|cb| self.store.async_raw_delete(ctx, key, cb).unwrap()).unwrap().1
     }
 }
 

--- a/tests/storage/test_raft_storage.rs
+++ b/tests/storage/test_raft_storage.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use std::thread;
 use tikv::util::HandyRwLock;
 use tikv::storage::{self, Storage, Engine, Snapshot, Modify, Mutation, make_key, ALL_CFS};
-use tikv::storage::engine::{self, Callback, Result};
+use tikv::storage::engine::{self, Callback, Result, CbContext};
 use kvproto::kvrpcpb::Context;
 use raftstore::server::new_server_cluster_with_cfs;
 use raftstore::cluster::Cluster;
@@ -131,7 +131,7 @@ fn test_scheduler_leader_change_twice() {
                         b"k".to_vec(),
                         10,
                         0,
-                        box move |res: storage::Result<_>| {
+                        box move |(_, res): (CbContext, storage::Result<_>)| {
             if let storage::Error::Engine(engine::Error::Request(ref e)) = *res.as_ref()
                 .err()
                 .unwrap() {


### PR DESCRIPTION
This PR aims to reduce data retransmission when region splits.

@siddontang @zhangjinpeng1987 @BusyJay 