### PR TITLE
[DNM] server, raftstore: add network monitoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto?branch=hhkbp2/network-monitoring#16fc91d798a508469d25cd188d07d8052e7be6fa"
+source = "git+https://github.com/pingcap/kvproto?branch=hhkbp2/network-monitoring#6d28e4ce399fbd73cda348f83c9772763b38b3f0"
 dependencies = [
  "protobuf 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto)",
+ "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto?branch=hhkbp2/network-monitoring)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -263,7 +263,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto#aded150330d960713683e2dde11cf345ae7bf183"
+source = "git+https://github.com/pingcap/kvproto?branch=hhkbp2/network-monitoring#16fc91d798a508469d25cd188d07d8052e7be6fa"
 dependencies = [
  "protobuf 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -786,7 +786,7 @@ dependencies = [
 "checksum idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1053236e00ce4f668aeca4a769a09b3bf5a682d802abd6f3cb39374f6b162c11"
 "checksum kernel32-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e014dab1082fd9d80ea1fa6fcb261b47ed3eb511612a14198bb507701add083e"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum kvproto 0.0.1 (git+https://github.com/pingcap/kvproto)" = "<none>"
+"checksum kvproto 0.0.1 (git+https://github.com/pingcap/kvproto?branch=hhkbp2/network-monitoring)" = "<none>"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
 "checksum lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "49247ec2a285bb3dcb23cbd9c35193c025e7251bfce77c1d5da97e6362dffe7f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ git = "https://github.com/ngaut/rust-rocksdb.git"
 
 [dependencies.kvproto]
 git = "https://github.com/pingcap/kvproto"
+branch = "hhkbp2/network-monitoring"
 
 [dependencies.tipb]
 git = "https://github.com/pingcap/tipb.git"

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -645,7 +645,11 @@ fn run_raft_server(pd_client: RpcClient, cfg: Config, backup_path: &str, config:
     let ch = SendCh::new(event_loop.channel(), "raft-server");
     let pd_client = Arc::new(pd_client);
     let resolver = PdStoreAddrResolver::new(pd_client.clone()).unwrap();
-    let network_monitor = SimpleNetworkMonitor::new(ch.clone()).unwrap();
+    let network_monitor = SimpleNetworkMonitor::new(cfg.network_monitor_max_store_number,
+                                                    cfg.network_monitor_keepalive_timeout,
+                                                    cfg.network_monitor_connection_timeout,
+                                                    ch.clone())
+        .unwrap();
 
     let store_path = &cfg.storage.path;
     let mut lock_path = Path::new(store_path).to_path_buf();

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -47,11 +47,12 @@ use prometheus::{Encoder, TextEncoder};
 use tikv::storage::{Storage, TEMP_DIR, ALL_CFS};
 use tikv::util::{self, logger, file_log, panic_hook, rocksdb as rocksdb_util};
 use tikv::util::transport::SendCh;
-use tikv::server::{DEFAULT_LISTENING_ADDR, DEFAULT_CLUSTER_ID, ServerChannel, Server, Node,
-                   Config, bind, create_event_loop, create_raft_storage, Msg};
+use tikv::server::{DEFAULT_LISTENING_ADDR, DEFAULT_CLUSTER_ID, ServerChannel, ServerHelper,
+                   Server, Node, Config, bind, create_event_loop, create_raft_storage, Msg};
 use tikv::server::{ServerTransport, ServerRaftStoreRouter};
 use tikv::server::transport::RaftStoreRouter;
 use tikv::server::{PdStoreAddrResolver, StoreAddrResolver};
+use tikv::server::{NetworkMonitor, SimpleNetworkMonitor};
 use tikv::raftstore::store::{self, SnapManager};
 use tikv::pd::RpcClient;
 use tikv::util::time_monitor::TimeMonitor;
@@ -504,7 +505,12 @@ fn build_raftkv(config: &toml::Value,
     let snap_path = snap_path.to_str().unwrap().to_owned();
     let snap_mgr = store::new_snap_mgr(snap_path, Some(node.get_sendch()));
 
-    node.start(event_loop, engine.clone(), trans, snap_mgr.clone()).unwrap();
+    node.start(event_loop,
+               engine.clone(),
+               trans.clone(),
+               trans,
+               snap_mgr.clone())
+        .unwrap();
     let router = ServerRaftStoreRouter::new(node.get_sendch(), node.id());
 
     (node,
@@ -557,12 +563,13 @@ fn get_store_labels(matches: &Matches, config: &toml::Value) -> HashMap<String, 
     util::config::parse_store_labels(&labels).unwrap()
 }
 
-fn start_server<T, S>(mut server: Server<T, S>,
-                      mut el: EventLoop<Server<T, S>>,
-                      engine: Arc<DB>,
-                      backup_path: &str)
+fn start_server<T, S, N>(mut server: Server<T, S, N>,
+                         mut el: EventLoop<Server<T, S, N>>,
+                         engine: Arc<DB>,
+                         backup_path: &str)
     where T: RaftStoreRouter,
-          S: StoreAddrResolver + Send + 'static
+          S: StoreAddrResolver + Send + 'static,
+          N: NetworkMonitor + Send + 'static
 {
     let ch = server.get_sendch();
     let h = thread::Builder::new()
@@ -638,6 +645,7 @@ fn run_raft_server(pd_client: RpcClient, cfg: Config, backup_path: &str, config:
     let ch = SendCh::new(event_loop.channel(), "raft-server");
     let pd_client = Arc::new(pd_client);
     let resolver = PdStoreAddrResolver::new(pd_client.clone()).unwrap();
+    let network_monitor = SimpleNetworkMonitor::new(ch.clone()).unwrap();
 
     let store_path = &cfg.storage.path;
     let mut lock_path = Path::new(store_path).to_path_buf();
@@ -666,12 +674,16 @@ fn run_raft_server(pd_client: RpcClient, cfg: Config, backup_path: &str, config:
         raft_router: raft_router,
         snapshot_status_sender: node.get_snapshot_status_sender(),
     };
+    let server_helper = ServerHelper {
+        resolver: resolver,
+        network_monitor: network_monitor,
+    };
     let svr = Server::new(&mut event_loop,
                           &cfg,
                           listener,
                           store,
                           server_chan,
-                          resolver,
+                          server_helper,
                           snap_mgr)
         .unwrap();
     start_server(svr, event_loop, engine, backup_path);

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -50,7 +50,7 @@ const DEFAULT_SNAPSHOT_APPLY_BATCH_SIZE: usize = 1024 * 1024 * 10; // 10m
 const DEFAULT_CONSISTENCY_CHECK_INTERVAL: u64 = 0;
 // Renew the network status between current server and remote servers in a low rate,
 // so that the network manitoring takes low cost.
-const DEFAULT_RENEW_NETWORK_STAT_INTERVAL: u64 = 6 * 60 * 1000; // 6 min
+const DEFAULT_RENEW_NETWORK_STAT_INTERVAL: u64 = 30 * 1000; // 30 seconds
 const DEFAULT_RENEW_NETWORK_STAT_MAX_STORE_NUMBER: usize = 200;
 
 #[derive(Debug, Clone)]

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -48,6 +48,10 @@ const DEFAULT_SNAPSHOT_APPLY_BATCH_SIZE: usize = 1024 * 1024 * 10; // 10m
 // Disable consistency check by default as it will hurt performance.
 // We should turn on this only in our tests.
 const DEFAULT_CONSISTENCY_CHECK_INTERVAL: u64 = 0;
+// Renew the network status between current server and remote servers in a low rate,
+// so that the network manitoring takes low cost.
+const DEFAULT_RENEW_NETWORK_STAT_INTERVAL: u64 = 6 * 60 * 1000; // 6 min
+const DEFAULT_RENEW_NETWORK_STAT_MAX_STORE_NUMBER: usize = 200;
 
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -110,6 +114,13 @@ pub struct Config {
 
     // Interval (ms) to check region whether the data is consistent.
     pub consistency_check_tick_interval: u64,
+
+    // Interval (ms) to renew the network status between current server and remote servers.
+    pub renew_network_stat_tick_interval: u64,
+
+    // On every `renew_network_stat_tick_interval`, the network status between current server and
+    // at most `renew_network_stat_max_store_number` remote store will be renewed.
+    pub renew_network_stat_max_store_number: usize,
 }
 
 impl Default for Config {
@@ -142,6 +153,8 @@ impl Default for Config {
             snap_apply_batch_size: DEFAULT_SNAPSHOT_APPLY_BATCH_SIZE,
             lock_cf_compact_interval: DEFAULT_LOCK_CF_COMPACT_INTERVAL,
             consistency_check_tick_interval: DEFAULT_CONSISTENCY_CHECK_INTERVAL,
+            renew_network_stat_tick_interval: DEFAULT_RENEW_NETWORK_STAT_INTERVAL,
+            renew_network_stat_max_store_number: DEFAULT_RENEW_NETWORK_STAT_MAX_STORE_NUMBER,
         }
     }
 }

--- a/src/raftstore/store/mod.rs
+++ b/src/raftstore/store/mod.rs
@@ -29,9 +29,9 @@ mod metrics;
 mod local_metrics;
 
 pub use self::msg::{Msg, Callback, Tick, SnapshotStatusMsg};
-pub use self::store::{StoreChannel, Store, create_event_loop};
+pub use self::store::{StoreChannel, StoreTransport, Store, create_event_loop};
 pub use self::config::Config;
-pub use self::transport::Transport;
+pub use self::transport::{Transport, NetworkMonitorTransport, RenewNetworkStat};
 pub use self::peer::Peer;
 pub use self::bootstrap::{bootstrap_store, bootstrap_region, write_region, clear_region};
 pub use self::engine::{Peekable, Iterable, Mutable};

--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -34,6 +34,7 @@ pub enum Tick {
     SnapGc,
     CompactLockCf,
     ConsistencyCheck,
+    RenewNetworkStat,
 }
 
 pub struct SnapshotStatusMsg {

--- a/src/raftstore/store/transport.rs
+++ b/src/raftstore/store/transport.rs
@@ -19,3 +19,13 @@ use raftstore::Result;
 pub trait Transport: Send + Clone {
     fn send(&self, msg: RaftMessage) -> Result<()>;
 }
+
+pub struct RenewNetworkStat {
+    pub store_id: u64,
+    pub remote_store_ids: Vec<u64>,
+}
+
+// Transports message between store and network monitor.
+pub trait NetworkMonitorTransport: Send + Clone {
+    fn send(&self, stat: RenewNetworkStat) -> Result<()>;
+}

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -25,6 +25,9 @@ const DEFAULT_END_POINT_CONCURRENCY: usize = 8;
 const DEFAULT_MESSAGES_PER_TICK: usize = 256;
 const DEFAULT_SEND_BUFFER_SIZE: usize = 128 * 1024;
 const DEFAULT_RECV_BUFFER_SIZE: usize = 128 * 1024;
+const DEFAULT_NETWORK_MONITOR_MAX_STORE_NUMBER: usize = 10000;
+const DEFAULT_NETWORK_MONITOR_KEEPALIVE_TIMETOUT_SEC: u64 = 60;
+const DEFAULT_NETWORK_MONITOR_CONNECTION_TIMEOUT_SEC: u64 = 5 * 60;
 
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -46,6 +49,9 @@ pub struct Config {
     pub storage: StorageConfig,
     pub raft_store: RaftStoreConfig,
     pub end_point_concurrency: usize,
+    pub network_monitor_max_store_number: usize,
+    pub network_monitor_keepalive_timeout: u64, // in second
+    pub network_monitor_connection_timeout: u64, // in second
 }
 
 impl Default for Config {
@@ -62,6 +68,9 @@ impl Default for Config {
             end_point_concurrency: DEFAULT_END_POINT_CONCURRENCY,
             storage: StorageConfig::default(),
             raft_store: RaftStoreConfig::default(),
+            network_monitor_max_store_number: DEFAULT_NETWORK_MONITOR_MAX_STORE_NUMBER,
+            network_monitor_keepalive_timeout: DEFAULT_NETWORK_MONITOR_KEEPALIVE_TIMETOUT_SEC,
+            network_monitor_connection_timeout: DEFAULT_NETWORK_MONITOR_CONNECTION_TIMEOUT_SEC,
         }
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -37,10 +37,11 @@ pub mod network_monitor;
 
 pub use self::config::{Config, DEFAULT_LISTENING_ADDR, DEFAULT_CLUSTER_ID};
 pub use self::errors::{Result, Error};
-pub use self::server::{ServerChannel, Server, create_event_loop, bind};
+pub use self::server::{ServerChannel, ServerHelper, Server, create_event_loop, bind};
 pub use self::transport::{ServerTransport, ServerRaftStoreRouter, MockRaftStoreRouter};
 pub use self::node::{Node, create_raft_storage};
 pub use self::resolve::{StoreAddrResolver, PdStoreAddrResolver};
+pub use self::network_monitor::{Event, NetworkMonitor, SimpleNetworkMonitor};
 
 pub type OnResponse = Box<FnBox(msgpb::Message) + Send>;
 
@@ -103,6 +104,8 @@ impl Display for ConnData {
             MessageType::CopResp => write!(f, "[{}] coprocessor response", self.msg_id),
             MessageType::PdReq => write!(f, "[{}] pd request", self.msg_id),
             MessageType::PdResp => write!(f, "[{}] pd response", self.msg_id),
+            MessageType::StatReq => write!(f, "[{}] stat request", self.msg_id),
+            MessageType::StatResp => write!(f, "[{}] stat response", self.msg_id),
             MessageType::None => write!(f, "[{}] invalid message", self.msg_id),
         }
     }
@@ -127,6 +130,11 @@ pub enum Msg {
         store_id: u64,
         sock_addr: Result<SocketAddr>,
         data: ConnData,
+    },
+    // Tell network monitor to renew store info.
+    RenewNetworkStat {
+        store_id: u64,
+        remote_store_ids: Vec<u64>,
     },
     CloseConn { token: Token },
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -33,6 +33,7 @@ pub mod transport;
 pub mod node;
 pub mod resolve;
 pub mod snap;
+pub mod network_monitor;
 
 pub use self::config::{Config, DEFAULT_LISTENING_ADDR, DEFAULT_CLUSTER_ID};
 pub use self::errors::{Result, Error};

--- a/src/server/network_monitor.rs
+++ b/src/server/network_monitor.rs
@@ -1,0 +1,64 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::{self, Formatter, Display};
+
+use super::{Result, Msg};
+use util::worker::Runnable;
+use util::transport::SendCh;
+
+pub enum Event {
+    RenewNetworkStat {
+        store_id: u64,
+        remote_store_ids: Vec<u64>,
+    },
+    Ping { from_store_id: u64 },
+    Pong { from_store_id: u64 },
+}
+
+impl Display for Event {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        // TODO add messages
+        match *self {
+            Event::RenewNetworkStat { .. } => write!(f, ""),
+            Event::Ping { .. } => write!(f, ""),
+            Event::Pong { .. } => write!(f, ""),
+        }
+    }
+}
+
+pub struct Runner {
+    ch: SendCh<Msg>,
+}
+
+impl Runner {
+    pub fn new(ch: SendCh<Msg>) -> Runner {
+        Runner { ch: ch }
+    }
+}
+
+impl Runnable<Event> for Runner {
+    fn run(&mut self, event: Event) {
+        match event {
+            Event::RenewNetworkStat { .. } => {
+                // TODO add impl
+            }
+            Event::Ping { .. } => {
+                // TODO add impl
+            }
+            Event::Pong { .. } => {
+                // TODO add impl
+            }
+        }
+    }
+}

--- a/src/server/network_monitor.rs
+++ b/src/server/network_monitor.rs
@@ -12,12 +12,22 @@
 // limitations under the License.
 
 use std::fmt::{self, Formatter, Display};
+use std::collections::{HashMap, VecDeque};
+use std::time::Duration as StdDuration;
 
-use kvproto::statpb::{Request as StatRequest, Response as StatResponse};
+use time::{Timespec, Duration, now, empty_tm};
 
-use super::{Result, Msg};
+use kvproto::msgpb::{MessageType, Message};
+use kvproto::statpb::{MessageType as StatMessageType, Timespec as StatTimespec,
+                      RequestHeader as StatRequestHeader, ResponseHeader as StatResponseHeader,
+                      Request as StatRequest, Response as StatResponse, PingReq, PingResp};
+
+use pd::INVALID_ID;
 use util::worker::{Runnable, Worker, Scheduler};
 use util::transport::SendCh;
+use super::{Result, Msg, ConnData};
+
+const PING_TIMEOUT_MAX_RETRY_NUMBER: usize = 200;
 
 // NetworkMonitor keep watch on the network status between servers.
 pub trait NetworkMonitor {
@@ -41,35 +51,278 @@ impl Display for Event {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         // TODO add messages
         match *self {
-            Event::RenewNetworkStat { .. } => write!(f, ""),
-            Event::Request { .. } => write!(f, ""),
-            Event::Response { .. } => write!(f, ""),
+            Event::RenewNetworkStat { store_id, .. } => {
+                write!(f, "renew network stat for current store id {}", store_id)
+            }
+            Event::Request { ref req } => write!(f, "request {:?}", req),
+            Event::Response { ref resp } => write!(f, "response {:?}", resp),
         }
     }
 }
 
+#[derive(Debug)]
+struct NetStat {
+    seq_id: u64,
+    last_active_ts: Option<Timespec>,
+    last_ping_ts: Timespec,
+}
+
+impl NetStat {
+    pub fn new() -> NetStat {
+        NetStat {
+            seq_id: 0,
+            last_active_ts: None,
+            last_ping_ts: empty_tm().to_timespec(),
+        }
+    }
+}
+
+struct Ping {
+    pub ts: Timespec,
+    pub store_id: u64,
+}
+
+fn timespec_elapsed(ts: Timespec) -> Duration {
+    let now_ts = now().to_timespec();
+    now_ts - ts
+}
+
+fn conv_timespec(ts: &StatTimespec) -> Timespec {
+    Timespec::new(ts.get_sec(), ts.get_nsec())
+}
+
+fn conv_stat_timespec(ts: Timespec) -> StatTimespec {
+    let mut sts = StatTimespec::new();
+    sts.set_sec(ts.sec);
+    sts.set_nsec(ts.nsec);
+    sts
+}
+
+fn calc_duration(timeout: u64) -> Duration {
+    Duration::from_std(StdDuration::from_secs(timeout)).unwrap()
+}
+
 pub struct Runner {
+    store_id: u64,
+    max_store_number: usize,
+    keepalive_timeout: Duration,
+    connection_timeout: Duration,
     ch: SendCh<Msg>,
+    stats: HashMap<u64, NetStat>,
+    ping_list: VecDeque<Ping>,
+    msg_id: u64,
 }
 
 impl Runner {
-    pub fn new(ch: SendCh<Msg>) -> Runner {
-        Runner { ch: ch }
+    pub fn new(max_store_number: usize,
+               keepalive_timeout: u64,
+               connection_timeout: u64,
+               ch: SendCh<Msg>)
+               -> Runner {
+        Runner {
+            store_id: INVALID_ID,
+            max_store_number: max_store_number,
+            keepalive_timeout: calc_duration(keepalive_timeout),
+            connection_timeout: calc_duration(connection_timeout),
+            ch: ch,
+            stats: HashMap::new(),
+            ping_list: VecDeque::new(),
+            msg_id: 0,
+        }
+    }
+
+    fn send_ping_store(&mut self, store_id: u64, seq_id: u64) -> Timespec {
+        let ts = now().to_timespec();
+
+        let mut ping_req = PingReq::new();
+        ping_req.set_ping_ts(conv_stat_timespec(ts));
+
+        let mut req_header = StatRequestHeader::new();
+        req_header.set_id(seq_id);
+        req_header.set_from_store_id(self.store_id);
+        req_header.set_to_store_id(store_id);
+
+        let mut req = StatRequest::new();
+        req.set_header(req_header);
+        req.set_msg_type(StatMessageType::Ping);
+        req.set_ping_req(ping_req);
+
+        let mut message = Message::new();
+        message.set_msg_type(MessageType::StatReq);
+        message.set_stat_req(req);
+
+        self.send_message(store_id, message);
+        ts
+    }
+
+    fn ping_store(&mut self, stat: &mut NetStat, store_id: u64) -> Timespec {
+        stat.seq_id += 1;
+        let ts = self.send_ping_store(store_id, stat.seq_id);
+        stat.last_ping_ts = ts;
+        ts
+    }
+
+    fn handle_renew_network_stat(&mut self, store_id: u64, remote_store_ids: Vec<u64>) {
+        if self.store_id == INVALID_ID {
+            self.store_id = store_id;
+        }
+
+        for remote_store_id in remote_store_ids {
+            // Ignore the store id that as already tracked.
+            if self.stats.contains_key(&remote_store_id) {
+                continue;
+            }
+
+            // Track new remote store.
+
+            if self.stats.len() >= self.max_store_number {
+                // Free one slot for the the new remote store id.
+                let op = self.ping_list.pop_front().unwrap();
+                let _ = self.stats.remove(&op.store_id);
+            }
+            // Ping the remote store and add its stat for tracking.
+            let mut stat = NetStat::new();
+            let ts = self.ping_store(&mut stat, remote_store_id);
+            self.stats.insert(remote_store_id, stat);
+            // Add new Ping for this remote store.
+            let op = Ping {
+                ts: ts,
+                store_id: remote_store_id,
+            };
+            self.ping_list.push_back(op);
+        }
+
+        // Retry the timeout Pings.
+        for _ in 0..PING_TIMEOUT_MAX_RETRY_NUMBER {
+            if self.ping_list.front().is_none() {
+                break;
+            }
+            {
+                let front = self.ping_list.front().unwrap();
+                if timespec_elapsed(front.ts) < self.keepalive_timeout {
+                    break;
+                }
+            }
+            // Get the first timeout Ping.
+            let op = self.ping_list.pop_front().unwrap();
+            let mut stat = self.stats.remove(&op.store_id).unwrap();
+            // Log a message if the connection is considered lost.
+            if (stat.last_active_ts.is_none() &&
+                timespec_elapsed(stat.last_ping_ts) >= self.connection_timeout) ||
+               (stat.last_active_ts.is_some() &&
+                timespec_elapsed(stat.last_active_ts.unwrap()) >= self.connection_timeout) {
+                info!("[store {}] lost connection with store {}",
+                      self.store_id,
+                      op.store_id);
+                // Stop tracking the store whose connection is considered lost.
+                continue;
+            }
+            // Retry to ping the store.
+            let ts = self.ping_store(&mut stat, op.store_id);
+            // Add the store stat for tracking.
+            self.stats.insert(op.store_id, stat);
+            // Add new Ping for this store.
+            let op = Ping {
+                ts: ts,
+                store_id: op.store_id,
+            };
+            self.ping_list.push_back(op);
+        }
+    }
+
+    fn alloc_msg_id(&mut self) -> u64 {
+        self.msg_id += 1;
+        self.msg_id
+    }
+
+    fn send_message(&mut self, to_store_id: u64, msg: Message) {
+        let msg_id = self.alloc_msg_id();
+        if let Err(e) = self.ch.try_send(Msg::SendStore {
+            store_id: to_store_id,
+            data: ConnData::new(msg_id, msg),
+        }) {
+            error!("[store {}] network monitor failed to send message {:?}",
+                   self.store_id,
+                   e);
+        }
+    }
+
+    fn handle_request(&mut self, mut req: StatRequest) {
+        let to_store_id = req.get_header().get_to_store_id();
+        if self.store_id != INVALID_ID && to_store_id != self.store_id {
+            error!("[store {}] receive invalid stat request with to_store_id {}",
+                   self.store_id,
+                   to_store_id);
+            return;
+        }
+
+        match req.get_msg_type() {
+            StatMessageType::Ping => {
+                let mut ping_resp = PingResp::new();
+                ping_resp.set_ping_ts(req.mut_ping_req().take_ping_ts());
+
+                let mut resp_header = StatResponseHeader::new();
+                resp_header.set_id(req.get_header().get_id());
+                resp_header.set_from_store_id(to_store_id);
+                resp_header.set_to_store_id(req.get_header().get_from_store_id());
+
+                let mut resp = StatResponse::new();
+                resp.set_header(resp_header);
+                resp.set_msg_type(StatMessageType::Ping);
+                resp.set_ping_resp(ping_resp);
+
+                let mut message = Message::new();
+                message.set_msg_type(MessageType::StatResp);
+                message.set_stat_resp(resp);
+
+                self.send_message(to_store_id, message)
+            }
+        }
+    }
+
+    fn handle_response(&mut self, resp: StatResponse) {
+        let to_store_id = resp.get_header().get_to_store_id();
+        if self.store_id != INVALID_ID && to_store_id != self.store_id {
+            error!("[store {}] receive invalid stat response with to_store_id {}",
+                   self.store_id,
+                   to_store_id);
+            return;
+        }
+        match resp.get_msg_type() {
+            StatMessageType::Ping => {
+                // Ensure that from_store_id is still tracked.
+                let from_store_id = resp.get_header().get_from_store_id();
+                if !self.stats.contains_key(&from_store_id) {
+                    debug!("[store {}] receive obsolete ping response from store id {}",
+                           self.store_id,
+                           from_store_id);
+                    return;
+                }
+                // Ensure the message is not stale.
+                let stat = self.stats.get_mut(&from_store_id).unwrap();
+                let seq_id = resp.get_header().get_id();
+                if seq_id < stat.seq_id {
+                    debug!("[store {}] receive stale ping response from store id {}",
+                           self.store_id,
+                           from_store_id);
+                    return;
+                }
+                // Update the last active timespec.
+                let ping_ts = conv_timespec(resp.get_ping_resp().get_ping_ts());
+                stat.last_active_ts = Some(ping_ts);
+            }
+        }
     }
 }
 
 impl Runnable<Event> for Runner {
     fn run(&mut self, event: Event) {
         match event {
-            Event::RenewNetworkStat { .. } => {
-                // TODO add impl
+            Event::RenewNetworkStat { store_id, remote_store_ids } => {
+                self.handle_renew_network_stat(store_id, remote_store_ids)
             }
-            Event::Request { .. } => {
-                // TODO add impl
-            }
-            Event::Response { .. } => {
-                // TODO add impl
-            }
+            Event::Request { req } => self.handle_request(req),
+            Event::Response { resp } => self.handle_response(resp),
         }
     }
 }
@@ -79,9 +332,13 @@ pub struct SimpleNetworkMonitor {
 }
 
 impl SimpleNetworkMonitor {
-    pub fn new(ch: SendCh<Msg>) -> Result<SimpleNetworkMonitor> {
+    pub fn new(max_store_number: usize,
+               keepalive_timeout: u64,
+               connection_timeout: u64,
+               ch: SendCh<Msg>)
+               -> Result<SimpleNetworkMonitor> {
         let mut m = SimpleNetworkMonitor { worker: Worker::new("network-monitor") };
-        let runner = Runner::new(ch);
+        let runner = Runner::new(max_store_number, keepalive_timeout, connection_timeout, ch);
         box_try!(m.worker.start(runner));
         Ok(m)
     }

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -24,8 +24,9 @@ use kvproto::raft_serverpb::StoreIdent;
 use kvproto::metapb;
 use protobuf::RepeatedField;
 use util::transport::SendCh;
-use raftstore::store::{self, Msg, SnapshotStatusMsg, StoreChannel, Store, Config as StoreConfig,
-                       keys, Peekable, Transport, SnapManager};
+use raftstore::store::{self, Msg, SnapshotStatusMsg, StoreChannel, StoreTransport, Store,
+                       Config as StoreConfig, keys, Peekable, Transport, NetworkMonitorTransport,
+                       SnapManager};
 use super::Result;
 use super::config::Config;
 use storage::{Storage, RaftKv};
@@ -58,11 +59,12 @@ pub struct Node<C: PdClient + 'static> {
 impl<C> Node<C>
     where C: PdClient
 {
-    pub fn new<T>(event_loop: &mut EventLoop<Store<T, C>>,
-                  cfg: &Config,
-                  pd_client: Arc<C>)
-                  -> Node<C>
-        where T: Transport + 'static
+    pub fn new<T, N>(event_loop: &mut EventLoop<Store<T, N, C>>,
+                     cfg: &Config,
+                     pd_client: Arc<C>)
+                     -> Node<C>
+        where T: Transport + 'static,
+              N: NetworkMonitorTransport + 'static
     {
         let mut store = metapb::Store::new();
         store.set_id(INVALID_ID);
@@ -93,13 +95,15 @@ impl<C> Node<C>
         }
     }
 
-    pub fn start<T>(&mut self,
-                    event_loop: EventLoop<Store<T, C>>,
-                    engine: Arc<DB>,
-                    trans: T,
-                    snap_mgr: SnapManager)
-                    -> Result<()>
-        where T: Transport + 'static
+    pub fn start<T, N>(&mut self,
+                       event_loop: EventLoop<Store<T, N, C>>,
+                       engine: Arc<DB>,
+                       trans: T,
+                       network_monitor_trans: N,
+                       snap_mgr: SnapManager)
+                       -> Result<()>
+        where T: Transport + 'static,
+              N: NetworkMonitorTransport + 'static
     {
         let bootstrapped = try!(self.check_cluster_bootstrapped());
         let mut store_id = try!(self.check_store(&engine));
@@ -124,7 +128,12 @@ impl<C> Node<C>
         }
 
         // inform pd.
-        try!(self.start_store(event_loop, store_id, engine, trans, snap_mgr));
+        try!(self.start_store(event_loop,
+                              store_id,
+                              engine,
+                              trans,
+                              network_monitor_trans,
+                              snap_mgr));
         try!(self.pd_client
             .put_store(self.store.clone()));
         Ok(())
@@ -224,14 +233,16 @@ impl<C> Node<C>
         Err(box_err!("check cluster bootstrapped failed"))
     }
 
-    fn start_store<T>(&mut self,
-                      mut event_loop: EventLoop<Store<T, C>>,
-                      store_id: u64,
-                      db: Arc<DB>,
-                      trans: T,
-                      snap_mgr: SnapManager)
-                      -> Result<()>
-        where T: Transport + 'static
+    fn start_store<T, N>(&mut self,
+                         mut event_loop: EventLoop<Store<T, N, C>>,
+                         store_id: u64,
+                         db: Arc<DB>,
+                         trans: T,
+                         network_monitor_trans: N,
+                         snap_mgr: SnapManager)
+                         -> Result<()>
+        where T: Transport + 'static,
+              N: NetworkMonitorTransport + 'static
     {
         info!("start raft store {} thread", store_id);
 
@@ -249,14 +260,19 @@ impl<C> Node<C>
         self.snapshot_status_sender = Some(snapshot_tx);
         let builder = thread::Builder::new().name(thd_name!(format!("raftstore-{}", store_id)));
         let h = try!(builder.spawn(move || {
-            let ch = StoreChannel {
+            let store_ch = StoreChannel {
                 sender: sender,
                 snapshot_status_receiver: snapshot_rx,
             };
-            let mut store = match Store::new(ch, store, cfg, db, trans, pd_client, snap_mgr) {
-                Err(e) => panic!("construct store {} err {:?}", store_id, e),
-                Ok(s) => s,
+            let store_trans = StoreTransport {
+                trans: trans,
+                network_monitor_trans: network_monitor_trans,
             };
+            let mut store =
+                match Store::new(store_ch, store, cfg, db, store_trans, pd_client, snap_mgr) {
+                    Err(e) => panic!("construct store {} err {:?}", store_id, e),
+                    Ok(s) => s,
+                };
             tx.send(0).unwrap();
             if let Err(e) = store.run(&mut event_loop) {
                 error!("store {} run err {:?}", store_id, e);

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -34,7 +34,7 @@ use super::coprocessor::{RequestTask, EndPointHost, EndPointTask};
 use super::transport::RaftStoreRouter;
 use super::resolve::StoreAddrResolver;
 use super::snap::{Task as SnapTask, Runner as SnapHandler};
-use super::network_monitor::{Event as MonitorEvent, Runner as MonitorRunner};
+use super::network_monitor::NetworkMonitor;
 use raft::SnapshotStatus;
 use util::sockopt::SocketOpt;
 use super::metrics::*;
@@ -43,9 +43,10 @@ const SERVER_TOKEN: Token = Token(1);
 const FIRST_CUSTOM_TOKEN: Token = Token(1024);
 const DEFAULT_COPROCESSOR_BATCH: usize = 50;
 
-pub fn create_event_loop<T, S>(config: &Config) -> Result<EventLoop<Server<T, S>>>
+pub fn create_event_loop<T, S, N>(config: &Config) -> Result<EventLoop<Server<T, S, N>>>
     where T: RaftStoreRouter,
-          S: StoreAddrResolver
+          S: StoreAddrResolver,
+          N: NetworkMonitor
 {
     let mut builder = EventLoopBuilder::new();
     builder.notify_capacity(config.notify_capacity);
@@ -66,7 +67,13 @@ pub struct ServerChannel<T: RaftStoreRouter + 'static> {
     pub snapshot_status_sender: Sender<SnapshotStatusMsg>,
 }
 
-pub struct Server<T: RaftStoreRouter + 'static, S: StoreAddrResolver> {
+// A help structure to bundle all the help workers for `Server`.
+pub struct ServerHelper<S: StoreAddrResolver, N: NetworkMonitor> {
+    pub resolver: S,
+    pub network_monitor: N,
+}
+
+pub struct Server<T: RaftStoreRouter + 'static, S: StoreAddrResolver, N: NetworkMonitor> {
     listener: TcpListener,
     // We use HashMap instead of common use mio slab to avoid token reusing.
     // In our raft server, a client with token 1 sends a raft command, we will
@@ -93,14 +100,12 @@ pub struct Server<T: RaftStoreRouter + 'static, S: StoreAddrResolver> {
     snap_mgr: SnapManager,
     snap_worker: Worker<SnapTask>,
 
-    network_monitor_worker: Worker<MonitorEvent>,
-
-    resolver: S,
+    helper: ServerHelper<S, N>,
 
     cfg: Config,
 }
 
-impl<T: RaftStoreRouter, S: StoreAddrResolver> Server<T, S> {
+impl<T: RaftStoreRouter, S: StoreAddrResolver, N: NetworkMonitor> Server<T, S, N> {
     // Create a server with already initialized engines.
     // Now some tests use 127.0.0.1:0 but we need real listening
     // address in Node before creating the Server, so we first
@@ -111,9 +116,9 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver> Server<T, S> {
                listener: TcpListener,
                storage: Storage,
                ch: ServerChannel<T>,
-               resolver: S,
+               helper: ServerHelper<S, N>,
                snap_mgr: SnapManager)
-               -> Result<Server<T, S>> {
+               -> Result<Server<T, S, N>> {
         try!(event_loop.register(&listener,
                                  SERVER_TOKEN,
                                  EventSet::readable(),
@@ -123,7 +128,6 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver> Server<T, S> {
         let store_handler = StoreHandler::new(storage);
         let end_point_worker = Worker::new("end-point-worker");
         let snap_worker = Worker::new("snap-handler");
-        let network_monitor_worker = Worker::new("network-monitor");
 
         let svr = Server {
             listener: listener,
@@ -137,8 +141,7 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver> Server<T, S> {
             end_point_worker: end_point_worker,
             snap_mgr: snap_mgr,
             snap_worker: snap_worker,
-            network_monitor_worker: network_monitor_worker,
-            resolver: resolver,
+            helper: helper,
             cfg: cfg.clone(),
         };
 
@@ -154,9 +157,6 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver> Server<T, S> {
         let ch = self.get_sendch();
         let snap_runner = SnapHandler::new(self.snap_mgr.clone(), self.ch.raft_router.clone(), ch);
         box_try!(self.snap_worker.start(snap_runner));
-
-        let network_monitor_runner = MonitorRunner::new(self.get_sendch());
-        box_try!(self.network_monitor_worker.start(network_monitor_runner));
 
         info!("TiKV is ready to serve");
 
@@ -282,6 +282,14 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver> Server<T, S> {
                 let req = RequestTask::new(msg.take_cop_req(), on_resp);
                 box_try!(self.end_point_worker.schedule(EndPointTask::Request(req)));
                 Ok(())
+            }
+            MessageType::StatReq => {
+                RECV_MSG_COUNTER.with_label_values(&["stat_req"]).inc();
+                self.helper.network_monitor.send_request(msg.take_stat_req())
+            }
+            MessageType::StatResp => {
+                RECV_MSG_COUNTER.with_label_values(&["stat_resp"]).inc();
+                self.helper.network_monitor.send_response(msg.take_stat_resp())
             }
             _ => {
                 RECV_MSG_COUNTER.with_label_values(&["invalid"]).inc();
@@ -411,7 +419,7 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver> Server<T, S> {
                 error!("send store sock msg err {:?}", e);
             }
         };
-        if let Err(e) = self.resolver.resolve(store_id, cb) {
+        if let Err(e) = self.helper.resolver.resolve(store_id, cb) {
             error!("try to resolve err {:?}", e);
         }
     }
@@ -503,6 +511,12 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver> Server<T, S> {
         self.write_data(event_loop, token, data)
     }
 
+    fn on_renew_network_stat(&self, store_id: u64, remote_store_ids: Vec<u64>) {
+        if let Err(e) = self.helper.network_monitor.renew_network_stat(store_id, remote_store_ids) {
+            error!("renew network stat for store {} failed {:?}", store_id, e);
+        }
+    }
+
     fn new_snapshot_reporter(&self, data: &ConnData) -> SnapshotReporter {
         let region_id = data.msg.get_raft().get_region_id();
         let to_peer_id = data.msg.get_raft().get_to_peer().get_id();
@@ -555,7 +569,7 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver> Server<T, S> {
     }
 }
 
-impl<T: RaftStoreRouter, S: StoreAddrResolver> Handler for Server<T, S> {
+impl<T: RaftStoreRouter, S: StoreAddrResolver, N: NetworkMonitor> Handler for Server<T, S, N> {
     type Timeout = Msg;
     type Message = Msg;
 
@@ -585,6 +599,9 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver> Handler for Server<T, S> {
             Msg::SendStore { store_id, data } => self.send_store(event_loop, store_id, data),
             Msg::ResolveResult { store_id, sock_addr, data } => {
                 self.on_resolve_result(event_loop, store_id, sock_addr, data)
+            }
+            Msg::RenewNetworkStat { store_id, remote_store_ids } => {
+                self.on_renew_network_stat(store_id, remote_store_ids)
             }
             Msg::CloseConn { token } => self.remove_conn(event_loop, token),
         }
@@ -661,9 +678,11 @@ mod tests {
     use super::super::{Msg, ConnData, Result, Config};
     use super::super::transport::RaftStoreRouter;
     use super::super::resolve::{StoreAddrResolver, Callback as ResolveCallback};
+    use super::super::network_monitor::NetworkMonitor;
     use storage::Storage;
     use kvproto::msgpb::{Message, MessageType};
     use kvproto::raft_serverpb::RaftMessage;
+    use kvproto::statpb::{Request as StatRequest, Response as StatResponse};
     use raftstore::Result as RaftStoreResult;
     use raftstore::store::{self, Msg as StoreMsg};
 
@@ -674,6 +693,22 @@ mod tests {
     impl StoreAddrResolver for MockResolver {
         fn resolve(&self, _: u64, cb: ResolveCallback) -> Result<()> {
             cb.call_box((Ok(self.addr),));
+            Ok(())
+        }
+    }
+
+    struct MockNetworkMonitor;
+
+    impl NetworkMonitor for MockNetworkMonitor {
+        fn renew_network_stat(&self, _: u64, _: Vec<u64>) -> Result<()> {
+            Ok(())
+        }
+
+        fn send_request(&self, _: StatRequest) -> Result<()> {
+            Ok(())
+        }
+
+        fn send_response(&self, _: StatResponse) -> Result<()> {
             Ok(())
         }
     }
@@ -717,6 +752,7 @@ mod tests {
         let listener = TcpListener::bind(&addr).unwrap();
 
         let resolver = MockResolver { addr: listener.local_addr().unwrap() };
+        let network_monitor = MockNetworkMonitor {};
 
         let cfg = Config::new();
         let mut event_loop = create_event_loop(&cfg).unwrap();
@@ -733,12 +769,16 @@ mod tests {
             raft_router: router,
             snapshot_status_sender: snapshot_status_sender,
         };
+        let helper = ServerHelper {
+            resolver: resolver,
+            network_monitor: network_monitor,
+        };
         let mut server = Server::new(&mut event_loop,
                                      &cfg,
                                      listener,
                                      storage,
                                      ch,
-                                     resolver,
+                                     helper,
                                      store::new_snap_mgr("", None))
             .unwrap();
 

--- a/tests/raftstore/server.rs
+++ b/tests/raftstore/server.rs
@@ -152,7 +152,11 @@ impl Simulator for ServerCluster {
         let mut event_loop = create_event_loop(&cfg).unwrap();
         let sendch = SendCh::new(event_loop.channel(), "cluster-simulator");
         let resolver = PdStoreAddrResolver::new(self.pd_client.clone()).unwrap();
-        let network_monitor = SimpleNetworkMonitor::new(sendch.clone()).unwrap();
+        let network_monitor = SimpleNetworkMonitor::new(cfg.network_monitor_max_store_number,
+                                                        cfg.network_monitor_keepalive_timeout,
+                                                        cfg.network_monitor_connection_timeout,
+                                                        sendch.clone())
+            .unwrap();
         let trans = ServerTransport::new(sendch.clone());
 
         let mut store_event_loop = store::create_event_loop(&cfg.raft_store).unwrap();

--- a/tests/raftstore/server.rs
+++ b/tests/raftstore/server.rs
@@ -23,8 +23,9 @@ use rocksdb::DB;
 use tempdir::TempDir;
 
 use super::cluster::{Simulator, Cluster};
-use tikv::server::{self, ServerChannel, Server, ServerTransport, create_event_loop, Msg, bind};
-use tikv::server::{Node, Config, create_raft_storage, PdStoreAddrResolver};
+use tikv::server::{self, ServerChannel, ServerHelper, Server, ServerTransport, create_event_loop,
+                   Msg, bind};
+use tikv::server::{Node, Config, create_raft_storage, PdStoreAddrResolver, SimpleNetworkMonitor};
 use tikv::server::transport::ServerRaftStoreRouter;
 use tikv::raftstore::{Error, Result, store};
 use tikv::raftstore::store::Msg as StoreMsg;
@@ -49,6 +50,7 @@ pub struct ServerCluster {
     addrs: HashMap<u64, SocketAddr>,
     conns: Mutex<HashMap<SocketAddr, Vec<TcpStream>>>,
     sim_trans: HashMap<u64, SimulateServerTransport>,
+    network_monitor_transports: HashMap<u64, DummyNetworkMonitorTransport>,
     store_chs: HashMap<u64, SendCh<StoreMsg>>,
     pub storages: HashMap<u64, Box<Engine>>,
     snap_paths: HashMap<u64, TempDir>,
@@ -65,6 +67,7 @@ impl ServerCluster {
             handles: HashMap::new(),
             addrs: HashMap::new(),
             sim_trans: HashMap::new(),
+            network_monitor_transports: HashMap::new(),
             conns: Mutex::new(HashMap::new()),
             msg_id: AtomicUsize::new(1),
             pd_client: pd_client,
@@ -149,6 +152,7 @@ impl Simulator for ServerCluster {
         let mut event_loop = create_event_loop(&cfg).unwrap();
         let sendch = SendCh::new(event_loop.channel(), "cluster-simulator");
         let resolver = PdStoreAddrResolver::new(self.pd_client.clone()).unwrap();
+        let network_monitor = SimpleNetworkMonitor::new(sendch.clone()).unwrap();
         let trans = ServerTransport::new(sendch.clone());
 
         let mut store_event_loop = store::create_event_loop(&cfg.raft_store).unwrap();
@@ -156,9 +160,11 @@ impl Simulator for ServerCluster {
         let mut node = Node::new(&mut store_event_loop, &cfg, self.pd_client.clone());
         let snap_mgr = store::new_snap_mgr(tmp_str, Some(node.get_sendch()));
 
+        let network_monitor_transport = DummyNetworkMonitorTransport::new();
         node.start(store_event_loop,
                    engine.clone(),
                    simulate_trans.clone(),
+                   network_monitor_transport.clone(),
                    snap_mgr.clone())
             .unwrap();
         let router = ServerRaftStoreRouter::new(node.get_sendch(), node.id());
@@ -172,6 +178,7 @@ impl Simulator for ServerCluster {
 
         self.store_chs.insert(node_id, node.get_sendch());
         self.sim_trans.insert(node_id, simulate_trans);
+        self.network_monitor_transports.insert(node_id, network_monitor_transport);
 
         let mut store = create_raft_storage(sim_router.clone(), engine, &cfg).unwrap();
         store.start(&cfg.storage).unwrap();
@@ -181,12 +188,16 @@ impl Simulator for ServerCluster {
             raft_router: sim_router.clone(),
             snapshot_status_sender: node.get_snapshot_status_sender(),
         };
+        let server_helper = ServerHelper {
+            resolver: resolver,
+            network_monitor: network_monitor,
+        };
         let mut server = Server::new(&mut event_loop,
                                      &cfg,
                                      listener,
                                      store,
                                      server_chan,
-                                     resolver,
+                                     server_helper,
                                      snap_mgr)
             .unwrap();
 

--- a/tests/raftstore/transport_simulate.rs
+++ b/tests/raftstore/transport_simulate.rs
@@ -14,7 +14,7 @@
 use kvproto::raft_serverpb::RaftMessage;
 use kvproto::eraftpb::MessageType;
 use tikv::raftstore::{Result, Error};
-use tikv::raftstore::store::{Msg as StoreMsg, Transport};
+use tikv::raftstore::store::{Msg as StoreMsg, Transport, NetworkMonitorTransport, RenewNetworkStat};
 use tikv::server::transport::*;
 use tikv::util::HandyRwLock;
 use tikv::util::transport;
@@ -174,6 +174,21 @@ impl<C: Channel<StoreMsg>> RaftStoreRouter for SimulateTransport<StoreMsg, C> {
 
     fn try_send(&self, m: StoreMsg) -> Result<()> {
         Channel::send(self, m)
+    }
+}
+#[derive(Clone)]
+pub struct DummyNetworkMonitorTransport;
+
+impl DummyNetworkMonitorTransport {
+    pub fn new() -> DummyNetworkMonitorTransport {
+        DummyNetworkMonitorTransport {}
+    }
+}
+
+impl NetworkMonitorTransport for DummyNetworkMonitorTransport {
+    fn send(&self, _: RenewNetworkStat) -> Result<()> {
+        // Just swallow the stat
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This PR tries to fix issue #1429 

Since there is a restriction about deployment of new process, it's only possible to implement the network monitoring as one component of the TiKV process. 

This PR adds a new worker to monitor the connection status between local store and remote stores in the server layer. The worker receives remote store ids from raftstore, and tries to track the connection status periodically. Currently it outputs log messages if the connections to remote stores are lost. Further extension to track all the bandwidth/latency/jitter and any other network indexes could be carried out in the future.

It's unusual to bind this fundamental monitoring to the main server process. There is still many issues about it, e.g. it requires a powerful database to store the great mount of monitoring data (and the corresponding network bandwidth to upload data) to track the networking between stores. And it would affect the performance of TiKV more or less.