### PR TITLE
*: speedup shutdown

### DIFF
--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -1696,22 +1696,13 @@ impl<T: Transport, C: PdClient> mio::Handler for Store<T, C> {
 
     fn tick(&mut self, event_loop: &mut EventLoop<Self>) {
         if !event_loop.is_running() {
-            let workers = vec![(self.split_check_worker.stop(), self.split_check_worker.name()),
-                               (self.region_worker.stop(), self.region_worker.name()),
-                               (self.raftlog_gc_worker.stop(), self.raftlog_gc_worker.name()),
-                               (self.compact_worker.stop(), self.compact_worker.name()),
-                               (self.pd_worker.stop(), self.pd_worker.name()),
-                               (self.consistency_check_worker.stop(),
-                                self.consistency_check_worker.name())];
+            self.split_check_worker.stop();
+            self.region_worker.stop();
+            self.raftlog_gc_worker.stop();
+            self.compact_worker.stop();
+            self.pd_worker.stop();
+            self.consistency_check_worker.stop();
 
-            // under tests, we need to check whether all the threads exit normally.
-            if cfg!(test) {
-                for (handle, name) in workers {
-                    if let Some(Err(e)) = handle.map(|h| h.join()) {
-                        error!("{} failed to stop {}: {:?}", self.tag, name, e);
-                    }
-                }
-            }
             for peer in self.region_peers.values_mut() {
                 peer.clear_pending_commands();
             }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -592,18 +592,10 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver> Handler for Server<T, S> {
         // we will quit the server here.
         // TODO: handle quit server if event_loop is_running() returns false.
         if !el.is_running() {
-            let end_point_handle = self.end_point_worker.stop();
-            let snap_handle = self.snap_worker.stop();
+            self.end_point_worker.stop();
+            self.snap_worker.stop();
             if let Err(e) = self.store.stop() {
                 error!("failed to stop store: {:?}", e);
-            }
-            if cfg!(test) {
-                if let Some(Err(e)) = end_point_handle.map(|h| h.join()) {
-                    error!("failed to stop end point: {:?}", e);
-                }
-                if let Some(Err(e)) = snap_handle.map(|h| h.join()) {
-                    error!("failed to stop snap handler: {:?}", e);
-                }
             }
         }
     }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -597,11 +597,13 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver> Handler for Server<T, S> {
             if let Err(e) = self.store.stop() {
                 error!("failed to stop store: {:?}", e);
             }
-            if let Some(Err(e)) = end_point_handle.map(|h| h.join()) {
-                error!("failed to stop end point: {:?}", e);
-            }
-            if let Some(Err(e)) = snap_handle.map(|h| h.join()) {
-                error!("failed to stop snap handler: {:?}", e);
+            if cfg!(test) {
+                if let Some(Err(e)) = end_point_handle.map(|h| h.join()) {
+                    error!("failed to stop end point: {:?}", e);
+                }
+                if let Some(Err(e)) = snap_handle.map(|h| h.join()) {
+                    error!("failed to stop snap handler: {:?}", e);
+                }
             }
         }
     }


### PR DESCRIPTION
When shutting down, tikv-server can safely exit without stopping all the workers. This can reduce the waiting time when doing gracefully shutdown.

@siddontang @zhangjinpeng1987 @disksing @hhkbp2 PTAL