### PR TITLE
optimize for short value

### DIFF
--- a/src/bin/tikv-ctl.rs
+++ b/src/bin/tikv-ctl.rs
@@ -274,6 +274,7 @@ fn dump_mvcc_write(db: &DB, key: &str, encoded: bool) {
         println!("Type: {:?}", write.write_type);
         println!("Start_ts: {:?}", write.start_ts);
         println!("Commit_ts: {:?}", commit_ts);
+        println!("Short value: {:?}", write.short_value);
         println!("");
     }
 }

--- a/src/bin/tikv-ctl.rs
+++ b/src/bin/tikv-ctl.rs
@@ -410,7 +410,7 @@ mod tests {
             })
             .collect();
         let lock_value: Vec<_> = test_data_lock.iter()
-            .map(|data| Lock::new(data.1, data.2.to_vec(), data.3, 0).to_bytes())
+            .map(|data| Lock::new(data.1, data.2.to_vec(), data.3, 0, None).to_bytes())
             .collect();
         let kvs = keys.iter().zip(lock_value.iter());
         let lock_cf = db.cf_handle(CF_LOCK).unwrap();
@@ -444,7 +444,7 @@ mod tests {
             })
             .collect();
         let write_value: Vec<_> = test_data_write.iter()
-            .map(|data| Write::new(data.1, data.2).to_bytes())
+            .map(|data| Write::new(data.1, data.2, None).to_bytes())
             .collect();
         let kvs = keys.iter().zip(write_value.iter());
         let write_cf = db.cf_handle(CF_WRITE).unwrap();

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -349,16 +349,16 @@ fn get_rocksdb_lock_cf_option() -> RocksdbOptions {
     let mut opts = RocksdbOptions::new();
     let mut block_base_opts = BlockBasedOptions::new();
     block_base_opts.set_block_size(16 * 1024);
-    block_base_opts.set_lru_cache(32 * 1024 * 1024);
+    block_base_opts.set_lru_cache(64 * 1024 * 1024);
     block_base_opts.set_bloom_filter(10, false);
     opts.set_block_based_table_factory(&block_base_opts);
 
     let cpl = "no:no:no:no:no:no:no".to_owned();
     let per_level_compression = util::config::parse_rocksdb_per_level_compression(&cpl).unwrap();
     opts.compression_per_level(&per_level_compression);
-    opts.set_write_buffer_size(32 * 1024 * 1024);
+    opts.set_write_buffer_size(64 * 1024 * 1024);
     opts.set_max_write_buffer_number(5);
-    opts.set_max_bytes_for_level_base(32 * 1024 * 1024);
+    opts.set_max_bytes_for_level_base(64 * 1024 * 1024);
     opts.set_target_file_size_base(32 * 1024 * 1024);
 
     // set level0_file_num_compaction_trigger = 1 is very important,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -43,6 +43,13 @@ pub const CF_WRITE: CfName = "write";
 pub const CF_RAFT: CfName = "raft";
 pub const ALL_CFS: &'static [CfName] = &[CF_DEFAULT, CF_LOCK, CF_WRITE, CF_RAFT];
 
+pub const SHORT_VALUE_MAX_LEN: usize = 32;
+pub const SHORT_VALUE_PREFIX: u8 = b'v';
+
+pub fn is_short_value(value: &[u8]) -> bool {
+    value.len() <= SHORT_VALUE_MAX_LEN
+}
+
 #[derive(Debug, Clone)]
 pub enum Mutation {
     Put((Key, Value)),

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -43,6 +43,7 @@ pub const CF_WRITE: CfName = "write";
 pub const CF_RAFT: CfName = "raft";
 pub const ALL_CFS: &'static [CfName] = &[CF_DEFAULT, CF_LOCK, CF_WRITE, CF_RAFT];
 
+// Short value max len must <= 255.
 pub const SHORT_VALUE_MAX_LEN: usize = 64;
 pub const SHORT_VALUE_PREFIX: u8 = b'v';
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -43,7 +43,7 @@ pub const CF_WRITE: CfName = "write";
 pub const CF_RAFT: CfName = "raft";
 pub const ALL_CFS: &'static [CfName] = &[CF_DEFAULT, CF_LOCK, CF_WRITE, CF_RAFT];
 
-pub const SHORT_VALUE_MAX_LEN: usize = 32;
+pub const SHORT_VALUE_MAX_LEN: usize = 64;
 pub const SHORT_VALUE_PREFIX: u8 = b'v';
 
 pub fn is_short_value(value: &[u8]) -> bool {

--- a/src/storage/mvcc/lock.rs
+++ b/src/storage/mvcc/lock.rs
@@ -113,7 +113,7 @@ impl Lock {
             if try!(b.read_u8()) == SHORT_VALUE_PREFIX {
                 Some(b.to_vec())
             } else {
-                None
+                panic!("invalid content in lock");
             }
         } else {
             None

--- a/src/storage/mvcc/lock.rs
+++ b/src/storage/mvcc/lock.rs
@@ -91,6 +91,7 @@ impl Lock {
         b.encode_var_u64(self.ttl).unwrap();
         if let Some(ref v) = self.short_value {
             b.push(SHORT_VALUE_PREFIX);
+            b.push(v.len() as u8);
             b.extend_from_slice(v);
         }
         b
@@ -111,6 +112,10 @@ impl Lock {
 
         let short_value = if b.len() > 0 {
             if try!(b.read_u8()) == SHORT_VALUE_PREFIX {
+                let len = try!(b.read_u8());
+                if len as usize != b.len() {
+                    panic!("short value len not equal to content");
+                }
                 Some(b.to_vec())
             } else {
                 panic!("invalid content in lock");

--- a/src/storage/mvcc/lock.rs
+++ b/src/storage/mvcc/lock.rs
@@ -83,15 +83,15 @@ impl Lock {
 
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut b = Vec::with_capacity(1 + MAX_VAR_U64_LEN + self.primary.len() + MAX_VAR_U64_LEN +
-                                       SHORT_VALUE_MAX_LEN + 1);
+                                       SHORT_VALUE_MAX_LEN +
+                                       1);
         b.push(self.lock_type.to_u8());
         b.encode_compact_bytes(&self.primary).unwrap();
         b.encode_var_u64(self.ts).unwrap();
         b.encode_var_u64(self.ttl).unwrap();
         if let Some(ref v) = self.short_value {
             b.push(SHORT_VALUE_PREFIX);
-            let mut v = v.clone();
-            b.append(&mut v);
+            b.extend_from_slice(v);
         }
         b
     }

--- a/src/storage/mvcc/lock.rs
+++ b/src/storage/mvcc/lock.rs
@@ -83,7 +83,7 @@ impl Lock {
 
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut b = Vec::with_capacity(1 + MAX_VAR_U64_LEN + self.primary.len() + MAX_VAR_U64_LEN +
-                                       SHORT_VALUE_MAX_LEN);
+                                       SHORT_VALUE_MAX_LEN + 1);
         b.push(self.lock_type.to_u8());
         b.encode_compact_bytes(&self.primary).unwrap();
         b.encode_var_u64(self.ts).unwrap();

--- a/src/storage/mvcc/lock.rs
+++ b/src/storage/mvcc/lock.rs
@@ -111,14 +111,17 @@ impl Lock {
         };
 
         let short_value = if b.len() > 0 {
-            if try!(b.read_u8()) == SHORT_VALUE_PREFIX {
+            let flag = try!(b.read_u8());
+            if flag == SHORT_VALUE_PREFIX {
                 let len = try!(b.read_u8());
                 if len as usize != b.len() {
-                    panic!("short value len not equal to content");
+                    panic!("short value len [{}] not equal to content len [{}]",
+                           len,
+                           b.len());
                 }
                 Some(b.to_vec())
             } else {
-                panic!("invalid content in lock");
+                panic!("invalid flag [{:?}] in write", flag);
             }
         } else {
             None

--- a/src/storage/mvcc/lock.rs
+++ b/src/storage/mvcc/lock.rs
@@ -84,7 +84,7 @@ impl Lock {
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut b = Vec::with_capacity(1 + MAX_VAR_U64_LEN + self.primary.len() + MAX_VAR_U64_LEN +
                                        SHORT_VALUE_MAX_LEN +
-                                       1);
+                                       2);
         b.push(self.lock_type.to_u8());
         b.encode_compact_bytes(&self.primary).unwrap();
         b.encode_var_u64(self.ts).unwrap();

--- a/src/storage/mvcc/reader.rs
+++ b/src/storage/mvcc/reader.rs
@@ -161,7 +161,7 @@ impl<'a> MvccReader<'a> {
                         WriteType::Put => {
                             if write.short_value.is_some() {
                                 if self.key_only {
-                                    return Ok(vec![]);
+                                    return Ok(Some(vec![]));
                                 }
                                 return Ok(write.short_value.take());
                             }

--- a/src/storage/mvcc/reader.rs
+++ b/src/storage/mvcc/reader.rs
@@ -156,9 +156,14 @@ impl<'a> MvccReader<'a> {
         }
         loop {
             match try!(self.seek_write(key, ts)) {
-                Some((commit_ts, write)) => {
+                Some((commit_ts, mut write)) => {
                     match write.write_type {
-                        WriteType::Put => return self.load_data(key, write.start_ts).map(Some),
+                        WriteType::Put => {
+                            if write.short_value.is_some() {
+                                return Ok(write.short_value.take());
+                            }
+                            return self.load_data(key, write.start_ts).map(Some);
+                        }
                         WriteType::Delete => return Ok(None),
                         WriteType::Lock | WriteType::Rollback => ts = commit_ts - 1,
                     }

--- a/src/storage/mvcc/reader.rs
+++ b/src/storage/mvcc/reader.rs
@@ -160,6 +160,9 @@ impl<'a> MvccReader<'a> {
                     match write.write_type {
                         WriteType::Put => {
                             if write.short_value.is_some() {
+                                if self.key_only {
+                                    return Ok(vec![]);
+                                }
                                 return Ok(write.short_value.take());
                             }
                             return self.load_data(key, write.start_ts).map(Some);

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -610,7 +610,10 @@ mod tests {
         assert!(txn.get(&key).unwrap().is_none());
         assert_eq!(txn.write_size, 0);
 
-        txn.prewrite(Mutation::Put((key.clone(), v.to_vec())), pk, &Options::default()).unwrap();
+        txn.prewrite(Mutation::Put((key.clone(), v.to_vec())),
+                      pk,
+                      &Options::default())
+            .unwrap();
         assert!(txn.write_size() > 0);
         engine.write(&ctx, txn.modifies()).unwrap();
 

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -274,141 +274,191 @@ mod tests {
     use super::MvccTxn;
     use super::super::MvccReader;
     use super::super::write::{Write, WriteType};
-    use storage::{make_key, Mutation, ALL_CFS, CF_WRITE, ScanMode, Options};
+    use storage::{make_key, Mutation, ALL_CFS, CF_WRITE, ScanMode, Options, SHORT_VALUE_MAX_LEN};
     use storage::engine::{self, Engine, TEMP_DIR};
+
+    fn gen_value(v: u8, len: usize) -> Vec<u8> {
+        let mut value = Vec::with_capacity(len);
+        for _ in 0..len {
+            value.push(v);
+        }
+
+        value
+    }
+
+    fn test_mvcc_txn_read_imp(k: &[u8], v: &[u8]) {
+        let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
+
+        must_get_none(engine.as_ref(), k, 1);
+
+        must_prewrite_put(engine.as_ref(), k, v, k, 5);
+        must_get_none(engine.as_ref(), k, 3);
+        must_get_err(engine.as_ref(), k, 7);
+
+        must_commit(engine.as_ref(), k, 5, 10);
+        must_get_none(engine.as_ref(), k, 3);
+        must_get_none(engine.as_ref(), k, 7);
+        must_get(engine.as_ref(), k, 13, v);
+
+        must_prewrite_delete(engine.as_ref(), k, k, 15);
+        must_commit(engine.as_ref(), k, 15, 20);
+        must_get_none(engine.as_ref(), k, 3);
+        must_get_none(engine.as_ref(), k, 7);
+        must_get(engine.as_ref(), k, 13, v);
+        must_get(engine.as_ref(), k, 17, v);
+        must_get_none(engine.as_ref(), k, 23);
+    }
 
     #[test]
     fn test_mvcc_txn_read() {
+        test_mvcc_txn_read_imp(b"k1", b"v1");
+
+        let long_value = gen_value(b'v', SHORT_VALUE_MAX_LEN + 1);
+        test_mvcc_txn_read_imp(b"k2", &long_value);
+    }
+
+    fn test_mvcc_txn_prewrite_imp(k: &[u8], v: &[u8]) {
         let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
 
-        must_get_none(engine.as_ref(), b"x", 1);
+        must_prewrite_put(engine.as_ref(), k, v, k, 5);
+        // Key is locked.
+        must_locked(engine.as_ref(), k, 5);
+        // Retry prewrite.
+        must_prewrite_put(engine.as_ref(), k, v, k, 5);
+        // Conflict.
+        must_prewrite_lock_err(engine.as_ref(), k, k, 6);
 
-        must_prewrite_put(engine.as_ref(), b"x", b"x5", b"x", 5);
-        must_get_none(engine.as_ref(), b"x", 3);
-        must_get_err(engine.as_ref(), b"x", 7);
-
-        must_commit(engine.as_ref(), b"x", 5, 10);
-        must_get_none(engine.as_ref(), b"x", 3);
-        must_get_none(engine.as_ref(), b"x", 7);
-        must_get(engine.as_ref(), b"x", 13, b"x5");
-
-        must_prewrite_delete(engine.as_ref(), b"x", b"x", 15);
-        must_commit(engine.as_ref(), b"x", 15, 20);
-        must_get_none(engine.as_ref(), b"x", 3);
-        must_get_none(engine.as_ref(), b"x", 7);
-        must_get(engine.as_ref(), b"x", 13, b"x5");
-        must_get(engine.as_ref(), b"x", 17, b"x5");
-        must_get_none(engine.as_ref(), b"x", 23);
+        must_commit(engine.as_ref(), k, 5, 10);
+        must_written(engine.as_ref(), k, 5, 10, WriteType::Put);
+        // Write conflict.
+        must_prewrite_lock_err(engine.as_ref(), k, k, 6);
+        must_unlocked(engine.as_ref(), k);
+        // Not conflict.
+        must_prewrite_lock(engine.as_ref(), k, k, 12);
+        must_locked(engine.as_ref(), k, 12);
+        must_rollback(engine.as_ref(), k, 12);
+        must_unlocked(engine.as_ref(), k);
+        must_written(engine.as_ref(), k, 12, 12, WriteType::Rollback);
+        // Cannot retry Prewrite after rollback.
+        must_prewrite_lock_err(engine.as_ref(), k, k, 12);
+        // Can prewrite after rollback.
+        must_prewrite_delete(engine.as_ref(), k, k, 13);
+        must_rollback(engine.as_ref(), k, 13);
+        must_unlocked(engine.as_ref(), k);
     }
 
     #[test]
     fn test_mvcc_txn_prewrite() {
+        test_mvcc_txn_prewrite_imp(b"k1", b"v1");
+
+        let long_value = gen_value(b'v', SHORT_VALUE_MAX_LEN + 1);
+        test_mvcc_txn_prewrite_imp(b"k2", &long_value);
+    }
+
+    fn test_mvcc_txn_commit_ok_imp(k1: &[u8], v1: &[u8], k2: &[u8], k3: &[u8]) {
         let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
-
-        must_prewrite_put(engine.as_ref(), b"x", b"x5", b"x", 5);
-        // Key is locked.
-        must_locked(engine.as_ref(), b"x", 5);
-        // Retry prewrite.
-        must_prewrite_put(engine.as_ref(), b"x", b"x5", b"x", 5);
-        // Conflict.
-        must_prewrite_lock_err(engine.as_ref(), b"x", b"x", 6);
-
-        must_commit(engine.as_ref(), b"x", 5, 10);
-        must_written(engine.as_ref(), b"x", 5, 10, WriteType::Put);
-        // Write conflict.
-        must_prewrite_lock_err(engine.as_ref(), b"x", b"x", 6);
-        must_unlocked(engine.as_ref(), b"x");
-        // Not conflict.
-        must_prewrite_lock(engine.as_ref(), b"x", b"x", 12);
-        must_locked(engine.as_ref(), b"x", 12);
-        must_rollback(engine.as_ref(), b"x", 12);
-        must_unlocked(engine.as_ref(), b"x");
-        must_written(engine.as_ref(), b"x", 12, 12, WriteType::Rollback);
-        // Cannot retry Prewrite after rollback.
-        must_prewrite_lock_err(engine.as_ref(), b"x", b"x", 12);
-        // Can prewrite after rollback.
-        must_prewrite_delete(engine.as_ref(), b"x", b"x", 13);
-        must_rollback(engine.as_ref(), b"x", 13);
-        must_unlocked(engine.as_ref(), b"x");
+        must_prewrite_put(engine.as_ref(), k1, v1, k1, 10);
+        must_prewrite_lock(engine.as_ref(), k2, k1, 10);
+        must_prewrite_delete(engine.as_ref(), k3, k1, 10);
+        must_locked(engine.as_ref(), k1, 10);
+        must_locked(engine.as_ref(), k2, 10);
+        must_locked(engine.as_ref(), k3, 10);
+        must_commit(engine.as_ref(), k1, 10, 15);
+        must_commit(engine.as_ref(), k2, 10, 15);
+        must_commit(engine.as_ref(), k3, 10, 15);
+        must_written(engine.as_ref(), k1, 10, 15, WriteType::Put);
+        must_written(engine.as_ref(), k2, 10, 15, WriteType::Lock);
+        must_written(engine.as_ref(), k3, 10, 15, WriteType::Delete);
+        // commit should be idempotent
+        must_commit(engine.as_ref(), k1, 10, 15);
+        must_commit(engine.as_ref(), k2, 10, 15);
+        must_commit(engine.as_ref(), k3, 10, 15);
     }
 
     #[test]
     fn test_mvcc_txn_commit_ok() {
+        test_mvcc_txn_commit_ok_imp(b"x", b"v", b"y", b"z");
+
+        let long_value = gen_value(b'v', SHORT_VALUE_MAX_LEN + 1);
+        test_mvcc_txn_commit_ok_imp(b"x", &long_value, b"y", b"z");
+    }
+
+    fn test_mvcc_txn_commit_err_imp(k: &[u8], v: &[u8]) {
         let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
-        must_prewrite_put(engine.as_ref(), b"x", b"x10", b"x", 10);
-        must_prewrite_lock(engine.as_ref(), b"y", b"x", 10);
-        must_prewrite_delete(engine.as_ref(), b"z", b"x", 10);
-        must_locked(engine.as_ref(), b"x", 10);
-        must_locked(engine.as_ref(), b"y", 10);
-        must_locked(engine.as_ref(), b"z", 10);
-        must_commit(engine.as_ref(), b"x", 10, 15);
-        must_commit(engine.as_ref(), b"y", 10, 15);
-        must_commit(engine.as_ref(), b"z", 10, 15);
-        must_written(engine.as_ref(), b"x", 10, 15, WriteType::Put);
-        must_written(engine.as_ref(), b"y", 10, 15, WriteType::Lock);
-        must_written(engine.as_ref(), b"z", 10, 15, WriteType::Delete);
-        // commit should be idempotent
-        must_commit(engine.as_ref(), b"x", 10, 15);
-        must_commit(engine.as_ref(), b"y", 10, 15);
-        must_commit(engine.as_ref(), b"z", 10, 15);
+
+        // Not prewrite yet
+        must_commit_err(engine.as_ref(), k, 1, 2);
+        must_prewrite_put(engine.as_ref(), k, v, k, 5);
+        // start_ts not match
+        must_commit_err(engine.as_ref(), k, 4, 5);
+        must_rollback(engine.as_ref(), k, 5);
+        // commit after rollback
+        must_commit_err(engine.as_ref(), k, 5, 6);
     }
 
     #[test]
     fn test_mvcc_txn_commit_err() {
+        test_mvcc_txn_commit_err_imp(b"k", b"v");
+
+        let long_value = gen_value(b'v', SHORT_VALUE_MAX_LEN + 1);
+        test_mvcc_txn_commit_err_imp(b"k2", &long_value);
+    }
+
+    fn test_mvcc_txn_rollback_imp(k: &[u8], v: &[u8]) {
         let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
 
-        // Not prewrite yet
-        must_commit_err(engine.as_ref(), b"x", 1, 2);
-        must_prewrite_put(engine.as_ref(), b"x", b"x5", b"x", 5);
-        // start_ts not match
-        must_commit_err(engine.as_ref(), b"x", 4, 5);
-        must_rollback(engine.as_ref(), b"x", 5);
-        // commit after rollback
-        must_commit_err(engine.as_ref(), b"x", 5, 6);
+        must_prewrite_put(engine.as_ref(), k, v, k, 5);
+        must_rollback(engine.as_ref(), k, 5);
+        // rollback should be idempotent
+        must_rollback(engine.as_ref(), k, 5);
+        // lock should be released after rollback
+        must_unlocked(engine.as_ref(), k);
+        must_prewrite_lock(engine.as_ref(), k, k, 10);
+        must_rollback(engine.as_ref(), k, 10);
+        // data should be dropped after rollback
+        must_get_none(engine.as_ref(), k, 20);
     }
 
     #[test]
     fn test_mvcc_txn_rollback() {
+        test_mvcc_txn_rollback_imp(b"k", b"v");
+
+        let long_value = gen_value(b'v', SHORT_VALUE_MAX_LEN + 1);
+        test_mvcc_txn_rollback_imp(b"k2", &long_value);
+    }
+
+    fn test_mvcc_txn_rollback_err_imp(k: &[u8], v: &[u8]) {
         let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
 
-        must_prewrite_put(engine.as_ref(), b"x", b"x5", b"x", 5);
-        must_rollback(engine.as_ref(), b"x", 5);
-        // rollback should be idempotent
-        must_rollback(engine.as_ref(), b"x", 5);
-        // lock should be released after rollback
-        must_unlocked(engine.as_ref(), b"x");
-        must_prewrite_lock(engine.as_ref(), b"x", b"x", 10);
-        must_rollback(engine.as_ref(), b"x", 10);
-        // data should be dropped after rollback
-        must_get_none(engine.as_ref(), b"x", 20);
+        must_prewrite_put(engine.as_ref(), k, v, k, 5);
+        must_commit(engine.as_ref(), k, 5, 10);
+        must_rollback_err(engine.as_ref(), k, 5);
+        must_rollback_err(engine.as_ref(), k, 5);
     }
 
     #[test]
     fn test_mvcc_txn_rollback_err() {
-        let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
+        test_mvcc_txn_rollback_err_imp(b"k", b"v");
 
-        must_prewrite_put(engine.as_ref(), b"x", b"x5", b"x", 5);
-        must_commit(engine.as_ref(), b"x", 5, 10);
-        must_rollback_err(engine.as_ref(), b"x", 5);
-        must_rollback_err(engine.as_ref(), b"x", 5);
+        let long_value = gen_value(b'v', SHORT_VALUE_MAX_LEN + 1);
+        test_mvcc_txn_rollback_err_imp(b"k2", &long_value);
     }
 
-    #[test]
-    fn test_gc() {
+    fn test_gc_imp(k: &[u8], v1: &[u8], v2: &[u8], v3: &[u8], v4: &[u8]) {
         let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
 
-        must_prewrite_put(engine.as_ref(), b"x", b"x5", b"x", 5);
-        must_commit(engine.as_ref(), b"x", 5, 10);
-        must_prewrite_put(engine.as_ref(), b"x", b"x15", b"x", 15);
-        must_commit(engine.as_ref(), b"x", 15, 20);
-        must_prewrite_delete(engine.as_ref(), b"x", b"x", 25);
-        must_commit(engine.as_ref(), b"x", 25, 30);
-        must_prewrite_put(engine.as_ref(), b"x", b"x35", b"x", 35);
-        must_commit(engine.as_ref(), b"x", 35, 40);
-        must_prewrite_lock(engine.as_ref(), b"x", b"x", 45);
-        must_commit(engine.as_ref(), b"x", 45, 50);
-        must_prewrite_put(engine.as_ref(), b"x", b"x55", b"x", 55);
-        must_rollback(engine.as_ref(), b"x", 55);
+        must_prewrite_put(engine.as_ref(), k, v1, k, 5);
+        must_commit(engine.as_ref(), k, 5, 10);
+        must_prewrite_put(engine.as_ref(), k, v2, k, 15);
+        must_commit(engine.as_ref(), k, 15, 20);
+        must_prewrite_delete(engine.as_ref(), k, k, 25);
+        must_commit(engine.as_ref(), k, 25, 30);
+        must_prewrite_put(engine.as_ref(), k, v3, k, 35);
+        must_commit(engine.as_ref(), k, 35, 40);
+        must_prewrite_lock(engine.as_ref(), k, k, 45);
+        must_commit(engine.as_ref(), k, 45, 50);
+        must_prewrite_put(engine.as_ref(), k, v4, k, 55);
+        must_rollback(engine.as_ref(), k, 55);
 
         // Transactions:
         // startTS commitTS Command
@@ -435,100 +485,132 @@ mod tests {
         // 10             Commit(PUT,5)
         // 5    x5
 
-        must_gc(engine.as_ref(), b"x", 12);
-        must_get(engine.as_ref(), b"x", 12, b"x5");
+        must_gc(engine.as_ref(), k, 12);
+        must_get(engine.as_ref(), k, 12, v1);
 
-        must_gc(engine.as_ref(), b"x", 22);
-        must_get(engine.as_ref(), b"x", 22, b"x15");
-        must_get_none(engine.as_ref(), b"x", 12);
+        must_gc(engine.as_ref(), k, 22);
+        must_get(engine.as_ref(), k, 22, v2);
+        must_get_none(engine.as_ref(), k, 12);
 
-        must_gc(engine.as_ref(), b"x", 32);
-        must_get_none(engine.as_ref(), b"x", 22);
-        must_get_none(engine.as_ref(), b"x", 35);
+        must_gc(engine.as_ref(), k, 32);
+        must_get_none(engine.as_ref(), k, 22);
+        must_get_none(engine.as_ref(), k, 35);
 
-        must_gc(engine.as_ref(), b"x", 60);
-        must_get(engine.as_ref(), b"x", 62, b"x35");
+        must_gc(engine.as_ref(), k, 60);
+        must_get(engine.as_ref(), k, 62, v3);
     }
 
     #[test]
-    fn test_write() {
+    fn test_gc() {
+        test_gc_imp(b"k1", b"v1", b"v2", b"v3", b"v4");
+
+        let v1 = gen_value(b'x', SHORT_VALUE_MAX_LEN + 1);
+        let v2 = gen_value(b'y', SHORT_VALUE_MAX_LEN + 1);
+        let v3 = gen_value(b'z', SHORT_VALUE_MAX_LEN + 1);
+        let v4 = gen_value(b'v', SHORT_VALUE_MAX_LEN + 1);
+        test_gc_imp(b"k2", &v1, &v2, &v3, &v4);
+    }
+
+    fn test_write_imp(k: &[u8], v: &[u8], k2: &[u8], k3: &[u8]) {
         let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
 
-        must_prewrite_put(engine.as_ref(), b"x", b"x5", b"x", 5);
-        must_seek_write_none(engine.as_ref(), b"x", 5);
+        must_prewrite_put(engine.as_ref(), k, v, k, 5);
+        must_seek_write_none(engine.as_ref(), k, 5);
 
-        must_commit(engine.as_ref(), b"x", 5, 10);
-        must_seek_write(engine.as_ref(),
-                        b"x",
-                        u64::max_value(),
-                        5,
-                        10,
-                        WriteType::Put);
-        must_reverse_seek_write(engine.as_ref(), b"x", 5, 5, 10, WriteType::Put);
-        must_seek_write_none(engine.as_ref(), b"a", u64::max_value());
-        must_reverse_seek_write_none(engine.as_ref(), b"y", 5);
-        must_get_commit_ts(engine.as_ref(), b"x", 5, 10);
+        must_commit(engine.as_ref(), k, 5, 10);
+        must_seek_write(engine.as_ref(), k, u64::max_value(), 5, 10, WriteType::Put);
+        must_reverse_seek_write(engine.as_ref(), k, 5, 5, 10, WriteType::Put);
+        must_seek_write_none(engine.as_ref(), k2, u64::max_value());
+        must_reverse_seek_write_none(engine.as_ref(), k3, 5);
+        must_get_commit_ts(engine.as_ref(), k, 5, 10);
 
-        must_prewrite_delete(engine.as_ref(), b"x", b"x", 15);
-        must_rollback(engine.as_ref(), b"x", 15);
+        must_prewrite_delete(engine.as_ref(), k, k, 15);
+        must_rollback(engine.as_ref(), k, 15);
         must_seek_write(engine.as_ref(),
-                        b"x",
+                        k,
                         u64::max_value(),
                         15,
                         15,
                         WriteType::Rollback);
-        must_reverse_seek_write_none(engine.as_ref(), b"x", 15);
-        must_get_commit_ts(engine.as_ref(), b"x", 5, 10);
-        must_get_commit_ts_none(engine.as_ref(), b"x", 15);
+        must_reverse_seek_write_none(engine.as_ref(), k, 15);
+        must_get_commit_ts(engine.as_ref(), k, 5, 10);
+        must_get_commit_ts_none(engine.as_ref(), k, 15);
 
-        must_prewrite_lock(engine.as_ref(), b"x", b"x", 25);
-        must_commit(engine.as_ref(), b"x", 25, 30);
+        must_prewrite_lock(engine.as_ref(), k, k, 25);
+        must_commit(engine.as_ref(), k, 25, 30);
         must_seek_write(engine.as_ref(),
-                        b"x",
+                        k,
                         u64::max_value(),
                         25,
                         30,
                         WriteType::Lock);
-        must_reverse_seek_write(engine.as_ref(), b"x", 25, 25, 30, WriteType::Lock);
-        must_get_commit_ts(engine.as_ref(), b"x", 25, 30);
+        must_reverse_seek_write(engine.as_ref(), k, 25, 25, 30, WriteType::Lock);
+        must_get_commit_ts(engine.as_ref(), k, 25, 30);
+    }
+
+    #[test]
+    fn test_write() {
+        test_write_imp(b"kk", b"v1", b"k", b"kkk");
+
+        let v2 = gen_value(b'x', SHORT_VALUE_MAX_LEN + 1);
+        test_write_imp(b"kk", &v2, b"k", b"kkk");
+    }
+
+    fn test_scan_keys_imp(keys: Vec<&[u8]>, values: Vec<&[u8]>) {
+        let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
+        must_prewrite_put(engine.as_ref(), keys[0], values[0], keys[0], 1);
+        must_commit(engine.as_ref(), keys[0], 1, 10);
+        must_prewrite_lock(engine.as_ref(), keys[1], keys[1], 1);
+        must_commit(engine.as_ref(), keys[1], 1, 5);
+        must_prewrite_delete(engine.as_ref(), keys[2], keys[2], 1);
+        must_commit(engine.as_ref(), keys[2], 1, 20);
+        must_prewrite_put(engine.as_ref(), keys[3], values[1], keys[3], 1);
+        must_prewrite_lock(engine.as_ref(), keys[4], keys[4], 10);
+        must_prewrite_delete(engine.as_ref(), keys[5], keys[5], 5);
+
+        must_scan_keys(engine.as_ref(),
+                       None,
+                       100,
+                       vec![keys[0], keys[1], keys[2]],
+                       None);
+        must_scan_keys(engine.as_ref(),
+                       None,
+                       3,
+                       vec![keys[0], keys[1], keys[2]],
+                       None);
+        must_scan_keys(engine.as_ref(),
+                       None,
+                       2,
+                       vec![keys[0], keys[1]],
+                       Some(keys[1]));
+        must_scan_keys(engine.as_ref(),
+                       Some(keys[1]),
+                       1,
+                       vec![keys[1]],
+                       Some(keys[1]));
     }
 
     #[test]
     fn test_scan_keys() {
-        let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
-        must_prewrite_put(engine.as_ref(), b"a", b"a", b"a", 1);
-        must_commit(engine.as_ref(), b"a", 1, 10);
-        must_prewrite_lock(engine.as_ref(), b"c", b"c", 1);
-        must_commit(engine.as_ref(), b"c", 1, 5);
-        must_prewrite_delete(engine.as_ref(), b"e", b"e", 1);
-        must_commit(engine.as_ref(), b"e", 1, 20);
-        must_prewrite_put(engine.as_ref(), b"b", b"b", b"b", 1);
-        must_prewrite_lock(engine.as_ref(), b"d", b"d", 10);
-        must_prewrite_delete(engine.as_ref(), b"f", b"f", 5);
+        test_scan_keys_imp(vec![b"a", b"c", b"e", b"b", b"d", b"f"], vec![b"a", b"b"]);
 
-        // Keys are ["a", "c", "e"].
-        must_scan_keys(engine.as_ref(), None, 100, vec![b"a", b"c", b"e"], None);
-        must_scan_keys(engine.as_ref(), None, 3, vec![b"a", b"c", b"e"], None);
-        must_scan_keys(engine.as_ref(), None, 2, vec![b"a", b"c"], Some(b"c"));
-        must_scan_keys(engine.as_ref(), Some(b"c"), 1, vec![b"c"], Some(b"c"));
+        let v1 = gen_value(b'x', SHORT_VALUE_MAX_LEN + 1);
+        let v4 = gen_value(b'v', SHORT_VALUE_MAX_LEN + 1);
+        test_scan_keys_imp(vec![b"a", b"c", b"e", b"b", b"d", b"f"], vec![&v1, &v4]);
     }
 
-    #[test]
-    fn test_write_size() {
+    fn test_write_size_imp(k: &[u8], v: &[u8], pk: &[u8]) {
         let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
         let ctx = Context::new();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot.as_ref(), 10, None);
-        let key = make_key(b"key");
+        let key = make_key(k);
         assert_eq!(txn.write_size, 0);
 
         assert!(txn.get(&key).unwrap().is_none());
         assert_eq!(txn.write_size, 0);
 
-        txn.prewrite(Mutation::Put((key.clone(), b"value".to_vec())),
-                      b"pk",
-                      &Options::default())
-            .unwrap();
+        txn.prewrite(Mutation::Put((key.clone(), v.to_vec())), pk, &Options::default()).unwrap();
         assert!(txn.write_size() > 0);
         engine.write(&ctx, txn.modifies()).unwrap();
 
@@ -537,6 +619,14 @@ mod tests {
         txn.commit(&key, 15).unwrap();
         assert!(txn.write_size() > 0);
         engine.write(&ctx, txn.modifies()).unwrap();
+    }
+
+    #[test]
+    fn test_write_size() {
+        test_write_size_imp(b"key", b"value", b"pk");
+
+        let v = gen_value(b'x', SHORT_VALUE_MAX_LEN + 1);
+        test_write_size_imp(b"key", &v, b"pk");
     }
 
     #[test]

--- a/src/storage/mvcc/write.rs
+++ b/src/storage/mvcc/write.rs
@@ -82,8 +82,7 @@ impl Write {
         b.encode_var_u64(self.start_ts).unwrap();
         if let Some(ref v) = self.short_value {
             b.push(SHORT_VALUE_PREFIX);
-            let mut v = v.clone();
-            b.append(&mut v);
+            b.extend_from_slice(v);
         }
         b
     }
@@ -98,7 +97,7 @@ impl Write {
             if try!(b.read_u8()) == SHORT_VALUE_PREFIX {
                 Some(b.to_vec())
             } else {
-                None
+                panic!("invalid write");
             }
         } else {
             None

--- a/src/storage/mvcc/write.rs
+++ b/src/storage/mvcc/write.rs
@@ -82,6 +82,7 @@ impl Write {
         b.encode_var_u64(self.start_ts).unwrap();
         if let Some(ref v) = self.short_value {
             b.push(SHORT_VALUE_PREFIX);
+            b.push(v.len() as u8);
             b.extend_from_slice(v);
         }
         b
@@ -95,6 +96,10 @@ impl Write {
         let start_ts = try!(b.decode_var_u64());
         let short_value = if b.len() > 0 {
             if try!(b.read_u8()) == SHORT_VALUE_PREFIX {
+                let len = try!(b.read_u8());
+                if len as usize != b.len() {
+                    panic!("short value len not equal to content");
+                }
                 Some(b.to_vec())
             } else {
                 panic!("invalid content in write");

--- a/src/storage/mvcc/write.rs
+++ b/src/storage/mvcc/write.rs
@@ -13,8 +13,10 @@
 
 use byteorder::ReadBytesExt;
 use util::codec::number::{NumberEncoder, NumberDecoder, MAX_VAR_U64_LEN};
+use storage::{SHORT_VALUE_PREFIX, SHORT_VALUE_MAX_LEN};
 use super::lock::LockType;
 use super::{Error, Result};
+use super::super::types::Value;
 
 #[derive(Debug,Clone,Copy,PartialEq)]
 pub enum WriteType {
@@ -62,20 +64,27 @@ impl WriteType {
 pub struct Write {
     pub write_type: WriteType,
     pub start_ts: u64,
+    pub short_value: Option<Value>,
 }
 
 impl Write {
-    pub fn new(write_type: WriteType, start_ts: u64) -> Write {
+    pub fn new(write_type: WriteType, start_ts: u64, short_value: Option<Value>) -> Write {
         Write {
             write_type: write_type,
             start_ts: start_ts,
+            short_value: short_value,
         }
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {
-        let mut b = Vec::with_capacity(1 + MAX_VAR_U64_LEN);
+        let mut b = Vec::with_capacity(1 + MAX_VAR_U64_LEN + SHORT_VALUE_MAX_LEN);
         b.push(self.write_type.to_u8());
         b.encode_var_u64(self.start_ts).unwrap();
+        if let Some(ref v) = self.short_value {
+            b.push(SHORT_VALUE_PREFIX);
+            let mut v = v.clone();
+            b.append(&mut v);
+        }
         b
     }
 
@@ -85,6 +94,15 @@ impl Write {
         }
         let write_type = try!(WriteType::from_u8(try!(b.read_u8())).ok_or(Error::BadFormatWrite));
         let start_ts = try!(b.decode_var_u64());
-        Ok(Write::new(write_type, start_ts))
+        let short_value = if b.len() > 0 {
+            if try!(b.read_u8()) == SHORT_VALUE_PREFIX {
+                Some(b.to_vec())
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        Ok(Write::new(write_type, start_ts, short_value))
     }
 }

--- a/src/storage/mvcc/write.rs
+++ b/src/storage/mvcc/write.rs
@@ -97,7 +97,7 @@ impl Write {
             if try!(b.read_u8()) == SHORT_VALUE_PREFIX {
                 Some(b.to_vec())
             } else {
-                panic!("invalid write");
+                panic!("invalid content in write");
             }
         } else {
             None

--- a/src/storage/mvcc/write.rs
+++ b/src/storage/mvcc/write.rs
@@ -77,7 +77,7 @@ impl Write {
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {
-        let mut b = Vec::with_capacity(1 + MAX_VAR_U64_LEN + SHORT_VALUE_MAX_LEN);
+        let mut b = Vec::with_capacity(1 + MAX_VAR_U64_LEN + SHORT_VALUE_MAX_LEN + 2);
         b.push(self.write_type.to_u8());
         b.encode_var_u64(self.start_ts).unwrap();
         if let Some(ref v) = self.short_value {

--- a/src/storage/mvcc/write.rs
+++ b/src/storage/mvcc/write.rs
@@ -95,14 +95,17 @@ impl Write {
         let write_type = try!(WriteType::from_u8(try!(b.read_u8())).ok_or(Error::BadFormatWrite));
         let start_ts = try!(b.decode_var_u64());
         let short_value = if b.len() > 0 {
-            if try!(b.read_u8()) == SHORT_VALUE_PREFIX {
+            let flag = try!(b.read_u8());
+            if flag == SHORT_VALUE_PREFIX {
                 let len = try!(b.read_u8());
                 if len as usize != b.len() {
-                    panic!("short value len not equal to content");
+                    panic!("short value len [{}] not equal to content len [{}]",
+                           len,
+                           b.len());
                 }
                 Some(b.to_vec())
             } else {
-                panic!("invalid content in write");
+                panic!("invalid flag [{:?}] in write", flag);
             }
         } else {
             None


### PR DESCRIPTION
In TiKV's MVCC model, content is stored in `default cf` of rocksdb, and commit info is stored in `write cf` of rocksdb, when the content is very short, the space amplification is no-negligible. The key of table index usually 30 or more bytes, and the value of table index is 1 byte or 8 bytes, the space amplification is about 2. So we store short value along with commit info in `write cf` of rocksdb.
@siddontang @BusyJay @disksing PTAL