### PR TITLE
travis: remove compilation cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
   directories:
   - $HOME/.cache/
   - $HOME/.cargo/
-  - $TRAVIS_BUILD_DIR/target
 
 matrix:
   include:


### PR DESCRIPTION
OS X build often fails when packaging new caches which is produced during compilation, so remove it to make it easier to finish. Though this will slow down CI check.

@siddontang @disksing PTAL