### PR TITLE
copr/metrics: add request wait time

### DIFF
--- a/src/server/coprocessor/endpoint.rs
+++ b/src/server/coprocessor/endpoint.rs
@@ -131,7 +131,7 @@ impl RequestTask {
         check_if_outdated(self.deadline, self.req.get_tp())
     }
 
-    fn start_handling(&mut self) {
+    fn stop_record_waiting(&mut self) {
         if self.wait_time.is_some() {
             return;
         }
@@ -141,8 +141,8 @@ impl RequestTask {
         self.wait_time = Some(wait_time);
     }
 
-    fn finish_handling(&mut self) {
-        self.start_handling();
+    fn stop_record_handling(&mut self) {
+        self.stop_record_waiting();
 
         let handle_time = duration_to_sec(self.timer.elapsed());
         let type_str = get_req_type_str(self.req.get_tp());
@@ -295,7 +295,7 @@ fn check_if_outdated(deadline: Instant, tp: i64) -> Result<()> {
 }
 
 fn respond(resp: Response, mut t: RequestTask) {
-    t.finish_handling();
+    t.stop_record_handling();
     let mut resp_msg = Message::new();
     resp_msg.set_msg_type(MessageType::CopResp);
     resp_msg.set_cop_resp(resp);
@@ -323,7 +323,7 @@ impl TiDbEndPoint {
     }
 
     fn handle_request(&self, mut t: RequestTask) {
-        t.start_handling();
+        t.stop_record_waiting();
         let tp = t.req.get_tp();
         match tp {
             REQ_TYPE_SELECT | REQ_TYPE_INDEX => {

--- a/src/server/coprocessor/metrics.rs
+++ b/src/server/coprocessor/metrics.rs
@@ -17,7 +17,7 @@ lazy_static! {
     pub static ref COPR_REQ_HISTOGRAM_VEC: HistogramVec =
         register_histogram_vec!(
             "tikv_coprocessor_request_duration_seconds",
-            "Bucketed histogram of coprocessor handle request duration",
+            "Bucketed histogram of coprocessor request duration",
             &["type", "req"]
         ).unwrap();
 
@@ -25,6 +25,13 @@ lazy_static! {
         register_histogram_vec!(
             "tikv_coprocessor_outdated_request_wait_seconds",
             "Bucketed histogram of outdated coprocessor request wait duration",
+            &["type", "req"]
+        ).unwrap();
+
+    pub static ref COPR_REQ_HANDLE_TIME: HistogramVec =
+        register_histogram_vec!(
+            "tikv_coprocessor_request_handle_seconds",
+            "Bucketed histogram of coprocessor handle request duration",
             &["type", "req"]
         ).unwrap();
 

--- a/src/server/coprocessor/metrics.rs
+++ b/src/server/coprocessor/metrics.rs
@@ -28,6 +28,13 @@ lazy_static! {
             &["type", "req"]
         ).unwrap();
 
+    pub static ref COPR_REQ_WAIT_TIME: HistogramVec =
+        register_histogram_vec!(
+            "tikv_coprocessor_request_wait_seconds",
+            "Bucketed histogram of coprocessor request wait duration",
+            &["type", "req"]
+        ).unwrap();
+
     pub static ref COPR_REQ_ERROR: CounterVec =
         register_counter_vec!(
             "tikv_coprocessor_request_error",

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -286,6 +286,14 @@ pub fn duration_to_ms(d: Duration) -> u64 {
     d.as_secs() * 1_000 + (nanos / 1_000_000)
 }
 
+/// Convert Duration to seconds.
+#[inline]
+pub fn duration_to_sec(d: Duration) -> f64 {
+    let nanos = d.subsec_nanos() as f64;
+    // Most of case, we can't have so large Duration, so here just panic if overflow now.
+    d.as_secs() as f64 + (nanos / 1_000_000_000.0)
+}
+
 /// Convert Duration to nanoseconds.
 #[inline]
 pub fn duration_to_nanos(d: Duration) -> u64 {
@@ -398,6 +406,7 @@ mod tests {
     use std::net::{SocketAddr, AddrParseError};
     use std::time::Duration;
     use std::rc::Rc;
+    use std::f64;
     use std::sync::atomic::{AtomicBool, Ordering};
     use super::*;
 
@@ -432,6 +441,9 @@ mod tests {
         for ms in tbl {
             let d = Duration::from_millis(ms);
             assert_eq!(ms, duration_to_ms(d));
+            let exp_sec = ms as f64 / 1000.0;
+            let act_sec = duration_to_sec(d);
+            assert!((act_sec - exp_sec).abs() < f64::EPSILON);
             assert_eq!(ms * 1_000_000, duration_to_nanos(d));
         }
     }


### PR DESCRIPTION
Requests may wait too long in queue before actually being handled, this pr add a metric to trace this problem.

@siddontang @disksing @shenli PTAL