### PR TITLE
ci: skip pd tests in travis

### DIFF
--- a/travis-build/test.sh
+++ b/travis-build/test.sh
@@ -37,7 +37,7 @@ status=$?
 if [[ "$SKIP_TESTS" = "" ]]; then
     # start pd
     which pd-server
-    if [ $? -eq 0 ]; then
+    if [ $? -eq 0 ] && [[ "$TRAVIS" != "true" ]]; then
         # Separate PD clusters.
         pd-server --name="pd1" \
             --data-dir="default.pd1" \


### PR DESCRIPTION
When enable pd tests, travis will fail occasionally. These tests are already covered on circle ic, so disable it when travis is detected.

@huachaohuang @siddontang PTAL