### PR TITLE
*: enable process collector and add thread collector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,14 +470,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "procinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "prometheus"
 version = "0.2.8"
-source = "git+https://github.com/pingcap/rust-prometheus.git#b6da17eab25a42ca7dc89fdcb32e6870180adeb9"
+source = "git+https://github.com/pingcap/rust-prometheus.git#79f73ba2be1d236e14fc16b3aa291209286e7797"
 dependencies = [
+ "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "procinfo 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -812,6 +825,7 @@ dependencies = [
 "checksum num-rational 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "48cdcc9ff4ae2a8296805ac15af88b3d88ce62128ded0cb74ffb63a587502a84"
 "checksum num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "51eab148f171aefad295f8cece636fc488b9b392ef544da31ea4b8ef6b9e9c39"
 "checksum num_cpus 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "cee7e88156f3f9e19bdd598f8d6c9db7bf4078f99f8381f43a55b09648d1a6e3"
+"checksum procinfo 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f42e8578852a3306838981aedad8c5642ba794929aa12af0c9eb6c072b77af6c"
 "checksum prometheus 0.2.8 (git+https://github.com/pingcap/rust-prometheus.git)" = "<none>"
 "checksum protobuf 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "0cf9bb92f38828ff1e0a7f828a0ec261ffdd5c9ef86b9b3bc7b1eef13495b563"
 "checksum quick-error 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7ac990ab4e038dd8481a5e3fd00641067fcfc674ad663f3222752ed5284e05d4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ git = "https://github.com/carllerche/mio.git"
 [dependencies.prometheus]
 git = "https://github.com/pingcap/rust-prometheus.git"
 default-features = false
-features = ["nightly", "push"]
+features = ["nightly", "push", "process"]
 
 [profile.dev]
 opt-level = 0  # Controls the --opt-level the compiler builds with

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -615,7 +615,7 @@ fn start_server<T, S>(mut server: Server<T, S>,
 {
     let ch = server.get_sendch();
     let h = thread::Builder::new()
-        .name("tikv-server".to_owned())
+        .name("tikv-eventloop".to_owned())
         .spawn(move || {
             server.run(&mut el).unwrap();
         })

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -214,6 +214,8 @@ fn initial_metric(config: &toml::Value, node_id: Option<u64>) {
 
     info!("start prometheus client");
 
+    util::monitor_threads("tikv").unwrap();
+
     util::run_prometheus(Duration::from_millis(push_interval as u64),
                          &push_address,
                          &push_job);

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -378,7 +378,7 @@ pub fn run_prometheus(interval: Duration,
     let job = job.to_owned();
     let address = address.to_owned();
     let handler = thread::Builder::new()
-        .name("PromePusher".to_owned())
+        .name("promepusher".to_owned())
         .spawn(move || {
             loop {
                 let metric_familys = prometheus::gather();

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -403,7 +403,7 @@ pub fn run_prometheus(interval: Duration,
 pub use self::thread_metrics::monitor_threads;
 
 #[cfg(not(target_os="linux"))]
-fn monitor_threads() -> io::Result<()> {
+pub fn monitor_threads<S: Into<String>>(_: S) -> io::Result<()> {
     Ok(())
 }
 

--- a/src/util/thread_metrics.rs
+++ b/src/util/thread_metrics.rs
@@ -40,7 +40,7 @@ impl ThreadsColletcor {
                                                    "Total user and system CPU time spent in \
                                                     seconds by threads.")
                                              .namespace(namespace),
-                                         &["name"])
+                                         &["name", "tid"])
             .unwrap();
         let descs = cpu_totals.desc().into_iter().cloned().collect();
 
@@ -63,7 +63,9 @@ impl Collector for ThreadsColletcor {
         for (tid, tname) in pairs {
             if let Ok((utime, stime)) = find_thread_cpu_time(self.pid, tid) {
                 let total = (utime + stime) / *CLK_TCK;
-                let cpu_total = cpu_totals.get_metric_with_label_values(&[&tname]).unwrap();
+                let cpu_total =
+                    cpu_totals.get_metric_with_label_values(&[&tname, &format!("{}", tid)])
+                        .unwrap();
                 let past = cpu_total.get();
                 let delta = total - past;
                 if delta > 0.0 {

--- a/src/util/thread_metrics.rs
+++ b/src/util/thread_metrics.rs
@@ -1,0 +1,217 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs;
+use std::io::{Result, Error, ErrorKind, Read};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
+
+use prometheus::{self, Opts, CounterVec, Desc, proto, Collector};
+
+use libc::{self, pid_t};
+
+/// monitor current process's threads.
+pub fn monitor_threads<S: Into<String>>(namespace: S) -> Result<()> {
+    let pid = unsafe { libc::getpid() };
+    let tc = try!(ThreadsColletcor::new(pid, namespace));
+    try!(prometheus::register(Box::new(tc)).map_err(|e| to_err(format!("{:?}", e))));
+
+    Ok(())
+}
+
+// Refresh monitoring threads.
+const REFRESH_CNT: usize = 10;
+
+struct ThreadsCore {
+    refresh: usize,
+    thread_ids: Vec<(pid_t, String)>,
+    cpu_totals: CounterVec,
+}
+
+struct ThreadsColletcor {
+    pid: pid_t,
+    descs: Vec<Desc>,
+    core: Mutex<ThreadsCore>,
+}
+
+impl ThreadsColletcor {
+    fn new<S: Into<String>>(pid: pid_t, namespace: S) -> Result<ThreadsColletcor> {
+        let cpu_totals = CounterVec::new(Opts::new("thread_cpu_seconds_total",
+                                                   "Total user and system CPU time spent in \
+                                                    seconds by threads.")
+                                             .namespace(namespace),
+                                         &["name"])
+            .unwrap();
+        let descs = cpu_totals.desc().into_iter().cloned().collect();
+
+        let pairs = try!(get_threads(pid));
+        let core = ThreadsCore {
+            refresh: 0,
+            thread_ids: pairs,
+            cpu_totals: cpu_totals,
+        };
+
+        Ok(ThreadsColletcor {
+            pid: pid,
+            descs: descs,
+            core: Mutex::new(core),
+        })
+    }
+}
+
+impl Collector for ThreadsColletcor {
+    fn desc(&self) -> Vec<&Desc> {
+        self.descs.iter().collect()
+    }
+
+    fn collect(&self) -> Vec<proto::MetricFamily> {
+        let mut core = self.core.lock().unwrap();
+        core.refresh += 1;
+        if core.refresh >= REFRESH_CNT {
+            core.thread_ids = get_threads(self.pid).unwrap();
+            core.refresh = 0;
+        }
+
+        for &(tid, ref tname) in &core.thread_ids {
+            if let Ok((utime, stime)) = find_thread_cpu_time(self.pid, tid) {
+                let total = (utime + stime) / *CLK_TCK;
+                let cpu_total = core.cpu_totals.get_metric_with_label_values(&[tname]).unwrap();
+                let past = cpu_total.get();
+                let delta = total - past;
+                if delta > 0.0 {
+                    cpu_total.inc_by(delta).unwrap();
+                }
+            }
+        }
+        core.cpu_totals.collect()
+    }
+}
+
+fn get_threads(pid: pid_t) -> Result<Vec<(pid_t, String)>> {
+    let mut pairs = Vec::new();
+
+    let dirs = try!(fs::read_dir(format!("/proc/{}/task", pid)));
+    for task in dirs {
+        let tid = match try!(task).file_name().to_str() {
+            Some(tid) => try!(tid.parse().map_err(|e| to_err(format!("{}", e)))),
+            None => return Err(to_err(format!("fail to read {} task", pid))),
+        };
+
+        let mut tname = String::new();
+        try!(fs::File::open(format!("/proc/{}/task/{}/comm", pid, tid))
+            .and_then(|mut f| f.read_to_string(&mut tname)));
+
+        // Pop tail '\n'.
+        tname.pop();
+        pairs.push((tid, sanitize_thread_name(tname)));
+    }
+
+    Ok(pairs)
+}
+
+static TH_CNT: AtomicUsize = ATOMIC_USIZE_INIT;
+
+fn sanitize_thread_name(name: String) -> String {
+    let mut san = String::with_capacity(name.len());
+    for c in name.chars() {
+        match c {
+            // Prometheus label characters `[a-zA-Z0-9_:]*`
+            'a'...'z' | 'A'...'Z' | '0'...'9' | '_' | ':' => {
+                san.push(c);
+            }
+            '-' => san.push('_'),
+            _ => (),
+        }
+    }
+
+    if san.is_empty() {
+        format!("unkonw_{}", TH_CNT.fetch_add(1, Ordering::Relaxed))
+    } else {
+        san
+    }
+}
+
+fn to_err(s: String) -> Error {
+    Error::new(ErrorKind::Other, s)
+}
+
+// See more man proc.
+const CPU_INDEX: [usize; 2] = [14 - 1, 15 - 1];
+
+fn find_thread_cpu_time(pid: pid_t, tid: pid_t) -> Result<(f64, f64)> {
+    let mut buffer = String::new();
+    try!(fs::File::open(format!("/proc/{}/task/{}/stat", pid, tid))
+        .and_then(|mut f| f.read_to_string(&mut buffer)));
+
+    let stats: Vec<_> = buffer.split_whitespace().collect();
+    let utime = stats[CPU_INDEX[0]];
+    let stime = stats[CPU_INDEX[1]];
+    Ok((utime.parse().unwrap(), stime.parse().unwrap()))
+}
+
+lazy_static! {
+    // getconf CLK_TCK
+    static ref CLK_TCK: f64 = {
+        unsafe {
+            libc::sysconf(libc::_SC_CLK_TCK) as f64
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread;
+    use std::sync;
+
+    use libc;
+
+    #[test]
+    fn test_get_thread_name() {
+        // Thread name's length is restricted to 16 characters,
+        // including the terminating null byte ('\0').
+        let name = "theadnametest66";
+        let (tx, rx) = sync::mpsc::channel();
+        let (tx1, rx1) = sync::mpsc::channel();
+        let h = thread::Builder::new()
+            .name(name.to_owned())
+            .spawn(move || {
+                tx1.send(()).unwrap();
+                rx.recv().unwrap();
+            })
+            .unwrap();
+
+        rx1.recv().unwrap();
+        let pid = unsafe { libc::getpid() };
+        let pairs = super::get_threads(pid).unwrap();
+
+        assert!(pairs.len() >= 1);
+        pairs.iter()
+            .find(|p| name == p.1)
+            .unwrap();
+
+        tx.send(()).unwrap();
+        h.join().unwrap();
+    }
+
+    #[test]
+    fn test_sanitize_thread_name() {
+        let case = [("ok123", "ok123"),
+                    ("a-b", "a_b"),
+                    ("Az_1:", "Az_1:"),
+                    ("@123", "123"),
+                    ("@", "unkonw_0")];
+        for &(i, o) in &case {
+            assert_eq!(super::sanitize_thread_name(i.to_owned()), o);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a custom prometheus collector, it collects each thread's CPU time. Also this PR updates promethues crate and enables the `process` feature.

PTAL @zhangjinpeng1987 @siddontang @BusyJay 

Close #1481