### PR TITLE
info StaleEpoch error

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -1435,7 +1435,10 @@ impl Peer {
 
         let mut ctx = ExecContext::new(self, index, term, req);
         let (resp, exec_result) = self.exec_raft_cmd(&mut ctx).unwrap_or_else(|e| {
-            error!("{} execute raft command err: {:?}", self.tag, e);
+            match e {
+                Error::StaleEpoch(..) => info!("{} stale epoch err: {:?}", self.tag, e),
+                _ => error!("{} execute raft command err: {:?}", self.tag, e),
+            }
             (cmd_resp::new_error(e), None)
         });
 


### PR DESCRIPTION
Many user have been confused by `StaleEpoch` Error log. Stale epoch will not cause error, because ticlient will resend the commad to the correct tikv after received response of stale epoch error.
@BusyJay @siddontang PTAL