### PR TITLE
fix panic when stop

### DIFF
--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -688,9 +688,7 @@ impl Scheduler {
                 snapshot: snapshot,
             }) {
                 Ok(_) => {}
-                e @ Err(TransportError::Closed) => {
-                    info!("ch closed, server is closing, err {:?}", e)
-                }
+                e @ Err(TransportError::Closed) => info!("channel closed, err {:?}", e),
                 Err(e) => panic!("send SnapshotFinish failed cmd id {}, err {:?}", cid, e),
             }
         };

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -204,7 +204,7 @@ fn make_engine_cb(cid: u64, pr: ProcessResult, ch: SendCh<Msg>) -> EngineCallbac
             result: result,
         }) {
             Ok(_) => {}
-            e @ Err(TransportError::Closed) => info!("ch closed, server is closing, err {:?}", e),
+            e @ Err(TransportError::Closed) => info!("channel closed, err {:?}", e),
             Err(e) => {
                 panic!("send write finished to scheduler failed cid={}, err:{:?}",
                        cid,
@@ -688,7 +688,9 @@ impl Scheduler {
                 snapshot: snapshot,
             }) {
                 Ok(_) => {}
-                e @ Err(TransportError::Closed) => info!("ch closed, server is closing, err {:?}", e),
+                e @ Err(TransportError::Closed) => {
+                    info!("ch closed, server is closing, err {:?}", e)
+                }
                 Err(e) => panic!("send SnapshotFinish failed cmd id {}, err {:?}", cid, e),
             }
         };

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -43,7 +43,7 @@ use storage::{Key, Value, KvPair, CMD_TAG_GC};
 use storage::engine::CbContext;
 use std::collections::HashMap;
 use mio::{self, EventLoop};
-use util::transport::SendCh;
+use util::transport::{SendCh, Error as TransportError};
 use util::SlowTimer;
 use storage::engine::{Result as EngineResult, Callback as EngineCallback, Modify};
 use super::Result;
@@ -197,15 +197,19 @@ impl Drop for RunningCtx {
 /// Creates a callback to receive async results of write prepare from the storage engine.
 fn make_engine_cb(cid: u64, pr: ProcessResult, ch: SendCh<Msg>) -> EngineCallback<()> {
     Box::new(move |(cb_ctx, result)| {
-        if let Err(e) = ch.send(Msg::WriteFinished {
+        match ch.send(Msg::WriteFinished {
             cid: cid,
             pr: pr,
             cb_ctx: cb_ctx,
             result: result,
         }) {
-            panic!("send write finished to scheduler failed cid={}, err:{:?}",
-                   cid,
-                   e);
+            Ok(_) => {}
+            e @ Err(TransportError::Closed) => info!("ch closed, server is closing, err {:?}", e),
+            Err(e) => {
+                panic!("send write finished to scheduler failed cid={}, err:{:?}",
+                       cid,
+                       e);
+            }
         }
     })
 }
@@ -678,12 +682,14 @@ impl Scheduler {
         SCHED_STAGE_COUNTER_VEC.with_label_values(&[self.get_ctx_tag(cid), "snapshot"]).inc();
         let ch = self.schedch.clone();
         let cb = box move |(cb_ctx, snapshot)| {
-            if let Err(e) = ch.send(Msg::SnapshotFinished {
+            match ch.send(Msg::SnapshotFinished {
                 cid: cid,
                 cb_ctx: cb_ctx,
                 snapshot: snapshot,
             }) {
-                panic!("send SnapshotFinish failed cmd id {}, err {:?}", cid, e);
+                Ok(_) => {}
+                e @ Err(TransportError::Closed) => info!("ch closed, server is closing, err {:?}", e),
+                Err(e) => panic!("send SnapshotFinish failed cmd id {}, err {:?}", cid, e),
             }
         };
 

--- a/src/util/transport.rs
+++ b/src/util/transport.rs
@@ -29,8 +29,8 @@ quick_error! {
             display("{}", reason)
         }
         Closed {
-            description("ch is closed")
-            display("ch is closed")
+            description("channel is closed")
+            display("channel is closed")
         }
         Other(err: Box<error::Error + Send + Sync>) {
             from()

--- a/src/util/transport.rs
+++ b/src/util/transport.rs
@@ -28,6 +28,10 @@ quick_error! {
             description("message is discarded")
             display("{}", reason)
         }
+        Closed {
+            description("ch is closed")
+            display("ch is closed")
+        }
         Other(err: Box<error::Error + Send + Sync>) {
             from()
             cause(err.as_ref())
@@ -42,6 +46,7 @@ impl<T: Debug> From<NotifyError<T>> for Error {
         match e {
             // ALLERT!! May cause sensitive data leak.
             NotifyError::Full(m) => Error::Discard(format!("Failed to send {:?} due to full", m)),
+            NotifyError::Closed(..) => Error::Closed,
             _ => box_err!("{:?}", e),
         }
     }


### PR DESCRIPTION
When stopping TiKV, the `scheduler` thread may be closed before `raftstore` thread, at that point if `raftstore` thread send msg to scheduler will cause panic.
ref https://github.com/pingcap/tikv/issues/1363
@BusyJay @disksing PTAL