### PR TITLE
raftstore: handle raft ready in batch

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -625,11 +625,8 @@ impl Peer {
         let mut ready = self.raft_group.ready();
         ready_timer.observe_duration();
 
-        let t = SlowTimer::new();
-
         self.update_leader_lease(&ready);
 
-        let ready_metrics = ctx.metrics.ready.clone();
         self.add_ready_metric(&ready, &mut ctx.metrics.ready);
 
         // The leader can write to disk and replicate to the followers concurrently
@@ -652,15 +649,6 @@ impl Peer {
             }
         };
         append_timer.observe_duration();
-
-        slow_log!(t,
-                  "{} handle ready, entries {}, messages \
-                   {}, snapshot {}, hard state changed {}",
-                  self.tag,
-                  ctx.metrics.ready.append - ready_metrics.append,
-                  ctx.metrics.ready.message - ready_metrics.message,
-                  ctx.metrics.ready.snapshot - ready_metrics.snapshot,
-                  ready.hs.is_some());
 
         ctx.ready_res.push((ready, invoke_ctx));
     }

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -669,12 +669,12 @@ impl Peer {
                                                  mut ready: Ready,
                                                  invoke_ctx: InvokeContext)
                                                  -> ReadyResult {
-        let apply_snap_result = self.mut_store().post_ready(invoke_ctx);
-
         if invoke_ctx.has_snapshot() {
-            // When apply snapshot, there is no log applied but not compacted yet.
+            // When apply snapshot, there is no log applied and not compacted yet.
             self.raft_log_size_hint = 0;
         }
+
+        let apply_snap_result = self.mut_store().post_ready(invoke_ctx);
 
         if !self.is_leader() {
             self.send(trans, ready.messages.drain(..), &mut metrics.message).unwrap_or_else(|e| {


### PR DESCRIPTION
When there are multiple readies to be handled, we can write them to disk at once instead of one per ready.

@siddontang @hhkbp2 PTAL