### PR TITLE
*: handle truncate error 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "tipb"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/tipb.git#38084aeaf922fb5d41284865d64b2113f3ae5f1c"
+source = "git+https://github.com/pingcap/tipb.git#378c9b0cba112f6f7335b3c86df6fd76c0dcfb78"
 dependencies = [
  "protobuf 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/server/coprocessor/aggregate.rs
+++ b/src/server/coprocessor/aggregate.rs
@@ -79,7 +79,7 @@ impl Sum {
     /// add others to res.
     ///
     /// return false means the others is skipped.
-    fn add_asssign(&mut self, mut args: Vec<Datum>) -> Result<bool> {
+    fn add_asssign(&mut self, ctx: &EvalContext, mut args: Vec<Datum>) -> Result<bool> {
         if args.len() != 1 {
             return Err(box_err!("sum only support one column, but got {}", args.len()));
         }
@@ -88,7 +88,7 @@ impl Sum {
             return Ok(false);
         }
         let res = match self.res.take() {
-            Some(b) => box_try!(evaluator::eval_arith(a, b, Datum::checked_add)),
+            Some(b) => box_try!(evaluator::eval_arith(ctx, a, b, Datum::checked_add)),
             None => a,
         };
         self.res = Some(res);
@@ -97,8 +97,8 @@ impl Sum {
 }
 
 impl AggrFunc for Sum {
-    fn update(&mut self, _: &EvalContext, args: Vec<Datum>) -> Result<()> {
-        try!(self.add_asssign(args));
+    fn update(&mut self, ctx: &EvalContext, args: Vec<Datum>) -> Result<()> {
+        try!(self.add_asssign(ctx, args));
         Ok(())
     }
 
@@ -120,8 +120,8 @@ struct Avg {
 }
 
 impl AggrFunc for Avg {
-    fn update(&mut self, _: &EvalContext, args: Vec<Datum>) -> Result<()> {
-        if try!(self.sum.add_asssign(args)) {
+    fn update(&mut self, ctx: &EvalContext, args: Vec<Datum>) -> Result<()> {
+        if try!(self.sum.add_asssign(ctx, args)) {
             self.cnt += 1;
         }
         Ok(())

--- a/src/server/coprocessor/endpoint.rs
+++ b/src/server/coprocessor/endpoint.rs
@@ -344,7 +344,6 @@ impl TiDbEndPoint {
                     // should we handle locked here too?
                     sel_resp.set_error(to_pb_error(&e));
                     // TODO add detail error
-                    // unwrap errors
                     resp.set_other_error(format!("{}", e));
                 } else {
                     // other error should be handle by ti client.

--- a/src/server/coprocessor/endpoint.rs
+++ b/src/server/coprocessor/endpoint.rs
@@ -344,6 +344,7 @@ impl TiDbEndPoint {
                     // should we handle locked here too?
                     sel_resp.set_error(to_pb_error(&e));
                     // TODO add detail error
+                    // unwrap errors
                     resp.set_other_error(format!("{}", e));
                 } else {
                     // other error should be handle by ti client.

--- a/src/server/coprocessor/endpoint.rs
+++ b/src/server/coprocessor/endpoint.rs
@@ -536,7 +536,7 @@ impl SelectContextCore {
         }
         try!(inflate_with_col(&mut self.eval, &self.ctx, values, &self.cond_cols, h));
         let res = box_try!(self.eval.eval(&self.ctx, self.sel.get_field_where()));
-        let b = box_try!(res.into_bool());
+        let b = box_try!(res.into_bool(&self.ctx));
         Ok(b.map_or(true, |v| !v))
     }
 

--- a/src/util/codec/convert.rs
+++ b/src/util/codec/convert.rs
@@ -63,7 +63,7 @@ pub fn bytes_to_f64(bytes: &[u8]) -> Result<f64> {
     Ok(f)
 }
 
-/// `bytes_to_f64` converts a byte array to a float64 in best effort.
+/// `bytes_to_f64_with_context` converts a byte array to a float64 in best effort.
 /// similar to `bytes_to_f64` with additional context.
 pub fn bytes_to_f64_with_context(ctx: &EvalContext, bytes: &[u8]) -> Result<f64> {
     let s = try!(str::from_utf8(bytes)).trim();

--- a/src/util/codec/convert.rs
+++ b/src/util/codec/convert.rs
@@ -46,7 +46,7 @@ pub fn bytes_to_int_without_context(bytes: &[u8]) -> Result<i64> {
 /// TODO: handle overflow.
 pub fn bytes_to_int(ctx: &EvalContext, bytes: &[u8]) -> Result<i64> {
     let s = try!(str::from_utf8(bytes)).trim();
-    let vs = get_valid_float_prefix(s);
+    let vs = get_valid_int_prefix(s);
     try!(handle_truncate(ctx, s.len() > vs.len()));
 
     bytes_to_int_without_context(vs.as_bytes())
@@ -87,6 +87,11 @@ fn handle_truncate(ctx: &EvalContext, is_truncated: bool) -> Result<()> {
     } else {
         Ok(())
     }
+}
+
+// TODO: prot `floatStrToIntStr`.
+fn get_valid_int_prefix(s: &str) -> &str {
+    get_valid_float_prefix(s)
 }
 
 fn get_valid_float_prefix(s: &str) -> &str {

--- a/src/util/codec/convert.rs
+++ b/src/util/codec/convert.rs
@@ -89,7 +89,7 @@ fn handle_truncate(ctx: &EvalContext, is_truncated: bool) -> Result<()> {
     }
 }
 
-// TODO: prot `floatStrToIntStr`.
+// TODO: port `floatStrToIntStr`.
 fn get_valid_int_prefix(s: &str) -> &str {
     get_valid_float_prefix(s)
 }

--- a/src/util/codec/convert.rs
+++ b/src/util/codec/convert.rs
@@ -183,6 +183,11 @@ mod test {
         let ctxs = vec![EvalContext {
                             tz: FixedOffset::east(0),
                             ignore_truncate: true,
+                            truncate_as_warning: true,
+                        },
+                        EvalContext {
+                            tz: FixedOffset::east(0),
+                            ignore_truncate: true,
                             truncate_as_warning: false,
                         },
                         EvalContext {
@@ -198,12 +203,12 @@ mod test {
 
         for ctx in &ctxs {
             assert!(super::handle_truncate(ctx, false).is_ok());
-            assert!(super::handle_truncate(ctx, false).is_ok());
         }
 
         assert!(super::handle_truncate(&ctxs[0], true).is_ok());
         assert!(super::handle_truncate(&ctxs[1], true).is_ok());
-        assert!(super::handle_truncate(&ctxs[2], true).is_err());
+        assert!(super::handle_truncate(&ctxs[2], true).is_ok());
+        assert!(super::handle_truncate(&ctxs[3], true).is_err());
     }
 
     #[test]

--- a/src/util/codec/convert.rs
+++ b/src/util/codec/convert.rs
@@ -43,6 +43,10 @@ pub fn bytes_to_int(bytes: &[u8]) -> Result<i64> {
     Ok(r)
 }
 
+pub fn bytes_to_int_with_context(_: &EvalContext, bytes: &[u8]) -> Result<i64> {
+    bytes_to_int(bytes)
+}
+
 /// `bytes_to_f64` converts a byte array to a float64 in best effort.
 pub fn bytes_to_f64(bytes: &[u8]) -> Result<f64> {
     let f = match std::str::from_utf8(bytes) {

--- a/src/util/codec/convert.rs
+++ b/src/util/codec/convert.rs
@@ -16,7 +16,10 @@ use std::{self, str};
 use util::xeval::EvalContext;
 use super::Result;
 
-fn bytes_to_int_without_context(bytes: &[u8]) -> Result<i64> {
+/// `bytes_to_int_without_context` converts a byte arrays to an i64
+/// in best effort, but without context.
+/// TODO: handle overflow.
+pub fn bytes_to_int_without_context(bytes: &[u8]) -> Result<i64> {
     // trim
     let mut trimed = bytes.iter().skip_while(|&&b| b == b' ' || b == b'\t');
     let mut negative = false;

--- a/src/util/codec/datum.rs
+++ b/src/util/codec/datum.rs
@@ -200,7 +200,6 @@ impl Datum {
             _ => {
                 let s = try!(str::from_utf8(bs));
                 let rd = try!(s.parse::<Res<Decimal>>());
-                info!("\n--- s: {}\n--- rd: {:?}", s, rd);
                 let d = try!(handle_truncate(ctx, rd)).unwrap();
                 let f = try!(d.as_f64());
                 self.cmp_f64(f)
@@ -869,7 +868,7 @@ fn handle_truncate<T: Display>(ctx: &EvalContext, res: Res<T>) -> Result<Res<T>>
         if ctx.ignore_truncate || ctx.truncate_as_warning {
             return Ok(res);
         } else {
-            return res.into_result().map(|d| Res::Truncated(d));
+            return res.into_result().map(Res::Truncated);
         }
     }
     Ok(res)

--- a/src/util/codec/datum.rs
+++ b/src/util/codec/datum.rs
@@ -253,7 +253,7 @@ impl Datum {
             Datum::U64(u) => Some(u != 0),
             Datum::F64(f) => Some(f.round() != 0f64),
             Datum::Bytes(ref bs) => {
-                Some(!bs.is_empty() && try!(convert::bytes_to_int_with_context(ctx, bs)) != 0)
+                Some(!bs.is_empty() && try!(convert::bytes_to_int(ctx, bs)) != 0)
             }
             Datum::Time(t) => Some(!t.is_zero()),
             Datum::Dur(d) => Some(!d.is_empty()),

--- a/src/util/codec/datum.rs
+++ b/src/util/codec/datum.rs
@@ -160,7 +160,7 @@ impl Datum {
             Datum::U64(u) => cmp_f64(u as f64, f),
             Datum::F64(ff) => cmp_f64(ff, f),
             Datum::Bytes(ref bs) => {
-                let ff = try!(convert::bytes_to_f64_with_context(ctx, bs));
+                let ff = try!(convert::bytes_to_f64(ctx, bs));
                 cmp_f64(ff, f)
             }
             Datum::Dec(ref d) => {
@@ -198,7 +198,7 @@ impl Datum {
                 Ok(d.cmp(&d2))
             }
             _ => {
-                let f = try!(convert::bytes_to_f64_with_context(ctx, bs));
+                let f = try!(convert::bytes_to_f64(ctx, bs));
                 self.cmp_f64(ctx, f)
             }
         }
@@ -287,7 +287,7 @@ impl Datum {
             Datum::I64(i) => Ok(i as f64),
             Datum::U64(u) => Ok(u as f64),
             Datum::F64(f) => Ok(f),
-            Datum::Bytes(bs) => convert::bytes_to_f64_with_context(ctx, &bs),
+            Datum::Bytes(bs) => convert::bytes_to_f64(ctx, &bs),
             Datum::Time(t) => {
                 let d = try!(t.to_decimal());
                 d.as_f64()
@@ -329,7 +329,7 @@ impl Datum {
     pub fn into_arith(self, ctx: &EvalContext) -> Result<Datum> {
         match self {
             // MySQL will convert string to float for arithmetic operation
-            Datum::Bytes(bs) => convert::bytes_to_f64_with_context(ctx, &bs).map(From::from),
+            Datum::Bytes(bs) => convert::bytes_to_f64(ctx, &bs).map(From::from),
             Datum::Time(t) => {
                 // if time has no precision, return int64
                 let dec = try!(t.to_decimal());

--- a/src/util/codec/mysql/decimal.rs
+++ b/src/util/codec/mysql/decimal.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 use std::fmt::{self, Display, Formatter};
-use std::str::FromStr;
+use std::str::{self, FromStr};
 use std::io::Write;
 use std::ops::{Deref, DerefMut, Add, Sub, Mul, Div, Rem};
 use std::{cmp, i64, u64, i32, u32, mem};
@@ -21,7 +21,6 @@ use std::cmp::Ordering;
 use byteorder::ReadBytesExt;
 
 use util::codec::{Result, Error, TEN_POW};
-use util::codec::convert;
 use util::codec::bytes::BytesDecoder;
 
 #[derive(Debug, PartialEq, Clone)]
@@ -1427,7 +1426,10 @@ impl Decimal {
         }
 
         if end_idx + 1 < bs.len() && (bs[end_idx] == b'e' || bs[end_idx] == b'E') {
-            let exp = try!(convert::bytes_to_int(&bs[end_idx + 1..]));
+            let exp = {
+                let s = try!(str::from_utf8(&bs[end_idx + 1..]));
+                box_try!(s.parse::<i64>())
+            };
             if exp > i32::MAX as i64 / 2 {
                 d.reset_to_zero();
                 return Ok(Res::Overflow(d.unwrap()));

--- a/src/util/codec/mysql/decimal.rs
+++ b/src/util/codec/mysql/decimal.rs
@@ -20,7 +20,7 @@ use std::cmp::Ordering;
 
 use byteorder::ReadBytesExt;
 
-use util::codec::{Result, Error, TEN_POW};
+use util::codec::{Result, Error, TEN_POW, convert};
 use util::codec::bytes::BytesDecoder;
 
 #[derive(Debug, PartialEq, Clone)]
@@ -1426,10 +1426,7 @@ impl Decimal {
         }
 
         if end_idx + 1 < bs.len() && (bs[end_idx] == b'e' || bs[end_idx] == b'E') {
-            let exp = {
-                let s = try!(str::from_utf8(&bs[end_idx + 1..]));
-                box_try!(s.parse::<i64>())
-            };
+            let exp = try!(convert::bytes_to_int_without_context(&bs[end_idx + 1..]));
             if exp > i32::MAX as i64 / 2 {
                 d.reset_to_zero();
                 return Ok(Res::Overflow(d.unwrap()));

--- a/src/util/codec/mysql/decimal.rs
+++ b/src/util/codec/mysql/decimal.rs
@@ -1535,6 +1535,14 @@ impl FromStr for Decimal {
     }
 }
 
+impl FromStr for Res<Decimal> {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Res<Decimal>> {
+        Decimal::from_str(s, WORD_BUF_LEN)
+    }
+}
+
 impl Display for Decimal {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
         let mut dec = self.clone();
@@ -2194,6 +2202,8 @@ mod test {
             (WORD_BUF_LEN, "2E0", Res::Ok("2")),
             (WORD_BUF_LEN, "2.2E-1", Res::Ok("0.22")),
             (WORD_BUF_LEN, "2.23E2", Res::Ok("223")),
+            (WORD_BUF_LEN, "11x", Res::Truncated("11")),
+            (WORD_BUF_LEN, "11x.", Res::Truncated("11")),
         ];
 
         for (word_buf_len, dec_str, exp) in cases {

--- a/src/util/codec/number.rs
+++ b/src/util/codec/number.rs
@@ -176,48 +176,6 @@ pub trait NumberDecoder: Read {
 
 impl<T: Read> NumberDecoder for T {}
 
-pub fn get_valid_float_prefix(s: &str) -> &str {
-    let mut saw_dot = false;
-    let mut saw_digit = false;
-    let mut valid_len = 0;
-    let mut e_idx = 0;
-    for (i, c) in s.chars().enumerate() {
-        if c == '+' || c == '-' {
-            if i != 0 && i != e_idx + 1 {
-                // "1e+1" is valid.
-                break;
-            }
-        } else if c == '.' {
-            if saw_dot {
-                // "1.1."
-                break;
-            }
-            saw_dot = true;
-            if saw_digit {
-                // "123." is valid.
-                valid_len = i + 1;
-            }
-        } else if c == 'e' || c == 'E' {
-            if !saw_digit {
-                // "+.e"
-                break;
-            }
-            if e_idx != 0 {
-                // "1e5e"
-                break;
-            }
-            e_idx = i
-        } else if c < '0' || c > '9' {
-            break;
-        } else {
-            saw_digit = true;
-            valid_len = i + 1;
-        }
-    }
-
-    &s[..valid_len]
-}
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/util/codec/number.rs
+++ b/src/util/codec/number.rs
@@ -176,6 +176,48 @@ pub trait NumberDecoder: Read {
 
 impl<T: Read> NumberDecoder for T {}
 
+pub fn get_valid_float_prefix(s: &str) -> &str {
+    let mut saw_dot = false;
+    let mut saw_digit = false;
+    let mut valid_len = 0;
+    let mut e_idx = 0;
+    for (i, c) in s.chars().enumerate() {
+        if c == '+' || c == '-' {
+            if i != 0 && i != e_idx + 1 {
+                // "1e+1" is valid.
+                break;
+            }
+        } else if c == '.' {
+            if saw_dot {
+                // "1.1."
+                break;
+            }
+            saw_dot = true;
+            if saw_digit {
+                // "123." is valid.
+                valid_len = i + 1;
+            }
+        } else if c == 'e' || c == 'E' {
+            if !saw_digit {
+                // "+.e"
+                break;
+            }
+            if e_idx != 0 {
+                // "1e5e"
+                break;
+            }
+            e_idx = i
+        } else if c < '0' || c > '9' {
+            break;
+        } else {
+            saw_digit = true;
+            valid_len = i + 1;
+        }
+    }
+
+    &s[..valid_len]
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/util/xeval/evaluator.rs
+++ b/src/util/xeval/evaluator.rs
@@ -329,7 +329,7 @@ impl Evaluator {
         where F: FnOnce(Datum, Datum) -> codec::Result<Datum>
     {
         let (left, right) = try!(self.eval_two_children(ctx, expr));
-        eval_arith(left, right, f)
+        eval_arith(ctx, left, right, f)
     }
 
     fn eval_case_when(&mut self, ctx: &EvalContext, expr: &Expr) -> Result<Datum> {
@@ -359,11 +359,11 @@ impl Evaluator {
 }
 
 #[inline]
-pub fn eval_arith<F>(left: Datum, right: Datum, f: F) -> Result<Datum>
+pub fn eval_arith<F>(ctx: &EvalContext, left: Datum, right: Datum, f: F) -> Result<Datum>
     where F: FnOnce(Datum, Datum) -> codec::Result<Datum>
 {
-    let left = try!(left.into_arith());
-    let right = try!(right.into_arith());
+    let left = try!(left.into_arith(ctx));
+    let right = try!(right.into_arith(ctx));
 
     let (left, right) = try!(Datum::coerce(left, right));
     if left == Datum::Null || right == Datum::Null {

--- a/src/util/xeval/evaluator.rs
+++ b/src/util/xeval/evaluator.rs
@@ -326,7 +326,7 @@ impl Evaluator {
     }
 
     fn eval_arith<F>(&mut self, ctx: &EvalContext, expr: &Expr, f: F) -> Result<Datum>
-        where F: FnOnce(Datum, Datum) -> codec::Result<Datum>
+        where F: FnOnce(Datum, &EvalContext, Datum) -> codec::Result<Datum>
     {
         let (left, right) = try!(self.eval_two_children(ctx, expr));
         eval_arith(ctx, left, right, f)
@@ -360,7 +360,7 @@ impl Evaluator {
 
 #[inline]
 pub fn eval_arith<F>(ctx: &EvalContext, left: Datum, right: Datum, f: F) -> Result<Datum>
-    where F: FnOnce(Datum, Datum) -> codec::Result<Datum>
+    where F: FnOnce(Datum, &EvalContext, Datum) -> codec::Result<Datum>
 {
     let left = try!(left.into_arith(ctx));
     let right = try!(right.into_arith(ctx));
@@ -370,7 +370,7 @@ pub fn eval_arith<F>(ctx: &EvalContext, left: Datum, right: Datum, f: F) -> Resu
         return Ok(Datum::Null);
     }
 
-    f(left, right).map_err(From::from)
+    f(left, ctx, right).map_err(From::from)
 }
 
 /// Check if `target` is in `value_list`.

--- a/src/util/xeval/evaluator.rs
+++ b/src/util/xeval/evaluator.rs
@@ -32,11 +32,11 @@ use chrono::FixedOffset;
 /// `FLAG_IGNORE_TRUNCATE` indicates if truncate error should be ignored.
 /// Read-only statements should ignore truncate error, write statements should not ignore
 /// truncate error.
-const FLAG_IGNORE_TRUNCATE: u64 = 1;
+pub const FLAG_IGNORE_TRUNCATE: u64 = 1;
 /// `FLAG_TRUNCATE_AS_WARNING` indicates if truncate error should be returned as warning.
 /// This flag only matters if `FLAG_IGNORE_TRUNCATE` is not set, in strict sql mode, truncate error
 /// should be returned as error, in non-strict sql mode, truncate error should be saved as warning.
-const FLAG_TRUNCATE_AS_WARNING: u64 = 1 << 1;
+pub const FLAG_TRUNCATE_AS_WARNING: u64 = 1 << 1;
 
 #[derive(Debug)]
 /// Some global variables needed in an evaluation.

--- a/src/util/xeval/evaluator.rs
+++ b/src/util/xeval/evaluator.rs
@@ -253,7 +253,7 @@ impl Evaluator {
         if d == Datum::Null {
             return Ok(Datum::Null);
         }
-        let b = try!(d.into_bool());
+        let b = try!(d.into_bool(ctx));
         Ok((b.map(|v| !v)).into())
     }
 
@@ -288,8 +288,8 @@ impl Evaluator {
                                  expr: &Expr)
                                  -> Result<(Option<bool>, Option<bool>)> {
         let (left, right) = try!(self.eval_two_children(ctx, expr));
-        let left_bool = try!(left.into_bool());
-        let right_bool = try!(right.into_bool());
+        let left_bool = try!(left.into_bool(ctx));
+        let right_bool = try!(right.into_bool(ctx));
         Ok((left_bool, right_bool))
     }
 
@@ -339,7 +339,7 @@ impl Evaluator {
                 // else statement
                 return Ok(res);
             }
-            if !try!(res.into_bool()).unwrap_or(false) {
+            if !try!(res.into_bool(ctx)).unwrap_or(false) {
                 continue;
             }
             return self.eval(ctx, &chunk[1]).map_err(From::from);

--- a/tests/coprocessor/test_select.rs
+++ b/tests/coprocessor/test_select.rs
@@ -1345,13 +1345,11 @@ fn test_handle_truncate() {
                      }];
 
     for cond in cases {
-        println!("{:?}", cond);
         // Ignore truncate error.
         let req = Select::from(&product.table)
             .where_expr(cond.clone())
             .build_with(&[FLAG_IGNORE_TRUNCATE]);
         let mut resp = handle_select(&end_point, req);
-        println!("{:?}", resp);
         assert_eq!(row_cnt(resp.get_chunks()), 1);
         let mut spliter = ChunkSpliter::new(resp.take_chunks().into_vec());
         let row = spliter.next().unwrap();


### PR DESCRIPTION
Handle truncate error.

For now the error message sent by tikv is different from tidb's. 

TiDB:

    ERROR 1105 (HY000): [1 [types:1265]Data Truncated

TiKV:

    ERROR 1105 (HY000): other error: unknown error Codec(Other(StringError("[1265] Data Truncated")))

PTAL @BusyJay @coocood @siddontang 

CC pingcap/tidb#2212