### PR TITLE
cache index and filter blocks in block cache

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -194,6 +194,11 @@ target-file-size-base = "16MB"
 # block-cache used to cache uncompressed blocks, big block-cache can speed up read
 block-cache-size = "1GB"
 
+# Indicating if we'd put index/filter blocks to the block cache.
+# If not specified, each "table reader" object will pre-load index/filter block
+# during table initialization.
+cache-index-and-filter-blocks = false
+
 # options for Column Family write
 # Column Family write used to store commit informations in MVCC model
 [rocksdb.writecf]
@@ -205,6 +210,7 @@ min-write-buffer-number-to-merge = 1
 max-bytes-for-level-base = "64MB"
 target-file-size-base = "16MB"
 block-cache-size = "256MB"
+cache-index-and-filter-blocks = false
 
 # options for Column Family raft.
 # Column Family raft is used to store raft log and raft states.

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -197,7 +197,7 @@ block-cache-size = "1GB"
 # Indicating if we'd put index/filter blocks to the block cache.
 # If not specified, each "table reader" object will pre-load index/filter block
 # during table initialization.
-cache-index-and-filter-blocks = false
+# cache-index-and-filter-blocks = true
 
 # options for Column Family write
 # Column Family write used to store commit informations in MVCC model
@@ -210,7 +210,7 @@ min-write-buffer-number-to-merge = 1
 max-bytes-for-level-base = "64MB"
 target-file-size-base = "16MB"
 block-cache-size = "256MB"
-cache-index-and-filter-blocks = false
+# cache-index-and-filter-blocks = true
 
 # options for Column Family raft.
 # Column Family raft is used to store raft log and raft states.

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -259,6 +259,12 @@ fn get_rocksdb_cf_option(config: &toml::Value,
                                         Some(block_cache_default));
     block_base_opts.set_lru_cache(block_cache_size as usize);
 
+    let cache_index_and_filter =
+        get_toml_boolean(config,
+                         (prefix.clone() + "cache-index-and-filter-blocks").as_str(),
+                         Some(false));
+    block_base_opts.set_cache_index_and_filter_blocks(cache_index_and_filter);
+
     if use_bloom_filter {
         let bloom_bits_per_key = get_toml_int(config,
                                               (prefix.clone() + "bloom-filter-bits-per-key")

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -262,7 +262,7 @@ fn get_rocksdb_cf_option(config: &toml::Value,
     let cache_index_and_filter =
         get_toml_boolean(config,
                          (prefix.clone() + "cache-index-and-filter-blocks").as_str(),
-                         Some(false));
+                         Some(true));
     block_base_opts.set_cache_index_and_filter_blocks(cache_index_and_filter);
 
     if use_bloom_filter {


### PR DESCRIPTION
When `cache_index_and_filter_blocks` is off, each `table reader` object will pre-load index/filter block during table initialization, this will takes extra memory to hold the index/filter blocks.