### PR TITLE
tests: retry when get StaleCommand error

### DIFF
--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -394,6 +394,11 @@ impl<T: Simulator> Cluster<T> {
         }
 
         let err = resp.get_header().get_error();
+        if err.has_stale_command() {
+            // command got truncated, leadership may have changed.
+            self.reset_leader_of_region(region_id);
+            return true;
+        }
         if !err.has_not_leader() {
             return false;
         }


### PR DESCRIPTION
In the past when a command is dropped, it will return NotLeader error and tests will retry in this cases. After pr #1328, StaleCommand is returned instead of NotLeader.

@siddontang @disksing PTAL
