### PR TITLE
raftstore: make raft log gc not depend on PeerStorage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto#b66543960fb3508671152f6c9f4a09ee9d7a2322"
+source = "git+https://github.com/pingcap/kvproto#007487fecab1fb30f0d32964463c543cd0114bcc"
 dependencies = [
  "protobuf 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -1697,6 +1697,7 @@ impl Peer {
         }
 
         let compact_term = req.get_compact_log().get_compact_term();
+        // TODO: add unit tests to cover all the message integrity checks.
         if compact_term == 0 {
             info!("{} compact term missing in {:?}, skip.",
                   self.tag,

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -75,6 +75,35 @@ impl PartialEq for SnapState {
     }
 }
 
+// Discard all log entries prior to compact_index. We must guarantee
+// that the compact_index is not greater than applied index.
+pub fn compact_raft_log(tag: &str,
+                        state: &mut RaftApplyState,
+                        compact_index: u64,
+                        compact_term: u64)
+                        -> Result<()> {
+    debug!("{} compact log entries to prior to {}", tag, compact_index);
+
+    if compact_index <= state.get_truncated_state().get_index() {
+        return Err(box_err!("try to truncate compacted entries"));
+    } else if compact_index > state.get_applied_index() {
+        return Err(box_err!("compact index {} > applied index {}",
+                            compact_index,
+                            state.get_applied_index()));
+    }
+    // we don't actually compact the log now, we add an async task to do it.
+
+    state.mut_truncated_state().set_index(compact_index);
+    state.mut_truncated_state().set_term(compact_term);
+
+    Ok(())
+}
+
+#[inline]
+pub fn first_index(state: &RaftApplyState) -> u64 {
+    state.get_truncated_state().get_index() + 1
+}
+
 pub struct PeerStorage {
     pub engine: Arc<DB>,
 
@@ -357,7 +386,7 @@ impl PeerStorage {
 
     #[inline]
     pub fn first_index(&self) -> u64 {
-        self.apply_state.get_truncated_state().get_index() + 1
+        first_index(&self.apply_state)
     }
 
     #[inline]
@@ -563,30 +592,6 @@ impl PeerStorage {
               ctx.apply_state);
 
         ctx.snap_region = Some(region);
-        Ok(())
-    }
-
-    // Discard all log entries prior to compact_index. We must guarantee
-    // that the compact_index is not greater than applied index.
-    pub fn compact(&self, state: &mut RaftApplyState, compact_index: u64) -> Result<()> {
-        debug!("{} compact log entries to prior to {}",
-               self.tag,
-               compact_index);
-
-        if compact_index <= self.truncated_index() {
-            return Err(box_err!("try to truncate compacted entries"));
-        } else if compact_index > self.applied_index() {
-            return Err(box_err!("compact index {} > applied index {}",
-                                compact_index,
-                                self.applied_index()));
-        }
-
-        let term = try!(self.term(compact_index - 1));
-        // we don't actually compact the log now, we add an async task to do it.
-
-        state.mut_truncated_state().set_index(compact_index - 1);
-        state.mut_truncated_state().set_term(term);
-
         Ok(())
     }
 
@@ -1144,7 +1149,9 @@ mod test {
             let sched = worker.scheduler();
             let store = new_storage_from_ents(sched, &td, &ents);
             let mut ctx = InvokeContext::new(&store);
-            let res = store.compact(&mut ctx.apply_state, idx);
+            let res = store.term(idx)
+                .map_err(From::from)
+                .and_then(|term| compact_raft_log(&store.tag, &mut ctx.apply_state, idx, term));
             // TODO check exact error type after refactoring error.
             if res.is_err() ^ werr.is_err() {
                 panic!("#{}: want {:?}, got {:?}", i, werr, res);
@@ -1214,7 +1221,8 @@ mod test {
         s.apply_state = ctx.apply_state;
         s.raft_state = ctx.raft_state;
         ctx = InvokeContext::new(&s);
-        s.compact(&mut ctx.apply_state, 7).unwrap();
+        let term = s.term(7).unwrap();
+        compact_raft_log(&s.tag, &mut ctx.apply_state, 7, term).unwrap();
         wb = WriteBatch::new();
         ctx.save_apply_to(&s.engine, &mut wb).unwrap();
         s.engine.write(wb).unwrap();

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -91,7 +91,8 @@ pub fn compact_raft_log(tag: &str,
                             compact_index,
                             state.get_applied_index()));
     }
-    // we don't actually compact the log now, we add an async task to do it.
+
+    // we don't actually delete the logs now, we add an async task to do it.
 
     state.mut_truncated_state().set_index(compact_index);
     state.mut_truncated_state().set_term(compact_term);

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -1233,7 +1233,8 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             // Have no idea why subtract 1 here, but original code did this by magic.
             assert!(compact_idx > 0);
             compact_idx -= 1;
-            if compact_idx <= first_idx {
+            if compact_idx < first_idx {
+                // In case compact_idx == first_idx before subtraction.
                 continue;
             }
 

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -1217,7 +1217,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             }
             let applied_idx = peer.get_store().applied_index();
             let first_idx = peer.get_store().first_index();
-            let compact_idx;
+            let mut compact_idx;
             if applied_idx > first_idx &&
                applied_idx - first_idx >= self.cfg.raft_log_gc_count_limit {
                 compact_idx = applied_idx;
@@ -1228,6 +1228,13 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                 continue;
             } else {
                 compact_idx = replicated_idx;
+            }
+
+            // Have no idea why subtract 1 here, but original code did this by magic.
+            assert!(compact_idx > 0);
+            compact_idx -= 1;
+            if compact_idx <= first_idx {
+                continue;
             }
 
             let term = peer.raft_group.raft.raft_log.term(compact_idx).unwrap();

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -897,7 +897,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             start_idx: peer.last_compacted_idx,
             end_idx: state.get_index() + 1,
         };
-        peer.last_compacted_idx = state.get_index() + 1;
+        peer.last_compacted_idx = task.end_idx;
         if let Err(e) = self.raftlog_gc_worker.schedule(task) {
             error!("[region {}] failed to schedule compact task: {}",
                    region_id,
@@ -1230,8 +1230,10 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                 compact_idx = replicated_idx;
             }
 
+            let term = peer.raft_group.raft.raft_log.term(compact_idx).unwrap();
+
             // Create a compact log request and notify directly.
-            let request = new_compact_log_request(region_id, peer.peer.clone(), compact_idx);
+            let request = new_compact_log_request(region_id, peer.peer.clone(), compact_idx, term);
 
             if let Err(e) = self.sendch.try_send(Msg::RaftCmd {
                 request: request,
@@ -1814,13 +1816,15 @@ fn register_timer<T: Transport, C: PdClient>(event_loop: &mut EventLoop<Store<T,
 
 fn new_compact_log_request(region_id: u64,
                            peer: metapb::Peer,
-                           compact_index: u64)
+                           compact_index: u64,
+                           compact_term: u64)
                            -> RaftCmdRequest {
     let mut request = new_admin_request(region_id, peer);
 
     let mut admin = AdminRequest::new();
     admin.set_cmd_type(AdminCmdType::CompactLog);
     admin.mut_compact_log().set_compact_index(compact_index);
+    admin.mut_compact_log().set_compact_term(compact_term);
     request.set_admin_request(admin);
     request
 }


### PR DESCRIPTION
PeerStorage is not thread-safe, so it we want to do async apply, it's better make apply not depends on PeerStorage.

@siddontang @hhkbp2 PTAL