### PR TITLE
txn:improvement for point get by unique key or pk

### DIFF
--- a/src/storage/mvcc/reader.rs
+++ b/src/storage/mvcc/reader.rs
@@ -178,9 +178,9 @@ impl<'a> MvccReader<'a> {
         if let Some(lock) = try!(self.load_lock(key)) {
             if lock.ts <= ts {
                 if ts == u64::MAX && try!(key.raw()) == lock.primary {
-                    // when ts==MAX(which means get latest committed version for primary key),
-                    // and current key is the primary key,
-                    // return latest commit version's value
+                    // when ts==u64::MAX(which means to get latest committed version for
+                    // primary key),and current key is the primary key, returns the latest
+                    // commit version's value
                     ts = lock.ts - 1;
                 } else {
                     // There is a pending lock. Client should wait or clean it.

--- a/tests/storage/test_storage.rs
+++ b/tests/storage/test_storage.rs
@@ -29,6 +29,7 @@ use super::util::new_raft_engine;
 use super::assert_storage::AssertionStorage;
 use storage::util;
 use std::collections::HashSet;
+use std::u64;
 
 #[test]
 fn test_txn_store_get() {
@@ -81,6 +82,31 @@ fn test_txn_store_cleanup_commit() {
     store.commit_ok(vec![b"primary"], 5, 10);
     store.cleanup_err(b"primary", 5);
     store.rollback_err(vec![b"primary"], 5);
+}
+
+#[test]
+fn test_txn_store_for_point_get_with_pk() {
+    let store = AssertionStorage::default();
+
+    store.put_ok(b"b", b"v2", 1, 2);
+    store.put_ok(b"primary", b"v1", 2, 3);
+    store.put_ok(b"secondary", b"v3", 3, 4);
+    store.prewrite_ok(vec![Mutation::Put((make_key(b"primary"), b"v3".to_vec())),
+                           Mutation::Put((make_key(b"secondary"), b"s-5".to_vec())),
+                           Mutation::Put((make_key(b"new_key"), b"new_key".to_vec()))],
+                      b"primary",
+                      5);
+    store.get_ok(b"primary", 4, b"v1");
+    store.get_ok(b"primary", u64::MAX, b"v1");
+    store.get_err(b"primary", 6);
+
+    store.get_ok(b"secondary", 4, b"v3");
+    store.get_err(b"secondary", 6);
+    store.get_err(b"secondary", u64::MAX);
+
+    store.get_err(b"new_key", 6);
+    store.get_ok(b"b", 6, b"v2");
+
 }
 
 #[test]


### PR DESCRIPTION
This PR implement improvement for point get by unique key or pk with tidb.
For `Get` with ts==uint64::max(which means it's a point get by pk or unique_key from tidb),  if  lock exist and current key the primary, return latest committed version instead of ErrorWithLock.  
@disksing @zhangjinpeng1987 PTAL