### PR TITLE
raftstore: expose split interval

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -57,6 +57,8 @@ region-split-size = "64MB"
 # When region size changes exceeds region-split-check-diff, we should check 
 # whether the region should be split or not. 
 region-split-check-diff = "8MB"
+# Interval to check region whether need to be split or not.
+split-region-check-tick-interval = "5s"
 
 # Interval to gc unnecessary raft log.
 # raft-log-gc-tick-interval = "10s"

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -392,6 +392,10 @@ fn build_cfg(matches: &Matches, config: &toml::Value, cluster_id: u64, addr: &st
         get_toml_int(config, "raftstore.notify-capacity", Some(40960)) as usize;
     cfg.raft_store.messages_per_tick =
         get_toml_int(config, "raftstore.messages-per-tick", Some(4096)) as usize;
+    let interval = get_toml_int(config,
+                                "raftstore.split-region-check-tick-interval",
+                                Some(10000));
+    cfg.raft_store.split_region_check_tick_interval = interval as u64;
     cfg.raft_store.region_split_size =
         get_toml_int(config,
                      "raftstore.region-split-size",


### PR DESCRIPTION
So the split interval can be changed without recompilation.

@siddontang @hhkbp2 PTAL