### PR TITLE
server/node: exit with error message if cluster id mismatch

### DIFF
--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -15,6 +15,7 @@ use std::thread;
 use std::sync::{Arc, mpsc};
 use std::sync::mpsc::Sender;
 use std::time::Duration;
+use std::process;
 
 use mio::EventLoop;
 use rocksdb::DB;
@@ -152,9 +153,10 @@ impl<C> Node<C>
 
         let ident = res.unwrap();
         if ident.get_cluster_id() != self.cluster_id {
-            return Err(box_err!("store ident {:?} has mismatched cluster id with {}",
-                                ident,
-                                self.cluster_id));
+            error!("cluster id mismatch: local_id {} remote_id {}",
+                   ident.get_cluster_id(),
+                   self.cluster_id);
+            process::exit(1);
         }
 
         let store_id = ident.get_store_id();

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -153,7 +153,7 @@ impl<C> Node<C>
 
         let ident = res.unwrap();
         if ident.get_cluster_id() != self.cluster_id {
-            error!("cluster id mismatch: local_id {} remote_id {}",
+            error!("cluster ID mismatch: local_id {} remote_id {}",
                    ident.get_cluster_id(),
                    self.cluster_id);
             process::exit(1);


### PR DESCRIPTION
The error stack makes user hard to understand what happen.