### PR TITLE
support dump fail log without coupling to travis environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ ifeq ($(ROCKSDB_SYS_PORTABLE),1)
 ENABLE_FEATURES += portable
 endif
 
+PROJECT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+
 DEPS_PATH = $(CURDIR)/tmp
 BIN_PATH = $(CURDIR)/bin
 GOROOT ?= $(DEPS_PATH)/go
@@ -35,6 +37,12 @@ release:
 
 static_release:
 	ROCKSDB_SYS_STATIC=1 ROCKSDB_SYS_PORTABLE=1 make release
+
+# unlike test, this target will trace tests and output logs when fail test is detected.
+trace_test:
+	export CI=true && \
+	export SKIP_FORMAT_CHECK=true && \
+	${PROJECT_DIR}/travis-build/test.sh
 
 test:
 	# When SIP is enabled, DYLD_LIBRARY_PATH will not work in subshell, so we have to set it

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -53,10 +53,10 @@ mod pd;
 use std::env;
 
 #[test]
-fn _0_travis_setup() {
-    // Set up travis test fail case log.
+fn _0_ci_setup() {
+    // Set up ci test fail case log.
     // The prefix "_" here is to guarantee running this case first.
-    if env::var("TRAVIS").is_ok() && env::var("LOG_FILE").is_ok() {
+    if env::var("CI").is_ok() && env::var("LOG_FILE").is_ok() {
         self::util::init_log();
     }
 }

--- a/travis-build/Makefile
+++ b/travis-build/Makefile
@@ -1,5 +1,7 @@
 SHELL=/bin/bash -o pipefail
 
+CI_BUILD_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+
 ${LOCAL_DIR}/lib/libgflags.a:
 	cd /tmp && \
 	curl -L https://github.com/gflags/gflags/archive/v2.1.2.tar.gz -o gflags.tar.gz && \
@@ -67,7 +69,7 @@ prepare_brew:
 prepare_osx: ${LOCAL_DIR}/lib/librocksdb.dylib ${LOCAL_DIR}/bin/pd-server prepare-rustfmt | prepare_brew prepare_rust
 
 test_linux test_osx:
-	./travis-build/test.sh
+	export CI=true && ${CI_BUILD_DIR}/test.sh
 
 cover_linux:
 	export LOG_LEVEL=DEBUG && \

--- a/travis-build/test.sh
+++ b/travis-build/test.sh
@@ -19,8 +19,10 @@ panic() {
     exit 1
 }
 
-make format
-git diff-index --quiet HEAD -- || panic "\e[35mplease make format before creating a pr!!!\e[0m" 
+if [[ "$SKIP_FORMAT_CHECK" != "true" ]]; then
+    make format
+    git diff-index --quiet HEAD -- || panic "\e[35mplease make format before creating a pr!!!\e[0m" 
+fi
 
 trap 'kill $(jobs -p) &> /dev/null || true' EXIT
 
@@ -28,12 +30,12 @@ if [[ "$ENABLE_FEATURES" = "" ]]; then
     export ENABLE_FEATURES=dev
 fi
 export LOG_FILE=tests.log
-export RUST_TEST_THREADS=1
+if [[ "$TRAVIS" = "true" ]]; then
+    export RUST_TEST_THREADS=1
+fi
 export RUSTFLAGS=-Dwarnings
 
-NO_RUN="--no-run" make test || exit $?
-
-if [[ "$SKIP_TESTS" = "" ]]; then
+if [[ "$SKIP_TESTS" != "true" ]]; then
     # start pd
     which pd-server
     if [ $? -eq 0 ] && [[ "$TRAVIS" != "true" ]]; then
@@ -52,7 +54,8 @@ if [[ "$SKIP_TESTS" = "" ]]; then
     fi
     make test 2>&1 | tee tests.out
 else
-    exit 0
+    NO_RUN="--no-run" make test
+    exit $?
 fi
 status=$?
 for case in `cat tests.out | python -c "import sys
@@ -64,7 +67,7 @@ for l in sys.stdin:
     m = p.search(l)
     if m:
         cases.add(m.group(1).split(':')[-1])
-print '\n'.join(cases)
+print('\n'.join(cases))
 "`; do
     echo find fail cases: $case
     grep $case $LOG_FILE | cut -d ' ' -f 2-
@@ -73,7 +76,10 @@ print '\n'.join(cases)
     echo
 done
 
-# don't remove the tests.out, coverage counts on it.
 rm $LOG_FILE || true
+# don't remove the tests.out, coverage counts on it.
+if [[ "$TRAVIS" != "true" ]]; then
+    rm tests.out || true
+fi
 
 exit $status

--- a/travis-build/test.sh
+++ b/travis-build/test.sh
@@ -67,7 +67,7 @@ for l in sys.stdin:
     m = p.search(l)
     if m:
         cases.add(m.group(1).split(':')[-1])
-print('\n'.join(cases))
+print ('\n'.join(cases))
 "`; do
     echo find fail cases: $case
     grep $case $LOG_FILE | cut -d ' ' -f 2-


### PR DESCRIPTION
Currently fail logs are only be printed in Travis CI. But we may need this too in general development or other CI environment, like reproducing a rare bug. So this pr add a target trace_test to meet this need.

@siddontang @disksing @iamxy PTAL