### PR TITLE
store: no need to cache local peer

### DIFF
--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -551,7 +551,6 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         }
 
         self.insert_peer_cache(msg.take_from_peer());
-        self.insert_peer_cache(msg.take_to_peer());
 
         let peer = self.region_peers.get_mut(&region_id).unwrap();
         try!(peer.step(msg.take_message()));


### PR DESCRIPTION
to_peer is the same local peer in the store, we don't need to get it from cache when send message. 

@BusyJay @hhkbp2 