### PR TITLE
*: upgrade rustc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,21 +9,14 @@ matrix:
   include:
     - os: linux
       rust: nightly
-      env: COMPILER=g++-4.8 RUSTC_DATE=2016-10-06
-      addons:
-         apt:
-            sources: ['ubuntu-toolchain-r-test']
-            packages: ['g++-4.8', 'zlib1g-dev', 'libbz2-dev', 'libsnappy-dev', 'curl', 'libdw-dev', 'libelf-dev', 'elfutils', 'binutils-dev']
-    - os: linux
-      rust: nightly
-      env: COMPILER=g++-4.8 RUSTC_DATE=2016-08-06 ENABLE_FEATURES=default SKIP_TESTS=true
+      env: COMPILER=g++-4.8 RUSTC_DATE=2016-12-19
       addons:
          apt:
             sources: ['ubuntu-toolchain-r-test']
             packages: ['g++-4.8', 'zlib1g-dev', 'libbz2-dev', 'libsnappy-dev', 'curl', 'libdw-dev', 'libelf-dev', 'elfutils', 'binutils-dev']
     - os: osx
       rust: nightly
-      env: COMPILER=clang++ RUSTC_DATE=2016-10-06
+      env: COMPILER=clang++ RUSTC_DATE=2016-12-19
 
 install:
   - export LOCAL_DIR=$HOME/.cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache:
   directories:
   - $HOME/.cache/
   - $HOME/.cargo/
+  - $TRAVIS_BUILD_DIR/target
 
 matrix:
   include:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ dependencies = [
  "bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy 0.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -128,15 +128,15 @@ dependencies = [
 
 [[package]]
 name = "clippy"
-version = "0.0.95"
+version = "0.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "clippy_lints 0.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy_lints 0.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "clippy_lints"
-version = "0.0.95"
+version = "0.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -771,8 +771,8 @@ dependencies = [
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
 "checksum chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9213f7cd7c27e95c2b57c49f0e69b1ea65b27138da84a170133fd21b07659c00"
 "checksum clap 2.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5fa304b03c49ccbb005784fc26e985b5d2310b1d37f2c311ce90dbcd18ea5fde"
-"checksum clippy 0.0.95 (registry+https://github.com/rust-lang/crates.io-index)" = "326a296da2adbb719fcc2301f3b44a148261f72a46dbda89930ead9c90d584b2"
-"checksum clippy_lints 0.0.95 (registry+https://github.com/rust-lang/crates.io-index)" = "921bb7c49a9a58f6bd097fbbb9f729426e0f05372fe5b81a0a053f6b2d98dc5b"
+"checksum clippy 0.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "ae3fb361e922a08b698e746d4f199ff2d1e8d4b5f1984eaf8881e720cf5b8e34"
+"checksum clippy_lints 0.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "70812027c1a8de9277d125557dce08262bc27508f2eb99592ad2d39a24a0b1c7"
 "checksum cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e3d6405328b6edb412158b3b7710e2634e23f3614b9bb1c412df7952489a626"
 "checksum crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "541a7a4936092a4dac8b3a1dc1abc264372e0ce1e7ab712dfe0484374f5a2b7b"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ test:
 	export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}:${LOCAL_DIR}/lib" && \
 	export LOG_LEVEL=DEBUG && \
 	export RUST_BACKTRACE=1 && \
-	cargo test --features "${ENABLE_FEATURES}" -- --nocapture && \
-	cargo test --features "${ENABLE_FEATURES}" --bench benches -- --nocapture 
+	cargo test --features "${ENABLE_FEATURES}" ${NO_RUN} -- --nocapture && \
+	cargo test --features "${ENABLE_FEATURES}" --bench benches ${NO_RUN} -- --nocapture 
 	# TODO: remove above target once https://github.com/rust-lang/cargo/issues/2984 is resolved.
 
 bench:

