### PR TITLE
scheduler: fix a bug that happens when prewrite meets locks.

### DIFF
--- a/tests/storage/test_storage.rs
+++ b/tests/storage/test_storage.rs
@@ -617,20 +617,11 @@ fn test_txn_store_lock_primary() {
     store.rollback_ok(vec![b"p"], 1);
     store.resolve_lock_ok(1, None);
 
-    // txn3 wants to write "s".
-    store.prewrite_locked(vec![Mutation::Put((make_key(b"s"), b"s3".to_vec()))],
-                          b"s",
-                          3,
-                          vec![(b"s", b"p", 2)]);
-    // txn3 cleanups txn2'lock.
-    store.rollback_ok(vec![b"p"], 2);
-
-    // txn2 resends prewrite and commits ok, but in txn3's view it should be rolled back.
-    store.prewrite_ok(vec![Mutation::Put((make_key(b"p"), b"p2".to_vec())),
-                           Mutation::Put((make_key(b"s"), b"s2".to_vec()))],
+    // txn3 wants to write "p", "s", neither of them should be locked.
+    store.prewrite_ok(vec![Mutation::Put((make_key(b"p"), b"p3".to_vec())),
+                           Mutation::Put((make_key(b"s"), b"s3".to_vec()))],
                       b"p",
-                      2);
-    store.commit_ok(vec![b"p", b"s"], 2, 4);
+                      3);
 }
 
 struct Oracle {

--- a/tests/storage/test_storage.rs
+++ b/tests/storage/test_storage.rs
@@ -21,8 +21,8 @@ use super::sync_storage::SyncStorage;
 use kvproto::kvrpcpb::{Context, LockInfo};
 use tikv::storage::{self, Mutation, Key, KvPair, make_key, ALL_CFS, Storage};
 use tikv::storage::engine::{self, TEMP_DIR, Engine};
-use tikv::storage::txn::{GC_BATCH_SIZE, RESOLVE_LOCK_BATCH_SIZE};
-use tikv::storage::mvcc::MAX_TXN_WRITE_SIZE;
+use tikv::storage::txn::{self, GC_BATCH_SIZE, RESOLVE_LOCK_BATCH_SIZE};
+use tikv::storage::mvcc::{self, MAX_TXN_WRITE_SIZE};
 use storage::util;
 
 #[derive(Clone)]
@@ -129,6 +129,27 @@ impl AssertionStorage {
 
     fn prewrite_ok(&self, mutations: Vec<Mutation>, primary: &[u8], start_ts: u64) {
         self.0.prewrite(Context::new(), mutations, primary.to_vec(), start_ts).unwrap();
+    }
+
+    fn prewrite_locked(&self,
+                       mutations: Vec<Mutation>,
+                       primary: &[u8],
+                       start_ts: u64,
+                       expect_locks: Vec<(&[u8], &[u8], u64)>) {
+        let res = self.0.prewrite(Context::new(), mutations, primary.to_vec(), start_ts).unwrap();
+        let locks: Vec<(&[u8], &[u8], u64)> = res.iter()
+            .filter_map(|x| {
+                if let Err(storage::Error::Txn(txn::Error::Mvcc(mvcc::Error::KeyIsLocked { ref key,
+                                                                              ref primary,
+                                                                              ts,
+                                                                              .. }))) = *x {
+                    Some((key.as_ref(), primary.as_ref(), ts))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert_eq!(expect_locks, locks);
     }
 
     fn commit_ok(&self, keys: Vec<&[u8]>, start_ts: u64, commit_ts: u64) {
@@ -576,6 +597,40 @@ fn test_txn_store_rawkv() {
     store.raw_get_ok(b"key".to_vec(), Some(b"v2".to_vec()));
     store.raw_delete_ok(b"key".to_vec());
     store.raw_get_ok(b"key".to_vec(), None);
+}
+
+#[test]
+fn test_txn_store_lock_primary() {
+    let store = new_assertion_storage();
+    // txn1 locks "p" then aborts.
+    store.prewrite_ok(vec![Mutation::Put((make_key(b"p"), b"p1".to_vec()))],
+                      b"p",
+                      1);
+
+    // txn2 wants to write "p", "s".
+    store.prewrite_locked(vec![Mutation::Put((make_key(b"p"), b"p2".to_vec())),
+                               Mutation::Put((make_key(b"s"), b"s2".to_vec()))],
+                          b"p",
+                          2,
+                          vec![(b"p", b"p", 1)]);
+    // txn2 cleanups txn1's lock.
+    store.rollback_ok(vec![b"p"], 1);
+    store.resolve_lock_ok(1, None);
+
+    // txn3 wants to write "s".
+    store.prewrite_locked(vec![Mutation::Put((make_key(b"s"), b"s3".to_vec()))],
+                          b"s",
+                          3,
+                          vec![(b"s", b"p", 2)]);
+    // txn3 cleanups txn2'lock.
+    store.rollback_ok(vec![b"p"], 2);
+
+    // txn2 resends prewrite and commits ok, but in txn3's view it should be rolled back.
+    store.prewrite_ok(vec![Mutation::Put((make_key(b"p"), b"p2".to_vec())),
+                           Mutation::Put((make_key(b"s"), b"s2".to_vec()))],
+                      b"p",
+                      2);
+    store.commit_ok(vec![b"p", b"s"], 2, 4);
 }
 
 struct Oracle {


### PR DESCRIPTION
If primary key is locked, other keys should not be submitted before primary key.

@siddontang @BusyJay @zhangjinpeng1987 