### PR TITLE
raftstore: use static lease

### DIFF
--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -54,7 +54,7 @@ const DEFAULT_CONSISTENCY_CHECK_INTERVAL: u64 = 0;
 
 const DEFAULT_REPORT_REGION_FLOW_INTERVAL: u64 = 30000; // 30 seconds
 
-const DEFAULT_RAFT_STORE_LEASE: i64 = 5; // 5 seconds
+const DEFAULT_RAFT_STORE_LEASE_SEC: i64 = 5; // 5 seconds
 
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -122,7 +122,7 @@ pub struct Config {
 
     pub report_region_flow_interval: u64,
     // The lease provided by a successfully proposed and applied entry.
-    pub raft_store_lease: TimeDuration,
+    pub raft_store_leader_lease: TimeDuration,
 }
 
 impl Default for Config {
@@ -157,7 +157,7 @@ impl Default for Config {
             lock_cf_compact_interval: DEFAULT_LOCK_CF_COMPACT_INTERVAL,
             consistency_check_tick_interval: DEFAULT_CONSISTENCY_CHECK_INTERVAL,
             report_region_flow_interval: DEFAULT_REPORT_REGION_FLOW_INTERVAL,
-            raft_store_lease: TimeDuration::seconds(DEFAULT_RAFT_STORE_LEASE),
+            raft_store_leader_lease: TimeDuration::seconds(DEFAULT_RAFT_STORE_LEASE_SEC),
         }
     }
 }
