### PR TITLE
add rustc version when printing tikv-server version

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -31,7 +31,10 @@ fn main() {
 // build_info returns a string of commit hash and utc time.
 fn build_info() -> String {
     // explicit separates outputs by '\n'.
-    format!("{}\n{}", commit_hash().trim_right(), utc_time())
+    format!("{}\n{}\n{}",
+            commit_hash().trim_right(),
+            utc_time(),
+            rustc_version())
 }
 
 fn utc_time() -> String {
@@ -43,4 +46,14 @@ fn commit_hash() -> String {
     let mut cmd = Command::new("git");
     cmd.args(&["rev-parse", "HEAD"]);
     cmd.output().ok().and_then(|o| String::from_utf8(o.stdout).ok()).unwrap_or("None".to_owned())
+}
+
+fn rustc_version() -> String {
+    let mut cmd = Command::new("rustc");
+    cmd.args(&["--version"]);
+    cmd.output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|v| v.trim_left_matches("rustc").trim().to_owned())
+        .unwrap()
 }

--- a/build.rs
+++ b/build.rs
@@ -49,7 +49,7 @@ fn commit_hash() -> String {
 }
 
 fn rustc_version() -> String {
-    let mut cmd = Command::new("rustc");
+    let mut cmd = Command::new(env::var("RUSTC").unwrap());
     cmd.args(&["--version"]);
     cmd.output()
         .ok()

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -717,9 +717,10 @@ fn main() {
         return;
     }
     if matches.opt_present("V") {
-        let (hash, date) = util::build_info();
+        let (hash, date, rustc) = util::build_info();
         println!("Git Commit Hash: {}", hash);
         println!("UTC Build Time:  {}", date);
+        println!("Rustc Version:   {}", rustc);
         return;
     }
     let config = match matches.opt_str("C") {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -358,20 +358,23 @@ impl<L, R> Either<L, R> {
 }
 
 /// `build_info` returns a tuple of Strings that contains build utc time and commit hash.
-pub fn build_info() -> (String, String) {
+pub fn build_info() -> (String, String, String) {
     let raw = include_str!(concat!(env!("OUT_DIR"), "/build-info.txt"));
     let mut parts = raw.split('\n');
 
-    (parts.next().unwrap_or("None").to_owned(), parts.next().unwrap_or("None").to_owned())
+    (parts.next().unwrap_or("None").to_owned(),
+     parts.next().unwrap_or("None").to_owned(),
+     parts.next().unwrap_or("None").to_owned())
 }
 
 /// `print_tikv_info` prints the tikv version information to the standard output.
 pub fn print_tikv_info() {
-    let (hash, date) = build_info();
+    let (hash, date, rustc) = build_info();
     info!("Welcome to TiKV.");
     info!("Version:");
     info!("Git Commit Hash: {}", hash);
     info!("UTC Build Time:  {}", date);
+    info!("Rustc Version:   {}", rustc);
 }
 
 /// `run_prometheus` runs a background prometheus client.


### PR DESCRIPTION
This makes `tikv-server -V` print following message, thus let users know which rustc builds tikv-server binary
```
Git Commit Hash: bf2e5e8e58ce2649385d3ad592ea22652fa1b9ef
UTC Build Time:  2017-01-23 03:46:47
Rustc Version:   1.15.0-nightly (71c06a56a 2016-12-18)
```