### PR TITLE
make clippy happy

### DIFF
--- a/src/util/codec/table.rs
+++ b/src/util/codec/table.rs
@@ -271,7 +271,6 @@ pub fn cut_idx_key<'a>(mut key: &'a [u8], col_ids: &[i64]) -> Result<(ValDict<'a
 #[cfg(test)]
 mod test {
     use super::*;
-    use util::codec::mysql::*;
     use util::codec::datum::{self, Datum};
     use util::codec::number::NumberEncoder;
     use tipb::schema::ColumnInfo;

--- a/src/util/codec/table.rs
+++ b/src/util/codec/table.rs
@@ -271,6 +271,7 @@ pub fn cut_idx_key<'a>(mut key: &'a [u8], col_ids: &[i64]) -> Result<(ValDict<'a
 #[cfg(test)]
 mod test {
     use super::*;
+    use util::codec::mysql::*;
     use util::codec::datum::{self, Datum};
     use util::codec::number::NumberEncoder;
     use tipb::schema::ColumnInfo;

--- a/tests/raftstore/test_compact_log.rs
+++ b/tests/raftstore/test_compact_log.rs
@@ -60,7 +60,7 @@ fn test_compact_log<T: Simulator>(cluster: &mut Cluster<T>) {
             get_msg_cf_or_default(engine, CF_RAFT, &keys::apply_state_key(1));
         let after_state = state.take_truncated_state();
 
-        let before_state = before_states.get(&id).unwrap();
+        let before_state = &before_states[&id];
         let idx = after_state.get_index();
         assert!(idx > before_state.get_index());
         assert!(after_state.get_term() > before_state.get_term());
@@ -111,7 +111,7 @@ fn test_compact_count_limit<T: Simulator>(cluster: &mut Cluster<T>) {
             get_msg_cf_or_default(engine, CF_RAFT, &keys::apply_state_key(1));
         let after_state = state.take_truncated_state();
 
-        let before_state = before_states.get(&id).unwrap();
+        let before_state = &before_states[&id];
         let idx = after_state.get_index();
         assert_eq!(idx, before_state.get_index());
     }
@@ -132,7 +132,7 @@ fn test_compact_count_limit<T: Simulator>(cluster: &mut Cluster<T>) {
             get_msg_cf_or_default(engine, CF_RAFT, &keys::apply_state_key(1));
         let after_state = state.take_truncated_state();
 
-        let before_state = before_states.get(&id).unwrap();
+        let before_state = &before_states[&id];
         let idx = after_state.get_index();
         assert!(idx > before_state.get_index());
 
@@ -183,7 +183,7 @@ fn test_compact_many_times<T: Simulator>(cluster: &mut Cluster<T>) {
             get_msg_cf_or_default(engine, CF_RAFT, &keys::apply_state_key(1));
         let after_state = state.take_truncated_state();
 
-        let before_state = before_states.get(&id).unwrap();
+        let before_state = &before_states[&id];
         let idx = after_state.get_index();
         // Compact raft log at least 2 times.
         assert!(idx - before_state.get_index() >= gc_limit * 2);
@@ -282,7 +282,7 @@ fn test_compact_size_limit<T: Simulator>(cluster: &mut Cluster<T>) {
             get_msg_cf_or_default(engine, CF_RAFT, &keys::apply_state_key(1));
         let after_state = state.take_truncated_state();
 
-        let before_state = before_states.get(&id).unwrap();
+        let before_state = &before_states[&id];
         let idx = after_state.get_index();
         assert_eq!(idx, before_state.get_index());
     }
@@ -308,7 +308,7 @@ fn test_compact_size_limit<T: Simulator>(cluster: &mut Cluster<T>) {
             get_msg_cf_or_default(engine, CF_RAFT, &keys::apply_state_key(1));
         let after_state = state.take_truncated_state();
 
-        let before_state = before_states.get(&id).unwrap();
+        let before_state = &before_states[&id];
         let idx = after_state.get_index();
         assert!(idx > before_state.get_index());
 

--- a/tests/raftstore/test_region_heartbeat.rs
+++ b/tests/raftstore/test_region_heartbeat.rs
@@ -58,8 +58,8 @@ fn test_leader_down_and_become_leader_again<T: Simulator>(cluster: &mut Cluster<
     let down_secs = begin.elapsed().as_secs();
     let down_peers = cluster.get_down_peers();
     debug!("down_secs: {} down_peers: {:?}", down_secs, down_peers);
-    check_down_seconds(down_peers.get(&node_id).unwrap(), down_secs);
-    check_down_seconds(down_peers.get(&next_id).unwrap(), down_secs);
+    check_down_seconds(&down_peers[&node_id], down_secs);
+    check_down_seconds(&down_peers[&next_id], down_secs);
 
     // Restart node and sleep a few seconds.
     let sleep_secs = 3;
@@ -81,9 +81,9 @@ fn test_leader_down_and_become_leader_again<T: Simulator>(cluster: &mut Cluster<
     wait_down_peers(cluster, 1);
 
     // Ensure that node will not reuse the previous peer heartbeats.
-    let prev_secs = cluster.get_down_peers().get(&next_id).unwrap().get_down_seconds();
+    let prev_secs = cluster.get_down_peers()[&next_id].get_down_seconds();
     for _ in 1..100 {
-        let down_secs = cluster.get_down_peers().get(&next_id).unwrap().get_down_seconds();
+        let down_secs = cluster.get_down_peers()[&next_id].get_down_seconds();
         if down_secs != prev_secs {
             assert!(down_secs < sleep_secs);
             break;
@@ -103,8 +103,8 @@ fn test_down_peers<T: Simulator>(cluster: &mut Cluster<T>, count: u64) {
 
     // Check 1, 3 are down.
     let down_peers = cluster.get_down_peers();
-    check_down_seconds(down_peers.get(&1).unwrap(), secs);
-    check_down_seconds(down_peers.get(&3).unwrap(), secs);
+    check_down_seconds(&down_peers[&1], secs);
+    check_down_seconds(&down_peers[&3], secs);
 
     // Restart 1, 3
     cluster.run_node(1);


### PR DESCRIPTION
Make clippy happy:
1. called `.get().unwrap()` on a HashMap. Using `[]` is more clear and more concise.
2. remove unused import.