### PR TITLE
*: tiny cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,7 @@ matrix:
   include:
     - os: linux
       rust: nightly
-      env: COMPILER=g++-4.8 RUSTC_DATE=2017-02-12 RUSTFMT_VERSION=v0.6.0 SKIP_FORMAT_CHECK=true CXX=g++-4.8
-      addons:
-         apt:
-            sources: ['ubuntu-toolchain-r-test']
-            packages: ['g++-4.8', 'zlib1g-dev', 'libbz2-dev', 'libsnappy-dev', 'curl', 'libdw-dev', 'libelf-dev', 'elfutils', 'binutils-dev']
-    - os: linux
-      rust: nightly
-      env: COMPILER=g++-4.8 RUSTC_DATE=2017-02-12 RUSTFMT_VERSION=v0.6.0 ENABLE_FEATURES=default SKIP_TESTS=true CXX=g++-4.8
+      env: COMPILER=g++-4.8 RUSTC_DATE=2017-02-12 RUSTFMT_VERSION=v0.6.0 CXX=g++-4.8
       addons:
          apt:
             sources: ['ubuntu-toolchain-r-test']

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,15 +12,12 @@
 // limitations under the License.
 
 #![crate_type = "lib"]
-#![allow(stable_features)]
-#![feature(mpsc_recv_timeout)]
 #![feature(test)]
 #![feature(btree_range, collections_bound)]
 #![feature(fnbox)]
 #![feature(alloc)]
 #![feature(slice_patterns)]
 #![feature(box_syntax)]
-#![feature(binary_heap_peek_mut)]
 #![cfg_attr(feature = "dev", feature(plugin))]
 #![cfg_attr(feature = "dev", plugin(clippy))]
 #![cfg_attr(not(feature = "dev"), allow(unknown_lints))]


### PR DESCRIPTION
Since we remove the old rustc support, only one linux build needs to be kept. And the legacy feature declare can be removed too.