### PR TITLE
etc/bin: tune default value

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -176,7 +176,7 @@ level0-stop-writes-trigger = 16
 
 # Amount of data to build up in memory (backed by an unsorted log
 # on disk) before converting to a sorted on-disk file.
-write-buffer-size = "64MB"
+write-buffer-size = "128MB"
 
 # The maximum number of write buffers that are built up in memory.
 max-write-buffer-number = 5
@@ -186,10 +186,10 @@ max-write-buffer-number = 5
 min-write-buffer-number-to-merge = 1
 
 # Control maximum total data size for base level (level 1).
-max-bytes-for-level-base = "64MB"
+max-bytes-for-level-base = "128MB"
 
 # Target file size for compaction.
-target-file-size-base = "16MB"
+target-file-size-base = "32MB"
 
 # block-cache used to cache uncompressed blocks, big block-cache can speed up read
 block-cache-size = "1GB"
@@ -203,12 +203,12 @@ block-cache-size = "1GB"
 # Column Family write used to store commit informations in MVCC model
 [rocksdb.writecf]
 compression-per-level = "lz4:lz4:lz4:lz4:lz4:lz4:lz4"
-block-size = "16KB"
-write-buffer-size = "64MB"
+block-size = "64KB"
+write-buffer-size = "128MB"
 max-write-buffer-number = 5
 min-write-buffer-number-to-merge = 1
-max-bytes-for-level-base = "64MB"
-target-file-size-base = "16MB"
+max-bytes-for-level-base = "128MB"
+target-file-size-base = "32MB"
 block-cache-size = "256MB"
 # cache-index-and-filter-blocks = true
 
@@ -216,12 +216,12 @@ block-cache-size = "256MB"
 # Column Family raft is used to store raft log and raft states.
 [rocksdb.raftcf]
 compression-per-level = "lz4:lz4:lz4:lz4:lz4:lz4:lz4"
-block-size = "16KB"
-write-buffer-size = "64MB"
+block-size = "64KB"
+write-buffer-size = "128MB"
 max-write-buffer-number = 5
 min-write-buffer-number-to-merge = 1
-max-bytes-for-level-base = "64MB"
-target-file-size-base = "16MB"
+max-bytes-for-level-base = "128MB"
+target-file-size-base = "32MB"
 block-cache-size = "256MB"
 
 [storage]
@@ -231,7 +231,7 @@ scheduler-notify-capacity = 10240
 # maximum number of messages can be processed in one tick
 scheduler-messages-per-tick = 1024
 
-scheduler-concurrency = 102400
+scheduler-concurrency = 1024000
 
 # scheduler's worker pool size
 scheduler-worker-pool-size = 4

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -252,7 +252,7 @@ fn get_rocksdb_cf_option(config: &toml::Value,
     let mut block_base_opts = BlockBasedOptions::new();
     let block_size = get_toml_int(config,
                                   (prefix.clone() + "block-size").as_str(),
-                                  Some(16 * 1024));
+                                  Some(64 * 1024));
     block_base_opts.set_block_size(block_size as usize);
     let block_cache_size = get_toml_int(config,
                                         (prefix.clone() + "block-cache-size").as_str(),
@@ -286,7 +286,7 @@ fn get_rocksdb_cf_option(config: &toml::Value,
 
     let write_buffer_size = get_toml_int(config,
                                          (prefix.clone() + "write-buffer-size").as_str(),
-                                         Some(64 * 1024 * 1024));
+                                         Some(128 * 1024 * 1024));
     opts.set_write_buffer_size(write_buffer_size as u64);
 
     let max_write_buffer_number = get_toml_int(config,
@@ -304,12 +304,12 @@ fn get_rocksdb_cf_option(config: &toml::Value,
     let max_bytes_for_level_base = get_toml_int(config,
                                                 (prefix.clone() + "max-bytes-for-level-base")
                                                     .as_str(),
-                                                Some(64 * 1024 * 1024));
+                                                Some(128 * 1024 * 1024));
     opts.set_max_bytes_for_level_base(max_bytes_for_level_base as u64);
 
     let target_file_size_base = get_toml_int(config,
                                              (prefix.clone() + "target-file-size-base").as_str(),
-                                             Some(16 * 1024 * 1024));
+                                             Some(32 * 1024 * 1024));
     opts.set_target_file_size_base(target_file_size_base as u64);
 
     let level_zero_slowdown_writes_trigger =


### PR DESCRIPTION
Enlarge default write-buffer-size to hold more data in write buffer.
Enlarge default target-file-size to reduce total files count.