### PR TITLE
raftstore: count kvs in other cf when doing split check

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -41,6 +41,8 @@ pub const CF_DEFAULT: CfName = "default";
 pub const CF_LOCK: CfName = "lock";
 pub const CF_WRITE: CfName = "write";
 pub const CF_RAFT: CfName = "raft";
+// Cfs that should be very large generally.
+pub const LARGE_CFS: &'static [CfName] = &[CF_DEFAULT, CF_WRITE];
 pub const ALL_CFS: &'static [CfName] = &[CF_DEFAULT, CF_LOCK, CF_WRITE, CF_RAFT];
 
 // Short value max len must <= 255.


### PR DESCRIPTION
We only count the kvs in default cf when doing split check, which can lead to a region with too many keys if most values are very small. So we need to count all the kvs in other large cfs too.
