### PR TITLE
storage: use seek_for_prev

### DIFF
--- a/src/raftstore/coprocessor/region_snapshot.rs
+++ b/src/raftstore/coprocessor/region_snapshot.rs
@@ -234,6 +234,16 @@ impl<'a> RegionIterator<'a> {
         Ok(self.update_valid(true))
     }
 
+    pub fn seek_for_prev(&mut self, key: &[u8]) -> Result<bool> {
+        try!(self.should_seekable(key));
+        let key = keys::data_key(key);
+        self.valid = self.iter.seek_for_prev(key.as_slice().into());
+        if self.valid && self.iter.key() == self.end_key.as_slice() {
+            self.valid = self.iter.prev();
+        }
+        Ok(self.update_valid(false))
+    }
+
     pub fn prev(&mut self) -> bool {
         if !self.valid {
             return false;
@@ -283,7 +293,7 @@ mod tests {
     use raftstore::store::keys::*;
     use raftstore::store::PeerStorage;
     use storage::{Cursor, Key, ALL_CFS, ScanMode};
-    use util::{worker, rocksdb};
+    use util::{worker, rocksdb, escape};
 
     use super::*;
     use std::sync::Arc;
@@ -352,6 +362,7 @@ mod tests {
         assert!(v4.is_err());
     }
 
+    #[allow(type_complexity)]
     #[test]
     fn test_iterate() {
         let path = TempDir::new("test-raftstore").unwrap();
@@ -373,13 +384,37 @@ mod tests {
         assert_eq!(data, &base_data[1..3]);
 
         let mut iter = snap.iter(None, true);
-        assert!(iter.seek(b"a1").is_err());
-        assert!(iter.seek(b"a2").unwrap());
-        assert_eq!(iter.key(), b"a3");
-        assert_eq!(iter.value(), b"v3");
-        assert!(!iter.seek(b"a6").unwrap());
-        assert!(!iter.seek(b"a7").unwrap());
-        assert!(iter.seek(b"a8").is_err());
+        let seek_table: Vec<(_, _, Option<(&[u8], &[u8])>, Option<(&[u8], &[u8])>)> = vec![
+            (b"a1", false, None, None),
+            (b"a2", true, Some((b"a3", b"v3")), None),
+            (b"a3", true, Some((b"a3", b"v3")), Some((b"a3", b"v3"))),
+            (b"a4", true, Some((b"a5", b"v5")), Some((b"a3", b"v3"))),
+            (b"a6", true, None, Some((b"a5", b"v5"))),
+            (b"a7", true, None, Some((b"a5", b"v5"))),
+            (b"a8", false, None, None),
+        ];
+        for (seek_key, in_range, seek_exp, prev_exp) in seek_table {
+            let check_res =
+                |iter: &RegionIterator, res: Result<bool>, exp: Option<(&[u8], &[u8])>| {
+                    if !in_range {
+                        assert!(res.is_err(), "exp failed at {}", escape(seek_key));
+                        return;
+                    }
+                    if exp.is_none() {
+                        assert!(!res.unwrap(), "exp none at {}", escape(seek_key));
+                        return;
+                    }
+
+                    assert!(res.unwrap(), "should succeed at {}", escape(seek_key));
+                    let (exp_key, exp_val) = exp.unwrap();
+                    assert_eq!(iter.key(), exp_key);
+                    assert_eq!(iter.value(), exp_val);
+                };
+            let seek_res = iter.seek(seek_key);
+            check_res(&iter, seek_res, seek_exp);
+            let prev_res = iter.seek_for_prev(seek_key);
+            check_res(&iter, prev_res, prev_exp);
+        }
 
         data.clear();
         snap.scan(b"a2",

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -319,7 +319,7 @@ impl<'a> Cursor<'a> {
     /// This method assume the current position of cursor is
     /// around `key`, otherwise you should use `reverse_seek` instead.
     pub fn near_reverse_seek(&mut self, key: &Key) -> Result<bool> {
-        if !try!(self.seek_for_prev(key)) {
+        if !try!(self.near_seek_for_prev(key)) {
             return Ok(false);
         }
 

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -114,6 +114,7 @@ pub trait Iterator {
     fn next(&mut self) -> bool;
     fn prev(&mut self) -> bool;
     fn seek(&mut self, key: &Key) -> Result<bool>;
+    fn seek_for_prev(&mut self, key: &Key) -> Result<bool>;
     fn seek_to_first(&mut self) -> bool;
     fn seek_to_last(&mut self) -> bool;
     fn valid(&self) -> bool;
@@ -234,13 +235,13 @@ impl<'a> Cursor<'a> {
             }
             return Ok(None);
         }
-        if try!(self.near_reverse_seek_le(key)) && self.iter.key() == &**key.encoded() {
+        if try!(self.near_seek_for_prev(key)) && self.iter.key() == &**key.encoded() {
             return Ok(Some(self.iter.value()));
         }
         Ok(None)
     }
 
-    fn reverse_seek_le(&mut self, key: &Key) -> Result<bool> {
+    fn seek_for_prev(&mut self, key: &Key) -> Result<bool> {
         assert!(self.scan_mode != ScanMode::Forward);
         if self.min_key.as_ref().map_or(false, |k| k >= key.encoded()) {
             try!(self.iter.validate_key(key));
@@ -252,27 +253,18 @@ impl<'a> Cursor<'a> {
             return Ok(true);
         }
 
-        if !try!(self.iter.seek(key)) && !self.iter.seek_to_last() {
-            self.min_key = Some(key.encoded().to_owned());
-            if self.max_key.as_ref().map_or(true, |k| k > key.encoded()) {
-                self.max_key = Some(key.encoded().to_owned());
-            }
-            return Ok(false);
-        }
-
-        if self.iter.key() > key.encoded() && !self.iter.prev() {
+        if !try!(self.iter.seek_for_prev(key)) {
             self.min_key = Some(key.encoded().to_owned());
             return Ok(false);
         }
-
         Ok(true)
     }
 
     /// Find the largest key that is not greater than the specific key.
-    pub fn near_reverse_seek_le(&mut self, key: &Key) -> Result<bool> {
+    pub fn near_seek_for_prev(&mut self, key: &Key) -> Result<bool> {
         assert!(self.scan_mode != ScanMode::Forward);
         if !self.iter.valid() {
-            return self.reverse_seek_le(key);
+            return self.seek_for_prev(key);
         }
         let ord = self.iter.key().cmp(key.encoded());
         if ord == Ordering::Equal ||
@@ -287,7 +279,7 @@ impl<'a> Cursor<'a> {
 
         if ord == Ordering::Less {
             near_loop!(self.iter.next() && self.iter.key() < key.encoded(),
-                       self.reverse_seek_le(key));
+                       self.seek_for_prev(key));
             if self.iter.valid() {
                 if self.iter.key() > key.encoded() {
                     self.iter.prev();
@@ -298,7 +290,7 @@ impl<'a> Cursor<'a> {
             }
         } else {
             near_loop!(self.iter.prev() && self.iter.key() > key.encoded(),
-                       self.reverse_seek_le(key));
+                       self.seek_for_prev(key));
         }
 
         if !self.iter.valid() {
@@ -309,7 +301,7 @@ impl<'a> Cursor<'a> {
     }
 
     pub fn reverse_seek(&mut self, key: &Key) -> Result<bool> {
-        if !try!(self.reverse_seek_le(key)) {
+        if !try!(self.seek_for_prev(key)) {
             return Ok(false);
         }
 
@@ -327,7 +319,7 @@ impl<'a> Cursor<'a> {
     /// This method assume the current position of cursor is
     /// around `key`, otherwise you should use `reverse_seek` instead.
     pub fn near_reverse_seek(&mut self, key: &Key) -> Result<bool> {
-        if !try!(self.near_reverse_seek_le(key)) {
+        if !try!(self.seek_for_prev(key)) {
             return Ok(false);
         }
 
@@ -605,10 +597,18 @@ mod tests {
         })
     }
 
+    #[derive(PartialEq, Eq, Clone, Copy)]
+    enum SeekMode {
+        Seek,
+        ReverseSeek,
+        SeekForPrev,
+    }
+
+    #[allow(cyclomatic_complexity)]
     // use step to controll the distance between target key and current key in cursor.
     fn test_linear_seek(snapshot: &Snapshot,
                         mode: ScanMode,
-                        reverse: bool,
+                        seek_mode: SeekMode,
                         start: usize,
                         step: usize) {
         let mut cursor = snapshot.iter(None, false, mode).unwrap();
@@ -616,35 +616,46 @@ mod tests {
         let limit = (SEEK_BOUND * 10 + 50 - 1) * 2;
 
         for (_, mut i) in (start..SEEK_BOUND * 30).enumerate().filter(|&(i, _)| i % step == 0) {
-            if reverse {
+            if seek_mode != SeekMode::Seek {
                 i = SEEK_BOUND * 30 - 1 - i;
             }
             let key = format!("key_{:03}", i);
             let seek_key = make_key(key.as_bytes());
             let exp_kv = if i <= 100 {
-                if reverse {
-                    None
-                } else {
-                    Some(("key_100".to_owned(), "value_50".to_owned()))
+                match seek_mode {
+                    SeekMode::ReverseSeek => None,
+                    SeekMode::SeekForPrev if i < 100 => None,
+                    SeekMode::Seek | SeekMode::SeekForPrev => {
+                        Some(("key_100".to_owned(), "value_50".to_owned()))
+                    }
                 }
             } else if i <= limit {
-                if reverse {
+                if seek_mode == SeekMode::ReverseSeek {
                     Some((format!("key_{}", (i - 1) / 2 * 2), format!("value_{}", (i - 1) / 2)))
+                } else if seek_mode == SeekMode::SeekForPrev {
+                    Some((format!("key_{}", i / 2 * 2), format!("value_{}", i / 2)))
                 } else {
                     Some((format!("key_{}", (i + 1) / 2 * 2), format!("value_{}", (i + 1) / 2)))
                 }
-            } else if reverse {
+            } else if seek_mode != SeekMode::Seek {
                 Some((format!("key_{:03}", limit), format!("value_{:03}", limit / 2)))
             } else {
                 None
             };
 
-            if reverse {
-                assert_seek!(cursor, reverse_seek, seek_key, exp_kv);
-                assert_seek!(near_cursor, near_reverse_seek, seek_key, exp_kv);
-            } else {
-                assert_seek!(cursor, seek, seek_key, exp_kv);
-                assert_seek!(near_cursor, near_seek, seek_key, exp_kv);
+            match seek_mode {
+                SeekMode::ReverseSeek => {
+                    assert_seek!(cursor, reverse_seek, seek_key, exp_kv);
+                    assert_seek!(near_cursor, near_reverse_seek, seek_key, exp_kv);
+                }
+                SeekMode::Seek => {
+                    assert_seek!(cursor, seek, seek_key, exp_kv);
+                    assert_seek!(near_cursor, near_seek, seek_key, exp_kv);
+                }
+                SeekMode::SeekForPrev => {
+                    assert_seek!(cursor, seek_for_prev, seek_key, exp_kv);
+                    assert_seek!(near_cursor, near_seek_for_prev, seek_key, exp_kv);
+                }
             }
         }
     }
@@ -665,22 +676,27 @@ mod tests {
             for start in 0..10 {
                 test_linear_seek(snapshot.as_ref(),
                                  ScanMode::Forward,
-                                 false,
+                                 SeekMode::Seek,
                                  start * SEEK_BOUND,
                                  step);
                 test_linear_seek(snapshot.as_ref(),
                                  ScanMode::Backward,
-                                 true,
+                                 SeekMode::ReverseSeek,
+                                 start * SEEK_BOUND,
+                                 step);
+                test_linear_seek(snapshot.as_ref(),
+                                 ScanMode::Backward,
+                                 SeekMode::SeekForPrev,
                                  start * SEEK_BOUND,
                                  step);
             }
         }
-        for &reverse in &[true, false] {
+        for &seek_mode in &[SeekMode::ReverseSeek, SeekMode::Seek, SeekMode::SeekForPrev] {
             for step in 1..SEEK_BOUND * 3 {
                 for start in 0..10 {
                     test_linear_seek(snapshot.as_ref(),
                                      ScanMode::Mixed,
-                                     reverse,
+                                     seek_mode,
                                      start * SEEK_BOUND,
                                      step);
                 }

--- a/src/storage/engine/raftkv.rs
+++ b/src/storage/engine/raftkv.rs
@@ -355,6 +355,10 @@ impl<'a> EngineIterator for RegionIterator<'a> {
         RegionIterator::seek(self, key.encoded()).map_err(From::from)
     }
 
+    fn seek_for_prev(&mut self, key: &Key) -> engine::Result<bool> {
+        RegionIterator::seek_for_prev(self, key.encoded()).map_err(From::from)
+    }
+
     fn seek_to_first(&mut self) -> bool {
         RegionIterator::seek_to_first(self)
     }

--- a/src/storage/engine/rocksdb.rs
+++ b/src/storage/engine/rocksdb.rs
@@ -208,6 +208,10 @@ impl<'a> EngineIterator for DBIterator<'a> {
         Ok(DBIterator::seek(self, key.encoded().as_slice().into()))
     }
 
+    fn seek_for_prev(&mut self, key: &Key) -> Result<bool> {
+        Ok(DBIterator::seek_for_prev(self, key.encoded().as_slice().into()))
+    }
+
     fn seek_to_first(&mut self) -> bool {
         DBIterator::seek(self, SeekKey::Start)
     }

--- a/src/storage/mvcc/reader.rs
+++ b/src/storage/mvcc/reader.rs
@@ -146,7 +146,7 @@ impl<'a> MvccReader<'a> {
 
         let mut cursor = self.write_cursor.as_mut().unwrap();
         let ok = if reverse {
-            try!(cursor.near_reverse_seek_le(&key.append_ts(ts)))
+            try!(cursor.near_seek_for_prev(&key.append_ts(ts)))
         } else {
             try!(cursor.near_seek(&key.append_ts(ts)))
         };


### PR DESCRIPTION
Now that rocksdb supports `seek_for_prev`, we can use the API directly. Ref #1416.

@siddontang @disksing PTAL