### PR TITLE
config: use millis for all interval

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -75,14 +75,14 @@ split-region-check-tick-interval = "5s"
 max-peer-down-duration = "5m"
 
 # Interval to check whether start compaction for a region.
-# region-compact-check-interval-secs = 300
+# region-compact-check-interval = "5min"
 # When delete keys of a region exceeds the size, a compaction will be started.
 # region-compact-delete-keys-count = 200000
 # Interval to check whether start lock compaction for a region.
-# lock-cf-compact-interval-secs = 600
+# lock-cf-compact-interval = "60s"
 
 # Interval (s) to check region whether the data are consistent.
-# consistency-check-interval-secs = 0
+# consistency-check-interval = 0
 
 [pd]
 # pd endpoints 

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -75,11 +75,11 @@ split-region-check-tick-interval = "5s"
 max-peer-down-duration = "5m"
 
 # Interval to check whether start compaction for a region.
-# region-compact-check-interval = "5min"
+# region-compact-check-interval = "5m"
 # When delete keys of a region exceeds the size, a compaction will be started.
 # region-compact-delete-keys-count = 200000
 # Interval to check whether start lock compaction for a region.
-# lock-cf-compact-interval = "60s"
+# lock-cf-compact-interval = "10m"
 
 # Interval (s) to check region whether the data are consistent.
 # consistency-check-interval = 0

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -425,20 +425,18 @@ fn build_cfg(matches: &Matches, config: &toml::Value, cluster_id: u64, addr: &st
                      "raftstore.raft-log-gc-size-limit",
                      Some(48 * 1024 * 1024)) as u64;
 
-    cfg.raft_store.region_compact_check_interval_secs =
+    cfg.raft_store.region_compact_check_interval =
         get_toml_int(config,
-                     "raftstore.region-compact-check-interval-secs",
-                     Some(300)) as u64;
+                     "raftstore.region-compact-check-interval",
+                     Some(300_000)) as u64;
 
     cfg.raft_store.region_compact_delete_keys_count =
         get_toml_int(config,
                      "raftstore.region-compact-delete-keys-count",
                      Some(1_000_000)) as u64;
 
-    cfg.raft_store.lock_cf_compact_interval_secs =
-        get_toml_int(config,
-                     "raftstore.lock-cf-compact-interval-secs",
-                     Some(300_000)) as u64;
+    cfg.raft_store.lock_cf_compact_interval =
+        get_toml_int(config, "raftstore.lock-cf-compact-interval", Some(600_000)) as u64;
 
     let max_peer_down_millis =
         get_toml_int(config, "raftstore.max-peer-down-duration", Some(300_000)) as u64;
@@ -453,7 +451,7 @@ fn build_cfg(matches: &Matches, config: &toml::Value, cluster_id: u64, addr: &st
                      Some(10_000)) as u64;
 
     cfg.raft_store.consistency_check_tick_interval =
-        get_toml_int(config, "raftstore.consistency-check-interval-secs", Some(0)) as u64;
+        get_toml_int(config, "raftstore.consistency-check-interval", Some(0)) as u64;
 
     cfg.storage.sched_notify_capacity =
         get_toml_int(config, "storage.scheduler-notify-capacity", Some(10240)) as usize;

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -40,7 +40,7 @@ const DEFAULT_MGR_GC_TICK_INTERVAL: u64 = 60000;
 const DEFAULT_SNAP_GC_TIMEOUT_SECS: u64 = 60 * 10;
 const DEFAULT_MESSAGES_PER_TICK: usize = 256;
 const DEFAULT_MAX_PEER_DOWN_SECS: u64 = 300;
-const DEFAULT_LOCK_CF_COMPACT_INTERVAL: u64 = 60 * 10 * 1000; // 10 min
+const DEFAULT_LOCK_CF_COMPACT_INTERVAL: u64 = 10 * 60 * 1000; // 10 min
 // If the leader missing for over 2 hours,
 // a peer should consider itself as a stale peer that is out of region.
 const DEFAULT_MAX_LEADER_MISSING_SECS: u64 = 2 * 60 * 60;

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -30,24 +30,24 @@ const SPLIT_REGION_CHECK_TICK_INTERVAL: u64 = 10000;
 const REGION_SPLIT_SIZE: u64 = 64 * 1024 * 1024;
 const REGION_MAX_SIZE: u64 = 80 * 1024 * 1024;
 const REGION_CHECK_DIFF: u64 = 8 * 1024 * 1024;
