### PR TITLE
build: speedup debug build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ features = ["nightly", "push"]
 [profile.dev]
 opt-level = 0  # Controls the --opt-level the compiler builds with
 debug = true   # Controls whether the compiler passes `-g`
+codegen-units = 4
 
 # The release profile, used for `cargo build --release`
 [profile.release]


### PR DESCRIPTION
When setting codegen-units, rustc will split the crate into several module and passing it to llvm in parallel. Debug build time is decreased about 15% on my machine, 18% on travis ci.

@siddontang @disksing @iamxy PTAL