### PR TITLE
raftstore: update lease before applying

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -209,6 +209,7 @@ impl PendingCmdQueue {
         self.conf_change.take()
     }
 
+    // TODO: seems we don't need to seperate conf change from normal entries.
     fn set_conf_change(&mut self, cmd: PendingCmd) {
         self.conf_change = Some(cmd);
     }

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -63,12 +63,52 @@ pub enum StaleState {
     ToValidate,
 }
 
+pub struct ProposalMeta {
+    pub uuid: Uuid,
+    pub term: u64,
+    /// `renew_lease_time` contains the last time when a peer starts to renew lease.
+    pub renew_lease_time: Option<Timespec>,
+}
+
+#[derive(Default)]
+struct ProposalQueue {
+    queue: VecDeque<ProposalMeta>,
+    uuids: HashSet<Uuid>,
+}
+
+impl ProposalQueue {
+    pub fn contains(&self, uuid: &Uuid) -> bool {
+        self.uuids.contains(uuid)
+    }
+
+    fn pop(&mut self, term: u64) -> Option<ProposalMeta> {
+        self.queue.pop_front().and_then(|meta| {
+            if meta.term > term {
+                self.queue.push_front(meta);
+                return None;
+            }
+            self.uuids.remove(&meta.uuid);
+            Some(meta)
+        })
+    }
+
+    fn push(&mut self, meta: ProposalMeta) {
+        self.uuids.insert(meta.uuid);
+        self.queue.push_back(meta);
+    }
+
+    fn clear(&mut self) {
+        if !self.uuids.is_empty() {
+            self.uuids.clear();
+            self.queue.clear();
+        }
+    }
+}
+
 pub struct PendingCmd {
     pub uuid: Uuid,
     pub term: u64,
     pub cb: Option<Callback>,
-    /// `renew_lease_time` contains the last time when a peer starts to renew lease.
-    pub renew_lease_time: Option<Timespec>,
 }
 
 impl PendingCmd {
@@ -146,47 +186,30 @@ pub struct ReadyResult {
 struct PendingCmdQueue {
     normals: VecDeque<PendingCmd>,
     conf_change: Option<PendingCmd>,
-    uuids: HashSet<Uuid>,
 }
 
 impl PendingCmdQueue {
-    pub fn contains(&self, uuid: &Uuid) -> bool {
-        self.uuids.contains(uuid)
-    }
-
-    fn remove(&mut self, cmd: &Option<PendingCmd>) {
-        if let Some(ref cmd) = *cmd {
-            self.uuids.remove(&cmd.uuid);
-        }
-    }
-
     fn pop_normal(&mut self, term: u64) -> Option<PendingCmd> {
         self.normals.pop_front().and_then(|cmd| {
             if cmd.term > term {
                 self.normals.push_front(cmd);
                 return None;
             }
-            let res = Some(cmd);
-            self.remove(&res);
-            res
+            Some(cmd)
         })
     }
 
     fn append_normal(&mut self, cmd: PendingCmd) {
-        self.uuids.insert(cmd.uuid);
         self.normals.push_back(cmd);
     }
 
     fn take_conf_change(&mut self) -> Option<PendingCmd> {
         // conf change will not be affected when changing between follower and leader,
         // so there is no need to check term.
-        let cmd = self.conf_change.take();
-        self.remove(&cmd);
-        cmd
+        self.conf_change.take()
     }
 
     fn set_conf_change(&mut self, cmd: PendingCmd) {
-        self.uuids.insert(cmd.uuid);
         self.conf_change = Some(cmd);
     }
 }
@@ -225,6 +248,7 @@ pub struct Peer {
     pub peer: metapb::Peer,
     region_id: u64,
     pub raft_group: RawNode<PeerStorage>,
+    proposals: ProposalQueue,
     pending_cmds: PendingCmdQueue,
     // Record the last instant of each peer's heartbeat response.
     pub peer_heartbeats: HashMap<u64, Instant>,
@@ -323,6 +347,7 @@ impl Peer {
             peer: util::new_peer(store_id, peer_id),
             region_id: region.get_id(),
             raft_group: raft_group,
+            proposals: Default::default(),
             pending_cmds: Default::default(),
             peer_cache: store.peer_cache(),
             peer_heartbeats: HashMap::new(),
@@ -686,29 +711,103 @@ impl Peer {
             }
             vec![]
         } else {
-            self.handle_raft_committed_entries(ready.committed_entries.take().unwrap())
+            let committed_entries = ready.committed_entries.take().unwrap();
+            // leader needs to update lease.
+            let mut to_be_updated = self.is_leader();
+            if !to_be_updated {
+                // It's not leader anymore, we are safe to clear proposals. If it becomes leader
+                // again, the lease should be updated when election is finished, old proposals
+                // have no effect. Although this may allow old uuids to be reused before old
+                // callbacks are called.
+                self.proposals.clear();
+            }
+            for entry in committed_entries.iter().rev() {
+                // raft meta is very small, can be ignored.
+                self.raft_log_size_hint += entry.get_data().len() as u64;
+                to_be_updated = to_be_updated &&
+                                self.maybe_update_lease(entry.get_term(), entry.get_data());
+            }
+            if !committed_entries.is_empty() {
+                self.handle_raft_committed_entries(committed_entries)
+            } else {
+                vec![]
+            }
         };
 
         self.raft_group.advance(ready);
+    }
+
+    /// Try to update lease.
+    ///
+    /// If the it can make sure that its lease is the latest lease, returns true.
+    fn maybe_update_lease(&mut self, term: u64, data: &[u8]) -> bool {
+        let mut req = RaftCmdRequest::new();
+        let propose_time = match req.merge_from_bytes(data)
+            .ok()
+            .and_then(|_| util::get_uuid_from_req(&req))
+            .and_then(|uuid| self.find_propose_time(uuid, term)) {
+            Some(t) => t,
+            _ => return false,
+        };
+
+        // Try to renew the leader lease as this command asks to.
+        if let Some(current_expired_time) = self.leader_lease_expired_time {
+            // This peer is leader and has recorded leader lease.
+            // Calculate the renewed lease for this command. If the renewed lease lives longer
+            // than the current leader lease, update the current leader lease to the renewed lease.
+            let next_expired_time = self.next_lease_expired_time(propose_time);
+            // Use the lease expired timestamp comparison here, so that these codes still
+            // work no matter how the leader changes before applying this command.
+            if current_expired_time < next_expired_time {
+                debug!("{} update leader lease expired time from {:?} to {:?}",
+                       self.tag,
+                       current_expired_time,
+                       next_expired_time);
+                self.leader_lease_expired_time = Some(next_expired_time)
+            }
+        } else if self.is_leader() {
+            // This peer is leader but its leader lease has expired.
+            // Calculate the renewed lease for this command, and update the leader lease
+            // for this peer.
+            let next_expired_time = self.next_lease_expired_time(propose_time);
+            debug!("{} update leader lease expired time from None to {:?}",
+                   self.tag,
+                   self.leader_lease_expired_time);
+            self.leader_lease_expired_time = Some(next_expired_time);
+        }
+
+        true
+    }
+
+    fn find_propose_time(&mut self, uuid: Uuid, term: u64) -> Option<Timespec> {
+        while let Some(meta) = self.proposals.pop(term) {
+            if meta.uuid == uuid {
+                return Some(meta.renew_lease_time.unwrap());
+            }
+        }
+        None
     }
 
     /// Propose a request.
     ///
     /// Return true means the request has been proposed successfully.
     pub fn propose(&mut self,
-                   mut cmd: PendingCmd,
+                   mut meta: ProposalMeta,
+                   cb: Callback,
                    req: RaftCmdRequest,
                    mut err_resp: RaftCmdResponse,
                    metrics: &mut RaftProposeMetrics)
                    -> bool {
-        if self.pending_cmds.contains(&cmd.uuid) {
-            cmd_resp::bind_error(&mut err_resp, box_err!("duplicated uuid {:?}", cmd.uuid));
-            cmd.call(err_resp);
+        if self.proposals.contains(&meta.uuid) {
+            cmd_resp::bind_error(&mut err_resp, box_err!("duplicated uuid {:?}", meta.uuid));
+            cb(err_resp);
             return false;
         }
 
-        debug!("{} propose command with uuid {:?}", self.tag, cmd.uuid);
+        debug!("{} propose command with uuid {:?}", self.tag, meta.uuid);
         metrics.all += 1;
+
+        let mut is_conf_change = false;
 
         if self.should_read_local(&req) {
             metrics.local_read += 1;
@@ -720,9 +819,9 @@ impl Peer {
                 (cmd_resp::new_error(e), None)
             });
 
-            cmd_resp::bind_uuid(&mut resp, cmd.uuid);
+            cmd_resp::bind_uuid(&mut resp, meta.uuid);
             cmd_resp::bind_term(&mut resp, self.term());
-            cmd.call(resp);
+            cb(resp);
             return false;
         } else if get_transfer_leader_cmd(&req).is_some() {
             metrics.transfer_leader += 1;
@@ -740,7 +839,7 @@ impl Peer {
 
             // transfer leader command doesn't need to replicate log and apply, so we
             // return immediately. Note that this command may fail, we can view it just as an advice
-            cmd.call(make_transfer_leader_response());
+            cb(make_transfer_leader_response());
             return false;
         } else if get_change_peer_cmd(&req).is_some() {
             if self.raft_group.raft.pending_conf {
@@ -748,33 +847,46 @@ impl Peer {
                 cmd_resp::bind_error(&mut err_resp,
                                      box_err!("{} there is a pending conf change, try later",
                                               self.tag));
-                cmd.call(err_resp);
+                cb(err_resp);
                 return false;
-            }
-            if let Some(cmd) = self.pending_cmds.take_conf_change() {
-                // if it loses leadership before conf change is replicated, there may be
-                // a stale pending conf change before next conf change is applied. If it
-                // becomes leader again with the stale pending conf change, will enter
-                // this block, so we notify leadership may have changed.
-                self.notify_stale_command(cmd);
             }
 
             if let Err(e) = self.propose_conf_change(req, metrics) {
                 cmd_resp::bind_error(&mut err_resp, e);
-                cmd.call(err_resp);
+                cb(err_resp);
                 return false;
             }
 
-            // Try to renew leader lease on every conf change request.
-            cmd.renew_lease_time = Some(clocktime::raw_now());
-            self.pending_cmds.set_conf_change(cmd);
+            is_conf_change = true;
         } else if let Err(e) = self.propose_normal(req, metrics) {
             cmd_resp::bind_error(&mut err_resp, e);
-            cmd.call(err_resp);
+            cb(err_resp);
             return false;
+        }
+
+
+        // Try to renew leader lease on every consistent read/write request.
+        meta.renew_lease_time = Some(clocktime::raw_now());
+
+
+        let cmd = PendingCmd {
+            uuid: meta.uuid,
+            term: meta.term,
+            cb: Some(cb),
+        };
+
+        self.proposals.push(meta);
+
+        if is_conf_change {
+            if let Some(stale_cmd) = self.pending_cmds.take_conf_change() {
+                // if it loses leadership before conf change is replicated, there may be
+                // a stale pending conf change before next conf change is applied. If it
+                // becomes leader again with the stale pending conf change, will enter
+                // this block, so we notify leadership may have changed.
+                self.notify_stale_command(stale_cmd);
+            }
+            self.pending_cmds.set_conf_change(cmd);
         } else {
-            // Try to renew leader lease on every consistent read/write request.
-            cmd.renew_lease_time = Some(clocktime::raw_now());
             self.pending_cmds.append_normal(cmd);
         }
 
@@ -1168,9 +1280,6 @@ impl Peer {
                        entry.get_index());
             }
 
-            // raft meta is very small, can be ignored.
-            self.raft_log_size_hint += entry.get_data().len() as u64;
-
             let res = match entry.get_entry_type() {
                 eraftpb::EntryType::EntryNormal => self.handle_raft_entry_normal(entry),
                 eraftpb::EntryType::EntryConfChange => self.handle_raft_entry_conf_change(entry),
@@ -1246,15 +1355,11 @@ impl Peer {
         }))
     }
 
-    fn find_cb(&mut self,
-               uuid: Uuid,
-               term: u64,
-               cmd: &RaftCmdRequest)
-               -> Option<(Callback, Timespec)> {
+    fn find_cb(&mut self, uuid: Uuid, term: u64, cmd: &RaftCmdRequest) -> Option<Callback> {
         if get_change_peer_cmd(cmd).is_some() {
             if let Some(mut cmd) = self.pending_cmds.take_conf_change() {
                 if cmd.uuid == uuid {
-                    return Some((cmd.cb.take().unwrap(), cmd.renew_lease_time.unwrap()));
+                    return Some(cmd.cb.take().unwrap());
                 } else {
                     self.notify_stale_command(cmd);
                 }
@@ -1263,7 +1368,7 @@ impl Peer {
         }
         while let Some(mut head) = self.pending_cmds.pop_normal(term) {
             if head.uuid == uuid {
-                return Some((head.cb.take().unwrap(), head.renew_lease_time.unwrap()));
+                return Some(head.cb.take().unwrap());
             }
             // Because of the lack of original RaftCmdRequest, we skip calling
             // coprocessor here.
@@ -1294,36 +1399,11 @@ impl Peer {
                uuid,
                index);
 
-        if cmd_cb.is_none() {
-            return exec_result;
-        }
+        let cb = match cmd_cb {
+            None => return exec_result,
+            Some(cb) => cb,
+        };
 
-        let (cb, lease_renew_time) = cmd_cb.unwrap();
-        // Try to renew the leader lease as this command asks to.
-        if let Some(current_expired_time) = self.leader_lease_expired_time {
-            // This peer is leader and has recorded leader lease.
-            // Calculate the renewed lease for this command. If the renewed lease lives longer
-            // than the current leader lease, update the current leader lease to the renewed lease.
-            let next_expired_time = self.next_lease_expired_time(lease_renew_time);
-            // Use the lease expired timestamp comparison here, so that these codes still
-            // work no matter how the leader changes before applying this command.
-            if current_expired_time < next_expired_time {
-                debug!("{} update leader lease expired time from {:?} to {:?}",
-                       self.tag,
-                       current_expired_time,
-                       next_expired_time);
-                self.leader_lease_expired_time = Some(next_expired_time)
-            }
-        } else if self.is_leader() {
-            // This peer is leader but its leader lease has expired.
-            // Calculate the renewed lease for this command, and update the leader lease
-            // for this peer.
-            let next_expired_time = self.next_lease_expired_time(lease_renew_time);
-            debug!("{} update leader lease expired time from None to {:?}",
-                   self.tag,
-                   self.leader_lease_expired_time);
-            self.leader_lease_expired_time = Some(next_expired_time);
-        }
         // Involve post apply hook.
         self.coprocessor_host.post_apply(self.raft_group.get_store(), &cmd, &mut resp);
         // TODO: if we have exec_result, maybe we should return this callback too. Outer

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -51,7 +51,7 @@ use super::{util, Msg, Tick, SnapshotStatusMsg, SnapManager};
 use super::keys::{self, enc_start_key, enc_end_key, data_end_key, data_key};
 use super::engine::{Iterable, Peekable, Snapshot as EngineSnapshot};
 use super::config::Config;
-use super::peer::{Peer, PendingCmd, ReadyResult, ExecResult, StaleState, ConsistencyState,
+use super::peer::{Peer, ProposalMeta, ReadyResult, ExecResult, StaleState, ConsistencyState,
                   ReadyContext, ChangePeer};
 use super::peer_storage::ApplySnapResult;
 use super::msg::Callback;
@@ -1109,13 +1109,12 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         let mut peer = self.region_peers.get_mut(&region_id).unwrap();
         let term = peer.term();
         bind_term(&mut resp, term);
-        let pending_cmd = PendingCmd {
+        let meta = ProposalMeta {
             uuid: uuid,
             term: term,
-            cb: Some(cb),
             renew_lease_time: None,
         };
-        if peer.propose(pending_cmd, msg, resp, &mut self.raft_metrics.propose) {
+        if peer.propose(meta, cb, msg, resp, &mut self.raft_metrics.propose) {
             self.pending_raft_groups.insert(region_id);
         }
 


### PR DESCRIPTION
When changing to async applying, it's not easy to update lease from another thread. So we need to move lease updating from applying.

@siddontang @hhkbp2 PTAL