### PR TITLE
README.md : fixed deadlink in next steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you want to dive into TiDB, see [development build guide](https://github.com/
 
 + Read the [deployment doc](https://github.com/pingcap/docs/blob/master/op-guide/binary-deployment.md#multi-nodes-deployment) on how to run the TiDB project.
 + Learn the [configuration explanations](https://github.com/pingcap/docs/blob/master/op-guide/configuration.md).
-+ Use [Docker](https://github.com/pingcap/docs/blob/master/op-guide/docker.md) to run the TiDB project.
++ Use [Docker](https://github.com/pingcap/docs/blob/master/op-guide/docker-deployment.md) to run the TiDB project.
 
 ### Contributing
 


### PR DESCRIPTION
Improve documentation. Fixed `next steps -> use Docker` link that was broken.