### PR TITLE
raft: port pending conf reset when adding node

### DIFF
--- a/src/raft/raft.rs
+++ b/src/raft/raft.rs
@@ -1205,6 +1205,9 @@ impl<T: Storage> Raft<T> {
                 for e in m.mut_entries().iter_mut() {
                     if e.get_entry_type() == EntryType::EntryConfChange {
                         if self.pending_conf {
+                            info!("propose conf {:?} ignored since pending unapplied \
+                                   configuration",
+                                  e);
                             *e = Entry::new();
                             e.set_entry_type(EntryType::EntryNormal);
                         }
@@ -1564,6 +1567,7 @@ impl<T: Storage> Raft<T> {
     }
 
     pub fn add_node(&mut self, id: u64) {
+        self.pending_conf = false;
         if self.prs.contains_key(&id) {
             // Ignore any redundant addNode calls (which can happen because the
             // initial bootstrapping entries are applied twice).
@@ -1571,7 +1575,6 @@ impl<T: Storage> Raft<T> {
         }
         let last_index = self.raft_log.last_index();
         self.set_progress(id, 0, last_index + 1);
-        self.pending_conf = false;
     }
 
     pub fn remove_node(&mut self, id: u64) {

--- a/tests/test_raw_node.rs
+++ b/tests/test_raw_node.rs
@@ -230,7 +230,7 @@ fn test_raw_node_propose_add_duplicate_node() {
         s.wl().append(&rd.entries).expect("");
         for e in &rd.committed_entries {
             if e.get_entry_type() == EntryType::EntryConfChange {
-                let conf_change = protobuf::parse_from_bytes::<ConfChange>(e.get_data()).unwrap();
+                let conf_change = protobuf::parse_from_bytes(e.get_data()).unwrap();
                 raw_node.apply_conf_change(conf_change);
             }
         }

--- a/tests/test_raw_node.rs
+++ b/tests/test_raw_node.rs
@@ -203,6 +203,61 @@ fn test_raw_node_propose_and_conf_change() {
     assert_eq!(entries[1].get_data(), &*ccdata);
 }
 
+// test_raw_node_propose_add_duplicate_node ensures that two proposes to add the same node should
+// not affect the later propose to add new node.
+#[test]
+fn test_raw_node_propose_add_duplicate_node() {
+    let s = new_storage();
+    let mut raw_node = new_raw_node(1, vec![], 10, 1, s.clone(), vec![new_peer(1)]);
+    let rd = raw_node.ready();
+    s.wl().append(&rd.entries).expect("");
+    raw_node.advance(rd);
+
+    raw_node.campaign().expect("");
+    loop {
+        let rd = raw_node.ready();
+        s.wl().append(&rd.entries).expect("");
+        if rd.ss.is_some() && rd.ss.as_ref().unwrap().leader_id == raw_node.raft.id {
+            raw_node.advance(rd);
+            break;
+        }
+        raw_node.advance(rd);
+    }
+
+    let mut propose_conf_change_and_apply = |cc| {
+        raw_node.propose_conf_change(cc).expect("");
+        let rd = raw_node.ready();
+        s.wl().append(&rd.entries).expect("");
+        for e in &rd.committed_entries {
+            if e.get_entry_type() == EntryType::EntryConfChange {
+                let conf_change = protobuf::parse_from_bytes::<ConfChange>(e.get_data()).unwrap();
+                raw_node.apply_conf_change(conf_change);
+            }
+        }
+        raw_node.advance(rd);
+    };
+
+    let cc1 = conf_change(ConfChangeType::AddNode, 1);
+    let ccdata1 = protobuf::Message::write_to_bytes(&cc1).unwrap();
+    propose_conf_change_and_apply(cc1.clone());
+
+    // try to add the same node again
+    propose_conf_change_and_apply(cc1);
+
+    // the new node join should be ok
+    let cc2 = conf_change(ConfChangeType::AddNode, 2);
+    let ccdata2 = protobuf::Message::write_to_bytes(&cc2).unwrap();
+    propose_conf_change_and_apply(cc2);
+
+    let last_index = s.last_index().unwrap();
+
+    // the last three entries should be: ConfChange cc1, cc1, cc2
+    let mut entries = s.entries(last_index - 2, last_index + 1, NO_LIMIT).unwrap();
+    assert_eq!(entries.len(), 3);
+    assert_eq!(entries[0].take_data(), ccdata1);
+    assert_eq!(entries[2].take_data(), ccdata2);
+}
+
 // test_raw_node_read_index ensures that RawNode.read_index sends the MsgReadIndex message
 // to the underlying raft. It also ensures that ReadState can be read out.
 #[test]


### PR DESCRIPTION
Hi,

This PR tries to fix issue #1326. It also includes the test case in https://github.com/coreos/etcd/pull/7121.