-const REGION_COMPACT_CHECK_TICK_INTERVAL: u64 = 300;
+const REGION_COMPACT_CHECK_TICK_INTERVAL: u64 = 5 * 60 * 1000; // 5 min
 const REGION_COMPACT_DELETE_KEYS_COUNT: u64 = 1_000_000;
-const PD_HEARTBEAT_TICK_INTERVAL_MS: u64 = 5000;
-const PD_STORE_HEARTBEAT_TICK_INTERVAL_MS: u64 = 10000;
+const PD_HEARTBEAT_TICK_INTERVAL: u64 = 5000;
+const PD_STORE_HEARTBEAT_TICK_INTERVAL: u64 = 10000;
 const STORE_CAPACITY: u64 = u64::MAX;
 const DEFAULT_NOTIFY_CAPACITY: usize = 4096;
-const DEFAULT_MGR_GC_TICK_INTERVAL_MS: u64 = 60000;
+const DEFAULT_MGR_GC_TICK_INTERVAL: u64 = 60000;
 const DEFAULT_SNAP_GC_TIMEOUT_SECS: u64 = 60 * 10;
 const DEFAULT_MESSAGES_PER_TICK: usize = 256;
 const DEFAULT_MAX_PEER_DOWN_SECS: u64 = 300;
-const DEFAULT_LOCK_CF_COMPACT_INTERVAL_SECS: u64 = 60 * 10; // 10 min
+const DEFAULT_LOCK_CF_COMPACT_INTERVAL: u64 = 60 * 10 * 1000; // 10 min
 // If the leader missing for over 2 hours,
 // a peer should consider itself as a stale peer that is out of region.
 const DEFAULT_MAX_LEADER_MISSING_SECS: u64 = 2 * 60 * 60;
 const DEFAULT_SNAPSHOT_APPLY_BATCH_SIZE: usize = 1024 * 1024 * 10; // 10m
 // Disable consistency check by default as it will hurt performance.
 // We should turn on this only in our tests.
