### PR TITLE
tikv-server: fix assert

### DIFF
--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -145,7 +145,10 @@ fn get_toml_int(config: &toml::Value, name: &str, default: Option<i64>) -> i64 {
 fn cfg_usize(target: &mut usize, config: &toml::Value, name: &str) {
     match get_toml_int_opt(config, name) {
         Some(i) => {
-            assert!(i >= 0 && i <= usize::MAX as i64);
+            assert!(i >= 0 && i as u64 <= usize::MAX as u64,
+                    "{}: {} is invalid.",
+                    name,
+                    i);
             *target = i as usize;
         }
         None => info!("{} keep default {}", name, *target),
@@ -155,7 +158,7 @@ fn cfg_usize(target: &mut usize, config: &toml::Value, name: &str) {
 fn cfg_u64(target: &mut u64, config: &toml::Value, name: &str) {
     match get_toml_int_opt(config, name) {
         Some(i) => {
-            assert!(i > 0);
+            assert!(i > 0, "{}: {} is invalid", name, i);
             *target = i as u64;
         }
         None => info!("{} keep default {}", name, *target),


### PR DESCRIPTION
It's not safe to convert usize to i64 directly.

@siddontang @zhangjinpeng1987 PTAL