@@ -201,7 +201,7 @@ impl Config {
 
         let election_timeout = self.raft_base_tick_interval *
                                self.raft_election_timeout_ticks as u64;
-        let lease = self.raft_store_lease.num_milliseconds() as u64;
+        let lease = self.raft_store_leader_lease.num_milliseconds() as u64;
         if election_timeout < lease {
             return Err(box_err!("election timeout {} ms is less than lease {} ms",
                                 election_timeout,

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -122,7 +122,7 @@ pub struct Config {
 
     pub report_region_flow_interval: u64,
     // The lease provided by a successfully proposed and applied entry.
-    pub raft_store_leader_lease: TimeDuration,
+    pub raft_store_max_leader_lease: TimeDuration,
 }
 
 impl Default for Config {
@@ -157,7 +157,7 @@ impl Default for Config {
             lock_cf_compact_interval: DEFAULT_LOCK_CF_COMPACT_INTERVAL,
             consistency_check_tick_interval: DEFAULT_CONSISTENCY_CHECK_INTERVAL,
             report_region_flow_interval: DEFAULT_REPORT_REGION_FLOW_INTERVAL,
-            raft_store_leader_lease: TimeDuration::seconds(DEFAULT_RAFT_STORE_LEASE_SEC),
+            raft_store_max_leader_lease: TimeDuration::seconds(DEFAULT_RAFT_STORE_LEASE_SEC),
         }
     }
 }
@@ -201,7 +201,7 @@ impl Config {
 
         let election_timeout = self.raft_base_tick_interval *
                                self.raft_election_timeout_ticks as u64;
-        let lease = self.raft_store_leader_lease.num_milliseconds() as u64;
+        let lease = self.raft_store_max_leader_lease.num_milliseconds() as u64;
         if election_timeout < lease {
             return Err(box_err!("election timeout {} ms is less than lease {} ms",
                                 election_timeout,

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -19,8 +19,8 @@ use time::Duration as TimeDuration;
 use raftstore::Result;
 
 const RAFT_BASE_TICK_INTERVAL: u64 = 100;
-const RAFT_HEARTBEAT_TICKS: usize = 10;
-const RAFT_ELECTION_TIMEOUT_TICKS: usize = 50;
+const RAFT_HEARTBEAT_TICKS: usize = 20;
+const RAFT_ELECTION_TIMEOUT_TICKS: usize = 100;
 const RAFT_MAX_SIZE_PER_MSG: u64 = 1024 * 1024;
 const RAFT_MAX_INFLIGHT_MSGS: usize = 256;
 const RAFT_ENTRY_MAX_SIZE: u64 = 8 * 1024 * 1024;
@@ -54,7 +54,7 @@ const DEFAULT_CONSISTENCY_CHECK_INTERVAL: u64 = 0;
 
 const DEFAULT_REPORT_REGION_FLOW_INTERVAL: u64 = 30000; // 30 seconds
 
-const DEFAULT_RAFT_STORE_LEASE_SEC: i64 = 5; // 5 seconds
+const DEFAULT_RAFT_STORE_LEASE_SEC: i64 = 9; // 5 seconds
 
 #[derive(Debug, Clone)]
 pub struct Config {

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -54,7 +54,7 @@ const DEFAULT_CONSISTENCY_CHECK_INTERVAL: u64 = 0;
 
 const DEFAULT_REPORT_REGION_FLOW_INTERVAL: u64 = 30000; // 30 seconds
 
-const DEFAULT_RAFT_STORE_LEASE_SEC: i64 = 9; // 5 seconds
+const DEFAULT_RAFT_STORE_LEASE_SEC: i64 = 9; // 9 seconds
 
 #[derive(Debug, Clone)]
 pub struct Config {

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -14,6 +14,8 @@
 use std::u64;
 use std::time::Duration;
 
+use time::Duration as TimeDuration;
+
 use raftstore::Result;
 
 const RAFT_BASE_TICK_INTERVAL: u64 = 100;
@@ -51,6 +53,8 @@ const DEFAULT_SNAPSHOT_APPLY_BATCH_SIZE: usize = 1024 * 1024 * 10; // 10m
 const DEFAULT_CONSISTENCY_CHECK_INTERVAL: u64 = 0;
 
 const DEFAULT_REPORT_REGION_FLOW_INTERVAL: u64 = 30000; // 30 seconds
+
+const DEFAULT_RAFT_STORE_LEASE: i64 = 5; // 5 seconds
 
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -117,6 +121,8 @@ pub struct Config {
     pub consistency_check_tick_interval: u64,
 
     pub report_region_flow_interval: u64,
+    // The lease provided by a successfully proposed and applied entry.
+    pub raft_store_lease: TimeDuration,
 }
 
 impl Default for Config {
@@ -151,6 +157,7 @@ impl Default for Config {
             lock_cf_compact_interval: DEFAULT_LOCK_CF_COMPACT_INTERVAL,
             consistency_check_tick_interval: DEFAULT_CONSISTENCY_CHECK_INTERVAL,
             report_region_flow_interval: DEFAULT_REPORT_REGION_FLOW_INTERVAL,
+            raft_store_lease: TimeDuration::seconds(DEFAULT_RAFT_STORE_LEASE),
         }
     }
 }
@@ -190,6 +197,15 @@ impl Config {
             return Err(box_err!("region max size {} must >= split size {}",
                                 self.region_max_size,
                                 self.region_split_size));
+        }
+
+        let election_timeout = self.raft_base_tick_interval *
+                               self.raft_election_timeout_ticks as u64;
+        let lease = self.raft_store_lease.num_milliseconds() as u64;
+        if election_timeout < lease {
+            return Err(box_err!("election timeout {} ms is less than lease {} ms",
+                                election_timeout,
+                                lease));
         }
 
         Ok(())

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -590,10 +590,10 @@ impl Peer {
 
     fn next_lease_expired_time(&self, send_to_quorum_ts: Timespec) -> Timespec {
         // The valid leader lease should be
-        // "lease = election_timeout - (quorum_commit_ts - send_to_quorum_ts)"
+        // "lease = max_lease - (quorum_commit_ts - send_to_quorum_ts)"
         // And the expired timestamp for that leader lease is "quorum_commit_ts + lease",
-        // which is "send_to_quorum_ts + election_timeout" in short.
-        send_to_quorum_ts + self.cfg.raft_store_leader_lease
+        // which is "send_to_quorum_ts + max_lease" in short.
+        send_to_quorum_ts + self.cfg.raft_store_max_leader_lease
     }
 
     fn update_leader_lease(&mut self, ready: &Ready) {

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -593,7 +593,7 @@ impl Peer {
         // "lease = election_timeout - (quorum_commit_ts - send_to_quorum_ts)"
         // And the expired timestamp for that leader lease is "quorum_commit_ts + lease",
         // which is "send_to_quorum_ts + election_timeout" in short.
-        send_to_quorum_ts + self.cfg.raft_store_lease
+        send_to_quorum_ts + self.cfg.raft_store_leader_lease
     }
 
     fn update_leader_lease(&mut self, ready: &Ready) {

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -605,7 +605,7 @@ impl Peer {
                     // The local read can only be performed after a new leader has applied
                     // the first empty entry on its term. After that the lease expiring time
                     // should be updated to
-                    //   send_to_quorum_ts + election_timeout
+                    //   send_to_quorum_ts + max_lease
                     // as the comments in `next_lease_expired_time` function explain.
                     // It is recommended to update the lease expiring time right after
                     // this peer becomes leader because it's more convenient to do it here and

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -76,9 +76,9 @@ pub struct StoreChannel {
 }
 
 pub struct Store<T, C: 'static> {
-    cfg: Config,
-    store: metapb::Store,
+    cfg: Rc<Config>,
     engine: Arc<DB>,
+    store: metapb::Store,
     sendch: SendCh<Msg>,
 
     sent_snapshot_count: u64,
@@ -158,7 +158,7 @@ impl<T, C> Store<T, C> {
         let tag = format!("[store {}]", meta.get_id());
 
         let mut s = Store {
-            cfg: cfg,
+            cfg: Rc::new(cfg),
             store: meta,
             engine: engine,
             sendch: sendch,
@@ -294,8 +294,8 @@ impl<T, C> Store<T, C> {
         self.store.get_id()
     }
 
-    pub fn config(&self) -> &Config {
-        &self.cfg
+    pub fn config(&self) -> Rc<Config> {
+        self.cfg.clone()
     }
 
     pub fn peer_cache(&self) -> Rc<RefCell<HashMap<u64, metapb::Peer>>> {

--- a/tests/raftstore/test_lease_read.rs
+++ b/tests/raftstore/test_lease_read.rs
@@ -99,7 +99,8 @@ fn test_renew_lease<T: Simulator>(cluster: &mut Cluster<T>) {
     let election_timeout =
         Duration::from_millis(cluster.cfg.raft_store.raft_base_tick_interval *
                               cluster.cfg.raft_store.raft_election_timeout_ticks as u64);
-    cluster.cfg.raft_store.raft_store_lease = TimeDuration::from_std(election_timeout).unwrap();
+    cluster.cfg.raft_store.raft_store_leader_lease = TimeDuration::from_std(election_timeout)
+        .unwrap();
 
     let node_id = 1u64;
     let store_id = 1u64;

--- a/tests/raftstore/test_lease_read.rs
+++ b/tests/raftstore/test_lease_read.rs
@@ -99,7 +99,7 @@ fn test_renew_lease<T: Simulator>(cluster: &mut Cluster<T>) {
     let election_timeout =
         Duration::from_millis(cluster.cfg.raft_store.raft_base_tick_interval *
                               cluster.cfg.raft_store.raft_election_timeout_ticks as u64);
-    cluster.cfg.raft_store.raft_store_leader_lease = TimeDuration::from_std(election_timeout)
+    cluster.cfg.raft_store.raft_store_max_leader_lease = TimeDuration::from_std(election_timeout)
         .unwrap();
 
     let node_id = 1u64;

--- a/tests/raftstore/test_lease_read.rs
+++ b/tests/raftstore/test_lease_read.rs
@@ -16,6 +16,8 @@
 use std::thread;
 use std::time::Duration;
 
+use time::Duration as TimeDuration;
+
 use kvproto::metapb::{Peer, Region};
 use kvproto::raft_cmdpb::CmdType;
 use kvproto::raft_serverpb::RaftLocalState;
@@ -94,8 +96,10 @@ fn test_renew_lease<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.cfg.raft_store.raft_base_tick_interval = 50;
     cluster.cfg.raft_store.raft_election_timeout_ticks = 90;
 
-    let election_timeout = Duration::from_millis(cluster.cfg.raft_store.raft_base_tick_interval) *
-                           cluster.cfg.raft_store.raft_election_timeout_ticks as u32;
+    let election_timeout =
+        Duration::from_millis(cluster.cfg.raft_store.raft_base_tick_interval *
+                              cluster.cfg.raft_store.raft_election_timeout_ticks as u64);
+    cluster.cfg.raft_store.raft_store_lease = TimeDuration::from_std(election_timeout).unwrap();
 
     let node_id = 1u64;
     let store_id = 1u64;

--- a/tests/raftstore/util.rs
+++ b/tests/raftstore/util.rs
@@ -88,7 +88,7 @@ pub fn new_store_cfg() -> Config {
         // should be configured far beyond the election timeout.
         max_leader_missing_duration: Duration::from_secs(3),
         report_region_flow_interval: 100, // 100ms
-        raft_store_lease: TimeDuration::milliseconds(25 * 10),
+        raft_store_leader_lease: TimeDuration::milliseconds(25 * 10),
         ..Config::default()
     }
 }

--- a/tests/raftstore/util.rs
+++ b/tests/raftstore/util.rs
@@ -88,7 +88,7 @@ pub fn new_store_cfg() -> Config {
         // should be configured far beyond the election timeout.
         max_leader_missing_duration: Duration::from_secs(3),
         report_region_flow_interval: 100, // 100ms
-        raft_store_leader_lease: TimeDuration::milliseconds(25 * 10),
+        raft_store_max_leader_lease: TimeDuration::milliseconds(25 * 10),
         ..Config::default()
     }
 }

--- a/tests/raftstore/util.rs
+++ b/tests/raftstore/util.rs
@@ -19,6 +19,7 @@ use std::thread;
 use rocksdb::DB;
 use uuid::Uuid;
 use protobuf;
+use time::Duration as TimeDuration;
 
 use kvproto::metapb::{self, RegionEpoch};
 use kvproto::raft_cmdpb::{Request, StatusRequest, AdminRequest, RaftCmdRequest, RaftCmdResponse};
@@ -87,6 +88,7 @@ pub fn new_store_cfg() -> Config {
         // should be configured far beyond the election timeout.
         max_leader_missing_duration: Duration::from_secs(3),
         report_region_flow_interval: 100, // 100ms
+        raft_store_lease: TimeDuration::milliseconds(25 * 10),
         ..Config::default()
     }
 }


### PR DESCRIPTION
So when the cluster can be upgraded rollingly as long as new election timeout is larger than old lease.

@siddontang @hhkbp2 PTAL