--- a/benches/channel/bench_channel.rs
+++ b/benches/channel/bench_channel.rs
@@ -38,7 +38,7 @@ impl Handler for CountHandler {
 fn mio_must_send(sender: &Sender<u32>, n: u32) {
     loop {
         // Send may return notify error, we must retry.
-        if let Ok(_) = sender.send(n) {
+        if sender.send(n).is_ok() {
             return;
         }
     }

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ machine:
     LDFLAGS: "-L$HOME/.local/lib"
     CPPFLAGS: "-I$HOME/.local/include"
     PKG_CONFIG_PATH: "$PKG_CONFIG_PATH:$HOME/.local/lib/pkgconfig"
-    RUSTC_DATE: "2016-10-06"
+    RUSTC_DATE: "2016-12-19"
     LOCAL_PREFIX: "$HOME/.local"
     # used by cargo
     LIBRARY_PATH: "$LIBRARY_PATH:$HOME/.local/lib"

--- a/docker/release_dockerfile
+++ b/docker/release_dockerfile
@@ -7,7 +7,7 @@ RUN yum update -y && \
     yum install -y devtoolset-4-gcc-c++ python27 && \
     yum clean all
 
-RUN curl -sSf https://static.rust-lang.org/rustup.sh |  sh -s -- --date=2016-08-06 --disable-sudo -y --channel=nightly
+RUN curl -sSf https://static.rust-lang.org/rustup.sh |  sh -s -- --date=2016-12-19 --disable-sudo -y --channel=nightly
 
 ADD https://github.com/pingcap/tikv/archive/master.tar.gz /master.tar.gz
 

--- a/docker/rust_dockerfile
+++ b/docker/rust_dockerfile
@@ -25,4 +25,4 @@ RUN cd / && \
     cd / && \
     rm -rf /rocksdb-4.12.fb /rocksdb.tar.gz
 
-RUN curl -sSf https://static.rust-lang.org/rustup.sh | sh -s  -- --date=2016-08-06 --disable-sudo -y --channel=nightly
+RUN curl -sSf https://static.rust-lang.org/rustup.sh | sh -s  -- --date=2016-12-19 --disable-sudo -y --channel=nightly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,17 +12,13 @@
 // limitations under the License.
 
 #![crate_type = "lib"]
-#![allow(stable_features)]
-#![feature(mpsc_recv_timeout)]
 #![feature(test)]
-#![feature(optin_builtin_traits)]
 #![feature(btree_range, collections_bound)]
 #![feature(fnbox)]
 #![feature(alloc)]
-#![feature(plugin)]
 #![feature(slice_patterns)]
 #![feature(box_syntax)]
-#![feature(const_fn)]
+#![cfg_attr(feature = "dev", feature(plugin))]
 #![cfg_attr(feature = "dev", plugin(clippy))]
 #![cfg_attr(not(feature = "dev"), allow(unknown_lints))]
 #![recursion_limit="100"]

--- a/src/raftstore/coprocessor/region_snapshot.rs
+++ b/src/raftstore/coprocessor/region_snapshot.rs
@@ -20,8 +20,6 @@ use raftstore::store::{keys, util, PeerStorage};
 use raftstore::Result;
 
 
-type Kv<'a> = (&'a [u8], &'a [u8]);
-
 /// Snapshot of a region.
 ///
 /// Only data within a region can be accessed.

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -52,7 +52,6 @@ pub const JOB_STATUS_CANCELLED: usize = 3;
 pub const JOB_STATUS_FINISHED: usize = 4;
 pub const JOB_STATUS_FAILED: usize = 5;
 
-pub type Ranges = Vec<(Vec<u8>, Vec<u8>)>;
 
 #[derive(Debug)]
 pub enum SnapState {

--- a/src/util/codec/table.rs
+++ b/src/util/codec/table.rs
@@ -271,7 +271,7 @@ pub fn cut_idx_key<'a>(mut key: &'a [u8], col_ids: &[i64]) -> Result<(ValDict<'a
 #[cfg(test)]
 mod test {
     use super::*;
-    use util::codec::mysql::*;
+    use util::codec::mysql::types;
     use util::codec::datum::{self, Datum};
     use util::codec::number::NumberEncoder;
     use tipb::schema::ColumnInfo;

--- a/tests/storage/test_storage.rs
+++ b/tests/storage/test_storage.rs
@@ -604,19 +604,20 @@ fn inc(store: &SyncStorage, oracle: &Oracle, key: &[u8]) -> Result<i32, ()> {
             }
         };
         let next = number + 1;
-        if let Err(_) = store.prewrite(Context::new(),
-                                       vec![Mutation::Put((make_key(key),
-                                                           next.to_string().into_bytes()))],
-                                       key.to_vec(),
-                                       start_ts) {
+        if store.prewrite(Context::new(),
+                      vec![Mutation::Put((make_key(key), next.to_string().into_bytes()))],
+                      key.to_vec(),
+                      start_ts)
+            .is_err() {
             backoff(i);
             continue;
         }
         let commit_ts = oracle.get_ts();
-        if let Err(_) = store.commit(Context::new(),
-                                     vec![key_address.clone()],
-                                     start_ts,
-                                     commit_ts) {
+        if store.commit(Context::new(),
+                    vec![key_address.clone()],
+                    start_ts,
+                    commit_ts)
+            .is_err() {
             backoff(i);
             continue;
         }
@@ -674,12 +675,12 @@ fn inc_multi(store: &SyncStorage, oracle: &Oracle, n: usize) -> bool {
             let next = number + 1;
             mutations.push(Mutation::Put((key.clone(), next.to_string().into_bytes())));
         }
-        if let Err(_) = store.prewrite(Context::new(), mutations, b"k0".to_vec(), start_ts) {
+        if store.prewrite(Context::new(), mutations, b"k0".to_vec(), start_ts).is_err() {
             backoff(i);
             continue;
         }
         let commit_ts = oracle.get_ts();
-        if let Err(_) = store.commit(Context::new(), keys, start_ts, commit_ts) {
+        if store.commit(Context::new(), keys, start_ts, commit_ts).is_err() {
             backoff(i);
             continue;
         }

--- a/travis-build/test.sh
+++ b/travis-build/test.sh
@@ -24,34 +24,36 @@ git diff-index --quiet HEAD -- || panic "\e[35mplease make format before creatin
 
 trap 'kill $(jobs -p) &> /dev/null || true' EXIT
 
-# start pd
-which pd-server
-if [ $? -eq 0 ]; then
-    # Separate PD clusters.
-    pd-server --name="pd1" \
-        --data-dir="default.pd1" \
-        --client-urls="http://:12379" \
-        --peer-urls="http://:12380" &
-    pd-server --name="pd2" \
-        --data-dir="default.pd2" \
-        --client-urls="http://:22379" \
-        --peer-urls="http://:22380" &
-    sleep 3s
-    export PD_ENDPOINTS=127.0.0.1:12379
-    export PD_ENDPOINTS_SEP=127.0.0.1:22379
-fi
-
 if [[ "$ENABLE_FEATURES" = "" ]]; then
     export ENABLE_FEATURES=dev
 fi
 export LOG_FILE=tests.log
 export RUST_TEST_THREADS=1
 export RUSTFLAGS=-Dwarnings
+
+NO_RUN="--no-run" make test
+status=$?
+
 if [[ "$SKIP_TESTS" = "" ]]; then
+    # start pd
+    which pd-server
+    if [ $? -eq 0 ]; then
+        # Separate PD clusters.
+        pd-server --name="pd1" \
+            --data-dir="default.pd1" \
+            --client-urls="http://:12379" \
+            --peer-urls="http://:12380" &
+        pd-server --name="pd2" \
+            --data-dir="default.pd2" \
+            --client-urls="http://:22379" \
+            --peer-urls="http://:22380" &
+        sleep 3s
+        export PD_ENDPOINTS=127.0.0.1:12379
+        export PD_ENDPOINTS_SEP=127.0.0.1:22379
+    fi
     make test 2>&1 | tee tests.out
 else
-    make build
-    exit $?
+    exit 0
 fi
 status=$?
 for case in `cat tests.out | python -c "import sys


### PR DESCRIPTION
This pr upgrades rustc to nightly-2016-12-18. You can setup it by
```
tikv $ rustup override set nightly-2016-12-19
```
If you have not installed rustup yet, you can get it from www.rustup.rs. Before installing rustup, you may want to uninstall all rustc installed previously.