### PR TITLE
copr: make copr task more concurrent

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@
 #![recursion_limit="100"]
 
 #![allow(module_inception)]
+#![allow(should_implement_trait)]
 
 #[macro_use]
 extern crate log;

--- a/src/raftstore/coprocessor/region_snapshot.rs
+++ b/src/raftstore/coprocessor/region_snapshot.rs
@@ -25,21 +25,21 @@ use raftstore::Result;
 /// Only data within a region can be accessed.
 pub struct RegionSnapshot {
     snap: SyncSnapshot,
-    region: Region,
+    region: Arc<Region>,
 }
 
 impl RegionSnapshot {
     pub fn new(ps: &PeerStorage) -> RegionSnapshot {
         RegionSnapshot {
             snap: ps.raw_snapshot().into_sync(),
-            region: ps.get_region().clone(),
+            region: Arc::new(ps.get_region().clone()),
         }
     }
 
     pub fn from_raw(db: Arc<DB>, region: Region) -> RegionSnapshot {
         RegionSnapshot {
             snap: Snapshot::new(db).into_sync(),
-            region: region,
+            region: Arc::new(region),
         }
     }
 
@@ -140,7 +140,7 @@ impl Peekable for RegionSnapshot {
 pub struct RegionIterator<'a> {
     iter: DBIterator<'a>,
     valid: bool,
-    region: Region,
+    region: Arc<Region>,
     start_key: Vec<u8>,
     end_key: Vec<u8>,
 }
@@ -156,7 +156,7 @@ fn adjust_upper_bound(upper_bound: Option<&[u8]>) -> Option<&[u8]> {
 // we use rocksdb's style iterator, doesn't need to impl std iterator.
 impl<'a> RegionIterator<'a> {
     pub fn new(snap: &'a Snapshot,
-               region: Region,
+               region: Arc<Region>,
                upper_bound: Option<&[u8]>,
                fill_cache: bool)
                -> RegionIterator<'a> {
@@ -173,7 +173,7 @@ impl<'a> RegionIterator<'a> {
     }
 
     pub fn new_cf(snap: &'a Snapshot,
-                  region: Region,
+                  region: Arc<Region>,
                   upper_bound: Option<&[u8]>,
                   fill_cache: bool,
                   cf: &str)

--- a/src/raftstore/store/worker/split_check.rs
+++ b/src/raftstore/store/worker/split_check.rs
@@ -95,7 +95,6 @@ impl<'a> MergedIterator<'a> {
         })
     }
 
-    #[allow(should_implement_trait)]
     fn next(&mut self) -> Option<KeyEntry> {
         let pos = match self.heap.peek() {
             None => return None,

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -107,6 +107,7 @@ pub trait Snapshot: Send {
                    fill_cache: bool,
                    mode: ScanMode)
                    -> Result<Cursor<'a>>;
+    fn clone(&self) -> Box<Snapshot>;
 }
 
 pub trait Iterator {
@@ -358,7 +359,6 @@ impl<'a> Cursor<'a> {
     }
 
     #[inline]
-    #[allow(should_implement_trait)]
     pub fn next(&mut self) -> bool {
         self.iter.next()
     }

--- a/src/storage/engine/raftkv.rs
+++ b/src/storage/engine/raftkv.rs
@@ -336,6 +336,10 @@ impl Snapshot for RegionSnapshot {
         Ok(Cursor::new(try!(RegionSnapshot::iter_cf(self, cf, upper_bound, fill_cache)),
                        mode))
     }
+
+    fn clone(&self) -> Box<Snapshot> {
+        Box::new(RegionSnapshot::clone(self))
+    }
 }
 
 impl<'a> EngineIterator for RegionIterator<'a> {

--- a/src/storage/engine/rocksdb.rs
+++ b/src/storage/engine/rocksdb.rs
@@ -16,7 +16,7 @@ use std::sync::{Arc, Mutex};
 use rocksdb::{DB, Writable, SeekKey, WriteBatch, DBIterator};
 use kvproto::kvrpcpb::Context;
 use storage::{Key, Value, CfName, CF_DEFAULT};
-use raftstore::store::engine::{Snapshot as RocksSnapshot, Peekable, Iterable};
+use raftstore::store::engine::{SyncSnapshot as RocksSnapshot, Peekable, Iterable};
 use util::escape;
 use util::rocksdb;
 use util::worker::{Runnable, Worker, Scheduler};
@@ -188,6 +188,10 @@ impl Snapshot for RocksSnapshot {
         trace!("RocksSnapshot: create cf iterator");
         Ok(Cursor::new(try!(self.new_iterator_cf(cf, upper_bound, fill_cache)),
                        mode))
+    }
+
+    fn clone(&self) -> Box<Snapshot> {
+        Box::new(RocksSnapshot::clone(self))
     }
 }
 

--- a/src/util/codec/datum.rs
+++ b/src/util/codec/datum.rs
@@ -91,7 +91,6 @@ fn checked_add_i64(l: u64, r: i64) -> Option<u64> {
     }
 }
 
-#[allow(should_implement_trait)]
 impl Datum {
     pub fn cmp(&self, ctx: &EvalContext, datum: &Datum) -> Result<Ordering> {
         match *datum {


### PR DESCRIPTION
Currently tasks in a batch of the same regions will be executed sequentially, we can handle it concurrently.

@siddontang @disksing PTAL