-const DEFAULT_CONSISTENCY_CHECK_INTERVAL_SECS: u64 = 0;
+const DEFAULT_CONSISTENCY_CHECK_INTERVAL: u64 = 0;
 
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -83,8 +83,8 @@ pub struct Config {
     /// When size change of region exceed the diff since last check, it
     /// will be checked again whether it should be split.
     pub region_check_size_diff: u64,
-    /// Interval to check whether start compaction for a region.
-    pub region_compact_check_interval_secs: u64,
+    /// Interval (ms) to check whether start compaction for a region.
+    pub region_compact_check_interval: u64,
     /// When delete keys of a region exceeds the size, a compaction will
     /// be started.
     pub region_compact_delete_keys_count: u64,
@@ -92,7 +92,7 @@ pub struct Config {
     pub pd_store_heartbeat_tick_interval: u64,
     pub snap_mgr_gc_tick_interval: u64,
     pub snap_gc_timeout: u64,
-    pub lock_cf_compact_interval_secs: u64,
+    pub lock_cf_compact_interval: u64,
 
     pub notify_capacity: usize,
     pub messages_per_tick: usize,
@@ -108,7 +108,7 @@ pub struct Config {
 
     pub snap_apply_batch_size: usize,
 
-    // Interval (s) to check region whether the data is consistent.
+    // Interval (ms) to check region whether the data is consistent.
     pub consistency_check_tick_interval: u64,
 }
 
@@ -129,19 +129,19 @@ impl Default for Config {
             region_max_size: REGION_MAX_SIZE,
             region_split_size: REGION_SPLIT_SIZE,
             region_check_size_diff: REGION_CHECK_DIFF,
-            region_compact_check_interval_secs: REGION_COMPACT_CHECK_TICK_INTERVAL,
+            region_compact_check_interval: REGION_COMPACT_CHECK_TICK_INTERVAL,
             region_compact_delete_keys_count: REGION_COMPACT_DELETE_KEYS_COUNT,
-            pd_heartbeat_tick_interval: PD_HEARTBEAT_TICK_INTERVAL_MS,
-            pd_store_heartbeat_tick_interval: PD_STORE_HEARTBEAT_TICK_INTERVAL_MS,
+            pd_heartbeat_tick_interval: PD_HEARTBEAT_TICK_INTERVAL,
+            pd_store_heartbeat_tick_interval: PD_STORE_HEARTBEAT_TICK_INTERVAL,
             notify_capacity: DEFAULT_NOTIFY_CAPACITY,
-            snap_mgr_gc_tick_interval: DEFAULT_MGR_GC_TICK_INTERVAL_MS,
+            snap_mgr_gc_tick_interval: DEFAULT_MGR_GC_TICK_INTERVAL,
             snap_gc_timeout: DEFAULT_SNAP_GC_TIMEOUT_SECS,
             messages_per_tick: DEFAULT_MESSAGES_PER_TICK,
             max_peer_down_duration: Duration::from_secs(DEFAULT_MAX_PEER_DOWN_SECS),
             max_leader_missing_duration: Duration::from_secs(DEFAULT_MAX_LEADER_MISSING_SECS),
             snap_apply_batch_size: DEFAULT_SNAPSHOT_APPLY_BATCH_SIZE,
-            lock_cf_compact_interval_secs: DEFAULT_LOCK_CF_COMPACT_INTERVAL_SECS,
-            consistency_check_tick_interval: DEFAULT_CONSISTENCY_CHECK_INTERVAL_SECS,
+            lock_cf_compact_interval: DEFAULT_LOCK_CF_COMPACT_INTERVAL,
+            consistency_check_tick_interval: DEFAULT_CONSISTENCY_CHECK_INTERVAL,
         }
     }
 }

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -1116,7 +1116,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
     fn register_compact_check_tick(&self, event_loop: &mut EventLoop<Self>) {
         if let Err(e) = register_timer(event_loop,
                                        Tick::CompactCheck,
-                                       self.cfg.region_compact_check_interval_secs * 1000) {
+                                       self.cfg.region_compact_check_interval) {
             error!("{} register compact check tick err: {:?}", self.tag, e);
         };
     }
@@ -1407,7 +1407,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
     fn register_compact_lock_cf_tick(&self, event_loop: &mut EventLoop<Self>) {
         if let Err(e) = register_timer(event_loop,
                                        Tick::CompactLockCf,
-                                       self.cfg.lock_cf_compact_interval_secs * 1000) {
+                                       self.cfg.lock_cf_compact_interval) {
             error!("{} register compact cf-lock tick err: {:?}", self.tag, e);
         }
     }

--- a/tests/raftstore/test_compact_after_delete.rs
+++ b/tests/raftstore/test_compact_after_delete.rs
@@ -22,7 +22,7 @@ use super::node::new_node_cluster;
 use super::server::new_server_cluster;
 
 fn test_compact_after_delete<T: Simulator>(cluster: &mut Cluster<T>) {
-    cluster.cfg.raft_store.region_compact_check_interval_secs = 500;
+    cluster.cfg.raft_store.region_compact_check_interval = 500_000;
     cluster.cfg.raft_store.region_compact_delete_keys_count = 5;
     cluster.run();
 

--- a/tests/raftstore/test_compact_lock_cf.rs
+++ b/tests/raftstore/test_compact_lock_cf.rs
@@ -21,7 +21,7 @@ use super::cluster::{Cluster, Simulator};
 use super::server::new_server_cluster;
 
 fn test_compact_lock_cf<T: Simulator>(cluster: &mut Cluster<T>) {
-    cluster.cfg.raft_store.lock_cf_compact_interval_secs = 1;
+    cluster.cfg.raft_store.lock_cf_compact_interval = 1000;
     cluster.run();
 
     for i in 1..9 {


### PR DESCRIPTION
tikv-server will convert all readable int to millis, so we should treat all intervals as millis.

@siddontang @zhangjinpeng1987 @disksing  PTAL