### PR TITLE
raftstore: check if tick generates any readiness

### DIFF
--- a/src/raft/raft.rs
+++ b/src/raft/raft.rs
@@ -603,6 +603,8 @@ impl<T: Storage> Raft<T> {
         self.maybe_commit();
     }
 
+    /// Return true to indicate that some internal states have been changed that
+    /// handle_raft_ready should be called.
     pub fn tick(&mut self) -> bool {
         match self.state {
             StateRole::Follower | StateRole::PreCandidate | StateRole::Candidate => {
@@ -614,6 +616,7 @@ impl<T: Storage> Raft<T> {
 
     // tick_election is run by followers and candidates after self.election_timeout.
     // TODO: revoke pub when there is a better way to test.
+    // Return true to indicate that handle_raft_ready needs to be called.
     pub fn tick_election(&mut self) -> bool {
         self.election_elapsed += 1;
         if !self.pass_election_timeout() || !self.promotable() {
@@ -627,6 +630,7 @@ impl<T: Storage> Raft<T> {
     }
 
     // tick_heartbeat is run by leaders to send a MsgBeat after self.heartbeat_timeout.
+    // Return true to indicate that handle_raft_ready needs to be called.
     fn tick_heartbeat(&mut self) -> bool {
         self.heartbeat_elapsed += 1;
         self.election_elapsed += 1;

--- a/src/raft/raft.rs
+++ b/src/raft/raft.rs
@@ -603,8 +603,7 @@ impl<T: Storage> Raft<T> {
         self.maybe_commit();
     }
 
-    /// Return true to indicate that some internal states have been changed that
-    /// handle_raft_ready should be called.
+    /// Returns true to indicate that there will probably be some readiness need to be handled.
     pub fn tick(&mut self) -> bool {
         match self.state {
             StateRole::Follower | StateRole::PreCandidate | StateRole::Candidate => {
@@ -616,7 +615,7 @@ impl<T: Storage> Raft<T> {
 
     // tick_election is run by followers and candidates after self.election_timeout.
     // TODO: revoke pub when there is a better way to test.
-    // Return true to indicate that handle_raft_ready needs to be called.
+    // Returns true to indicate that there will probably be some readiness need to be handled.
     pub fn tick_election(&mut self) -> bool {
         self.election_elapsed += 1;
         if !self.pass_election_timeout() || !self.promotable() {
@@ -630,7 +629,7 @@ impl<T: Storage> Raft<T> {
     }
 
     // tick_heartbeat is run by leaders to send a MsgBeat after self.heartbeat_timeout.
-    // Return true to indicate that handle_raft_ready needs to be called.
+    // Returns true to indicate that there will probably be some readiness need to be handled.
     fn tick_heartbeat(&mut self) -> bool {
         self.heartbeat_elapsed += 1;
         self.election_elapsed += 1;

--- a/src/raft/raft.rs
+++ b/src/raft/raft.rs
@@ -600,7 +600,7 @@ impl<T: Storage> Raft<T> {
         self.maybe_commit();
     }
 
-    pub fn tick(&mut self) {
+    pub fn tick(&mut self) -> bool {
         match self.state {
             StateRole::Follower | StateRole::PreCandidate | StateRole::Candidate => {
                 self.tick_election()
@@ -611,24 +611,29 @@ impl<T: Storage> Raft<T> {
 
     // tick_election is run by followers and candidates after self.election_timeout.
     // TODO: revoke pub when there is a better way to test.
-    pub fn tick_election(&mut self) {
+    pub fn tick_election(&mut self) -> bool {
         self.election_elapsed += 1;
-        if self.promotable() && self.pass_election_timeout() {
-            self.election_elapsed = 0;
-            let m = new_message(INVALID_ID, MessageType::MsgHup, Some(self.id));
-            self.step(m).is_ok();
+        if !self.pass_election_timeout() || !self.promotable() {
+            return false;
         }
+
+        self.election_elapsed = 0;
+        let m = new_message(INVALID_ID, MessageType::MsgHup, Some(self.id));
+        self.step(m).is_ok();
+        true
     }
 
     // tick_heartbeat is run by leaders to send a MsgBeat after self.heartbeat_timeout.
-    fn tick_heartbeat(&mut self) {
+    fn tick_heartbeat(&mut self) -> bool {
         self.heartbeat_elapsed += 1;
         self.election_elapsed += 1;
 
+        let mut has_ready = false;
         if self.election_elapsed >= self.election_timeout {
             self.election_elapsed = 0;
             if self.check_quorum {
                 let m = new_message(INVALID_ID, MessageType::MsgCheckQuorum, Some(self.id));
+                has_ready = true;
                 self.step(m).is_ok();
             }
             if self.state == StateRole::Leader && self.lead_transferee.is_some() {
@@ -637,14 +642,16 @@ impl<T: Storage> Raft<T> {
         }
 
         if self.state != StateRole::Leader {
-            return;
+            return has_ready;
         }
 
         if self.heartbeat_elapsed >= self.heartbeat_timeout {
             self.heartbeat_elapsed = 0;
+            has_ready = true;
             let m = new_message(INVALID_ID, MessageType::MsgBeat, Some(self.id));
             self.step(m).is_ok();
         }
+        has_ready
     }
 
     pub fn become_follower(&mut self, term: u64, leader_id: u64) {

--- a/src/raft/raw_node.rs
+++ b/src/raft/raw_node.rs
@@ -227,6 +227,8 @@ impl<T: Storage> RawNode<T> {
     }
 
     // Tick advances the internal logical clock by a single tick.
+    //
+    // Return true to indicate that handle_raft_ready needs to be called.
     pub fn tick(&mut self) -> bool {
         self.raft.tick()
     }

--- a/src/raft/raw_node.rs
+++ b/src/raft/raw_node.rs
@@ -228,7 +228,7 @@ impl<T: Storage> RawNode<T> {
 
     // Tick advances the internal logical clock by a single tick.
     //
-    // Return true to indicate that handle_raft_ready needs to be called.
+    // Returns true to indicate that there will probably be some readiness need to be handled.
     pub fn tick(&mut self) -> bool {
         self.raft.tick()
     }

--- a/tests/raft/test_raft_paper.rs
+++ b/tests/raft/test_raft_paper.rs
@@ -199,7 +199,7 @@ fn test_nonleader_start_election(state: StateRole) {
     }
 
     for _ in 1..2 * et {
-        r.tick()
+        r.tick();
     }
 
     assert_eq!(r.term, 2);


### PR DESCRIPTION
So handle_raft_ready will be called only when it's necessary.

@siddontang @hhkbp2 @zhangjinpeng1987 PTAL