### PR TITLE
raftstore: update raft only in store thread after confchange

### DIFF
--- a/src/raft/raw_node.rs
+++ b/src/raft/raw_node.rs
@@ -261,7 +261,7 @@ impl<T: Storage> RawNode<T> {
         self.raft.step(m)
     }
 
-    pub fn apply_conf_change(&mut self, cc: ConfChange) -> ConfState {
+    pub fn apply_conf_change(&mut self, cc: &ConfChange) -> ConfState {
         if cc.get_node_id() == INVALID_ID {
             self.raft.reset_pending_conf();
             let mut cs = ConfState::new();

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -1394,6 +1394,8 @@ impl Peer {
                 }
                 ExecResult::SplitRegion { ref left, .. } => {
                     storage.region = left.clone();
+                    self.size_diff_hint = 0;
+                    self.delete_keys_hint = 0;
                 }
             }
         }
@@ -1659,9 +1661,6 @@ impl Peer {
         for (index, peer) in new_region.mut_peers().iter_mut().enumerate() {
             let peer_id = new_peer_ids[index];
             peer.set_id(peer_id);
-
-            // Add this peer to cache.
-            self.peer_cache.borrow_mut().insert(peer_id, peer.clone());
         }
 
         // update region version
@@ -1681,9 +1680,6 @@ impl Peer {
         let mut resp = AdminResponse::new();
         resp.mut_split().set_left(region.clone());
         resp.mut_split().set_right(new_region.clone());
-
-        self.size_diff_hint = 0;
-        self.delete_keys_hint = 0;
 
         PEER_ADMIN_CMD_COUNTER_VEC.with_label_values(&["split", "success"]).inc();
 

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -35,6 +35,9 @@ use raft::{self, RawNode, StateRole, SnapshotStatus, Ready, ProgressState, Progr
 use raftstore::{Result, Error};
 use raftstore::coprocessor::CoprocessorHost;
 use raftstore::coprocessor::split_observer::SplitObserver;
+use raftstore::store::Config;
+use raftstore::store::worker::PdTask;
+use util::worker::Worker;
 use util::{escape, SlowTimer, rocksdb, clocktime};
 use pd::INVALID_ID;
 use storage::{CF_LOCK, CF_RAFT};
@@ -83,13 +86,16 @@ impl Drop for PendingCmd {
     }
 }
 
+#[derive(Default, Debug)]
+pub struct ChangePeer {
+    pub conf_change: eraftpb::ConfChange,
+    pub peer: metapb::Peer,
+    pub region: metapb::Region,
+}
+
 #[derive(Debug)]
 pub enum ExecResult {
-    ChangePeer {
-        change_type: ConfChangeType,
-        peer: metapb::Peer,
-        region: metapb::Region,
-    },
+    ChangePeer(ChangePeer),
     CompactLog {
         state: RaftTruncatedState,
         first_index: u64,
@@ -362,14 +368,11 @@ impl Peer {
         let region = self.get_store().get_region().clone();
         info!("{} begin to destroy", self.tag);
 
-        // If pending_remove, meta was destroyed when applying removal.
-        if !self.pending_remove {
-            // First set Tombstone state explicitly, and clear raft meta.
-            let wb = WriteBatch::new();
-            try!(self.get_store().clear_meta(&wb));
-            try!(write_peer_state(&wb, &region, PeerState::Tombstone));
-            try!(self.engine.write(wb));
-        }
+        // First set Tombstone state explicitly, and clear raft meta.
+        let wb = WriteBatch::new();
+        try!(self.get_store().clear_meta(&wb));
+        try!(write_peer_state(&wb, &region, PeerState::Tombstone));
+        try!(self.engine.write(wb));
 
         // TODO: figure out a way to unit test this.
         let peer_id = self.peer_id();
@@ -1052,6 +1055,18 @@ impl Peer {
         None
     }
 
+    pub fn heartbeat_pd(&self, cfg: &Config, worker: &Worker<PdTask>) {
+        let task = PdTask::Heartbeat {
+            region: self.region().clone(),
+            peer: self.peer.clone(),
+            down_peers: self.collect_down_peers(cfg.max_peer_down_duration),
+            pending_peers: self.collect_pending_peers(),
+        };
+        if let Err(e) = worker.schedule(task) {
+            error!("{} failed to notify pd: {}", self.tag, e);
+        }
+    }
+
     fn send_raft_message<T: Transport>(&mut self, msg: eraftpb::Message, trans: &T) -> Result<()> {
         let mut send_msg = RaftMessage::new();
         send_msg.set_region_id(self.region_id);
@@ -1214,14 +1229,21 @@ impl Peer {
         let term = entry.get_term();
         let conf_change: eraftpb::ConfChange = parse_data_at(entry.get_data(), index, &self.tag);
         let cmd = parse_data_at(conf_change.get_context(), index, &self.tag);
-        let (res, cc) = match self.process_raft_cmd(index, term, cmd) {
-            res @ Some(_) => (res, conf_change),
+        Some(self.process_raft_cmd(index, term, cmd).map_or_else(|| {
             // If failed, tell raft that the config change was aborted.
-            None => (None, eraftpb::ConfChange::new()),
-        };
-        self.raft_group.apply_conf_change(cc);
-
-        res
+            ExecResult::ChangePeer(Default::default())
+        }, |mut res| {
+            if let ExecResult::ChangePeer(ref mut cp) = res {
+                cp.conf_change = conf_change;
+            } else {
+                panic!("{} unexpected result {:?} for conf change {:?} at {}",
+                       self.tag,
+                       res,
+                       conf_change,
+                       index);
+            }
+            res
+        }))
     }
 
     fn find_cb(&mut self,
@@ -1359,8 +1381,8 @@ impl Peer {
 
         if let Some(ref exec_result) = exec_result {
             match *exec_result {
-                ExecResult::ChangePeer { ref region, .. } => {
-                    storage.region = region.clone();
+                ExecResult::ChangePeer(ref cp) => {
+                    storage.region = cp.region.clone();
                 }
                 ExecResult::ComputeHash { .. } |
                 ExecResult::VerifyHash { .. } => {}
@@ -1529,11 +1551,9 @@ impl Peer {
                                         peer,
                                         self.region()));
                 }
+
                 // TODO: Do we allow adding peer in same node?
 
-                // Add this peer to cache.
-                self.peer_cache.borrow_mut().insert(peer.get_id(), peer.clone());
-                self.peer_heartbeats.insert(peer.get_id(), Instant::now());
                 region.mut_peers().push(peer.clone());
 
                 PEER_ADMIN_CMD_COUNTER_VEC.with_label_values(&["add_peer", "success"]).inc();
@@ -1562,9 +1582,6 @@ impl Peer {
                     self.pending_remove = true;
                 }
 
-                // Remove this peer from cache.
-                self.peer_cache.borrow_mut().remove(&peer.get_id());
-                self.peer_heartbeats.remove(&peer.get_id());
                 util::remove_peer(&mut region, store_id).unwrap();
 
                 PEER_ADMIN_CMD_COUNTER_VEC.with_label_values(&["remove_peer", "success"]).inc();
@@ -1576,25 +1593,24 @@ impl Peer {
             }
         }
 
-        if self.pending_remove {
-            self.get_store()
-                .clear_meta(&ctx.wb)
-                .and_then(|_| write_peer_state(&ctx.wb, &region, PeerState::Tombstone))
-                .unwrap_or_else(|e| panic!("{} failed to remove self: {:?}", self.tag, e));
+        let state = if self.pending_remove {
+            PeerState::Tombstone
         } else {
-            write_peer_state(&ctx.wb, &region, PeerState::Normal)
-                .unwrap_or_else(|e| panic!("{} failed to update region state: {:?}", self.tag, e));
+            PeerState::Normal
+        };
+        if let Err(e) = write_peer_state(&ctx.wb, &region, state) {
+            panic!("{} failed to update region state: {:?}", self.tag, e);
         }
 
         let mut resp = AdminResponse::new();
         resp.mut_change_peer().set_region(region.clone());
 
         Ok((resp,
-            Some(ExecResult::ChangePeer {
-            change_type: change_type,
+            Some(ExecResult::ChangePeer(ChangePeer {
+            conf_change: Default::default(),
             peer: peer.clone(),
             region: region,
-        })))
+        }))))
     }
 
     fn exec_split(&mut self,

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -368,7 +368,7 @@ impl Peer {
         let region = self.get_store().get_region().clone();
         info!("{} begin to destroy", self.tag);
 
-        // First set Tombstone state explicitly, and clear raft meta.
+        // Set Tombstone state explicitly
         let wb = WriteBatch::new();
         try!(self.get_store().clear_meta(&wb));
         try!(write_peer_state(&wb, &region, PeerState::Tombstone));

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -933,6 +933,10 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                              right: metapb::Region) {
         let new_region_id = right.get_id();
         if let Some(peer) = self.region_peers.get(&new_region_id) {
+            // Add new peers to cache.
+            for meta in right.get_peers() {
+                self.peer_cache.borrow_mut().insert(meta.get_id(), meta.to_owned());
+            }
             // If the store received a raft msg with the new region raft group
             // before splitting, it will creates a uninitialized peer.
             // We can remove this uninitialized peer directly.

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -37,7 +37,7 @@ use pd::PdClient;
 use kvproto::raft_cmdpb::{AdminCmdType, AdminRequest, StatusCmdType, StatusResponse,
                           RaftCmdRequest, RaftCmdResponse};
 use protobuf::Message;
-use raft::{SnapshotStatus, INVALID_INDEX};
+use raft::{self, SnapshotStatus, INVALID_INDEX};
 use raftstore::{Result, Error};
 use kvproto::metapb;
 use util::worker::{Worker, Scheduler};
@@ -52,7 +52,7 @@ use super::keys::{self, enc_start_key, enc_end_key, data_end_key, data_key};
 use super::engine::{Iterable, Peekable, Snapshot as EngineSnapshot};
 use super::config::Config;
 use super::peer::{Peer, PendingCmd, ReadyResult, ExecResult, StaleState, ConsistencyState,
-                  ReadyContext};
+                  ReadyContext, ChangePeer};
 use super::peer_storage::ApplySnapResult;
 use super::msg::Callback;
 use super::cmd_resp::{bind_uuid, bind_term, bind_error};
@@ -863,28 +863,50 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         }
     }
 
-    fn on_ready_change_peer(&mut self,
-                            region_id: u64,
-                            change_type: ConfChangeType,
-                            peer: metapb::Peer) {
-        let mut peer_id = 0;
-        if let Some(p) = self.region_peers.get(&region_id) {
+    fn on_ready_change_peer(&mut self, region_id: u64, cp: ChangePeer) {
+        let my_peer_id;
+        let change_type = cp.conf_change.get_change_type();
+        if let Some(p) = self.region_peers.get_mut(&region_id) {
+            p.raft_group.apply_conf_change(&cp.conf_change);
+            if cp.conf_change.get_node_id() == raft::INVALID_ID {
+                // Apply failed, skip.
+                return;
+            }
             if p.is_leader() {
                 // Notify pd immediately.
                 info!("{} notify pd with change peer region {:?}",
                       p.tag,
                       p.region());
-                self.heartbeat_pd(p);
+                p.heartbeat_pd(&self.cfg, &self.pd_worker);
             }
-            peer_id = p.peer_id();
+
+            match change_type {
+                ConfChangeType::AddNode => {
+                    // Add this peer to cache.
+                    let peer = cp.peer.clone();
+                    p.peer_heartbeats.insert(peer.get_id(), Instant::now());
+                    self.peer_cache.borrow_mut().insert(peer.get_id(), peer);
+                }
+                ConfChangeType::RemoveNode => {
+                    // Remove this peer from cache.
+                    p.peer_heartbeats.remove(&cp.peer.get_id());
+                    self.peer_cache.borrow_mut().remove(&cp.peer.get_id());
+                }
+            }
+
+            my_peer_id = p.peer_id();
+        } else {
+            panic!("{} missing region {}", self.tag, region_id);
         }
+
+        let peer = cp.peer;
 
         // We only care remove itself now.
         if change_type == ConfChangeType::RemoveNode && peer.get_store_id() == self.store_id() {
-            if peer_id == peer.get_id() {
+            if my_peer_id == peer.get_id() {
                 self.destroy_peer(region_id, peer)
             } else {
-                panic!("trying to remove unknown peer {:?}", peer);
+                panic!("{} trying to remove unknown peer {:?}", self.tag, peer);
             }
         }
     }
@@ -970,8 +992,8 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         info!("notify pd with split left {:?}, right {:?}",
               left_region,
               right_region);
-        self.heartbeat_pd(left);
-        self.heartbeat_pd(right);
+        left.heartbeat_pd(&self.cfg, &self.pd_worker);
+        right.heartbeat_pd(&self.cfg, &self.pd_worker);
 
         // Now pd only uses ReportSplit for history operation show,
         // so we send it independently here.
@@ -1020,9 +1042,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         // handle executing committed log results
         for result in ready_result.exec_results {
             match result {
-                ExecResult::ChangePeer { change_type, peer, .. } => {
-                    self.on_ready_change_peer(region_id, change_type, peer)
-                }
+                ExecResult::ChangePeer(cp) => self.on_ready_change_peer(region_id, cp),
                 ExecResult::CompactLog { state, .. } => self.on_ready_compact_log(region_id, state),
                 ExecResult::SplitRegion { left, right } => {
                     self.on_ready_split_region(region_id, left, right)
@@ -1365,18 +1385,6 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         }
     }
 
-    fn heartbeat_pd(&self, peer: &Peer) {
-        let task = PdTask::Heartbeat {
-            region: peer.region().clone(),
-            peer: peer.peer.clone(),
-            down_peers: peer.collect_down_peers(self.cfg.max_peer_down_duration),
-            pending_peers: peer.collect_pending_peers(),
-        };
-        if let Err(e) = self.pd_worker.schedule(task) {
-            error!("{} failed to notify pd: {}", peer.tag, e);
-        }
-    }
-
     fn on_pd_heartbeat_tick(&mut self, event_loop: &mut EventLoop<Self>) {
         for peer in self.region_peers.values_mut() {
             peer.check_peers();
@@ -1386,7 +1394,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         for peer in self.region_peers.values() {
             if peer.is_leader() {
                 leader_count += 1;
-                self.heartbeat_pd(peer);
+                peer.heartbeat_pd(&self.cfg, &self.pd_worker);
             }
         }
 

--- a/src/util/sockopt.rs
+++ b/src/util/sockopt.rs
@@ -22,7 +22,7 @@ pub trait SocketOpt {
 
 #[cfg(unix)]
 mod unix {
-    use super::SocketOpt;
+    use util::sockopt::SocketOpt;
 
     use std::io::{Result, Error};
     use std::os::unix::io::AsRawFd;

--- a/tests/raftstore/pd.rs
+++ b/tests/raftstore/pd.rs
@@ -365,6 +365,10 @@ impl TestPdClient {
         self.cluster.wl().rule = None;
     }
 
+    pub fn get_region_epoch(&self, region_id: u64) -> metapb::RegionEpoch {
+        self.get_region_by_id(region_id).unwrap().unwrap().take_region_epoch()
+    }
+
     // Set an empty rule which nothing to do to disable default max peer count
     // check rule, we can use reset_rule to enable default again.
     pub fn disable_default_rule(&self) {

--- a/tests/raftstore/util.rs
+++ b/tests/raftstore/util.rs
@@ -188,6 +188,14 @@ pub fn new_admin_request(region_id: u64,
     req
 }
 
+pub fn new_change_peer_request(change_type: ConfChangeType, peer: metapb::Peer) -> AdminRequest {
+    let mut req = AdminRequest::new();
+    req.set_cmd_type(AdminCmdType::ChangePeer);
+    req.mut_change_peer().set_change_type(change_type);
+    req.mut_change_peer().set_peer(peer);
+    req
+}
+
 pub fn new_transfer_leader_cmd(peer: metapb::Peer) -> AdminRequest {
     let mut cmd = AdminRequest::new();
     cmd.set_cmd_type(AdminCmdType::TransferLeader);

--- a/tests/test_raw_node.rs
+++ b/tests/test_raw_node.rs
@@ -231,7 +231,7 @@ fn test_raw_node_propose_add_duplicate_node() {
         for e in rd.committed_entries.as_ref().unwrap() {
             if e.get_entry_type() == EntryType::EntryConfChange {
                 let conf_change = protobuf::parse_from_bytes(e.get_data()).unwrap();
-                raw_node.apply_conf_change(conf_change);
+                raw_node.apply_conf_change(&conf_change);
             }
         }
         raw_node.advance(rd);


### PR DESCRIPTION
RawNode is not designed to be thread safe, so we should only update RawNode in store thread after confchange is applied.

@siddontang @hhkbp2 PTAL