### PR TITLE
raftstore: make the campaign after split happen faster

### DIFF
--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -584,6 +584,9 @@ fn build_cfg(matches: &Matches,
     cfg_u64(&mut cfg.raft_store.consistency_check_tick_interval,
             config,
             "raftstore.consistency-check-interval");
+    cfg_usize(&mut cfg.raft_store.accelerate_campaign_reserved_ticks,
+              config,
+              "raftstore.accelerate-campaign-reserved-ticks");
     cfg_usize(&mut cfg.storage.sched_notify_capacity,
               config,
               "storage.scheduler-notify-capacity");

--- a/src/raft/raft.rs
+++ b/src/raft/raft.rs
@@ -207,13 +207,13 @@ pub struct Raft<T: Storage> {
     pub check_quorum: bool,
     pre_vote: bool,
 
-    pub heartbeat_timeout: usize,
+    heartbeat_timeout: usize,
     election_timeout: usize,
 
     // randomized_election_timeout is a random number between
     // [election_timeout, 2 * election_timeout - 1]. It gets reset
     // when raft changes its state to follower or candidate.
-    pub randomized_election_timeout: usize,
+    randomized_election_timeout: usize,
 
     /// Will be called when step** is about to be called.
     /// return false will skip step**.
@@ -369,6 +369,10 @@ impl<T: Storage> Raft<T> {
 
     pub fn get_heartbeat_timeout(&self) -> usize {
         self.heartbeat_timeout
+    }
+
+    pub fn get_randomized_election_timeout(&self) -> usize {
+        self.randomized_election_timeout
     }
 
     pub fn nodes(&self) -> Vec<u64> {

--- a/src/raft/raft.rs
+++ b/src/raft/raft.rs
@@ -207,7 +207,7 @@ pub struct Raft<T: Storage> {
     pub check_quorum: bool,
     pre_vote: bool,
 
-    heartbeat_timeout: usize,
+    pub heartbeat_timeout: usize,
     election_timeout: usize,
 
     // randomized_election_timeout is a random number between

--- a/src/raft/raft.rs
+++ b/src/raft/raft.rs
@@ -213,7 +213,7 @@ pub struct Raft<T: Storage> {
     // randomized_election_timeout is a random number between
     // [election_timeout, 2 * election_timeout - 1]. It gets reset
     // when raft changes its state to follower or candidate.
-    randomized_election_timeout: usize,
+    pub randomized_election_timeout: usize,
 
     /// Will be called when step** is about to be called.
     /// return false will skip step**.

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -127,9 +127,9 @@ pub struct Config {
     pub raft_store_max_leader_lease: TimeDuration,
 
     // For the peer which is the leader of the region before split,
-    // it would accelerate ticks to make peer of new region start to campaign faster after split.
-    // Then it may take the leadership earlier and shorten the leading missing time, to gain
-    // higher availability.
+    // it would accelerate ticks for the peer of new region after split, so that
+    // the peer of new region could start campaign faster. And then this peer may take
+    // the leadership earlier and shorten the leading missing time to gain higher availability.
     // To make sure followers are replicated up-to-date and be ready to vote this peer's campaign,
     // The time interval specified by `accelerate_campaign_reserved_ticks * raft_base_tick_interval`
     // would be reserved before the peer of new region starts to campaign.

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -56,6 +56,8 @@ const DEFAULT_REPORT_REGION_FLOW_INTERVAL: u64 = 30000; // 30 seconds
 
 const DEFAULT_RAFT_STORE_LEASE_SEC: i64 = 9; // 9 seconds
 
+const DEFAULT_ACCELERATE_CAMPAIGN_RESERVED_TICKS: usize = 1;
+
 #[derive(Debug, Clone)]
 pub struct Config {
     // store capacity.
@@ -123,6 +125,15 @@ pub struct Config {
     pub report_region_flow_interval: u64,
     // The lease provided by a successfully proposed and applied entry.
     pub raft_store_max_leader_lease: TimeDuration,
+
+    // For the peer which is the leader of the region before split,
+    // it would accelerate ticks to make peer of new region start to campaign faster after split.
+    // Then it may take the leadership earlier and shorten the leading missing time, to gain
+    // higher availability.
+    // To make sure followers are replicated up-to-date and be ready to vote this peer's campaign,
+    // The time interval specified by `accelerate_campaign_reserved_ticks * raft_base_tick_interval`
+    // would be reserved before the peer of new region starts to campaign.
+    pub accelerate_campaign_reserved_ticks: usize,
 }
 
 impl Default for Config {
@@ -158,6 +169,7 @@ impl Default for Config {
             consistency_check_tick_interval: DEFAULT_CONSISTENCY_CHECK_INTERVAL,
             report_region_flow_interval: DEFAULT_REPORT_REGION_FLOW_INTERVAL,
             raft_store_max_leader_lease: TimeDuration::seconds(DEFAULT_RAFT_STORE_LEASE_SEC),
+            accelerate_campaign_reserved_ticks: DEFAULT_ACCELERATE_CAMPAIGN_RESERVED_TICKS,
         }
     }
 }
@@ -198,6 +210,13 @@ impl Config {
             return Err(box_err!("election timeout {} ms is less than lease {} ms",
                                 election_timeout,
                                 lease));
+        }
+
+        if self.accelerate_campaign_reserved_ticks >= self.raft_election_timeout_ticks {
+            return Err(box_err!("accelerate campaign reserved ticks {} must < election timeout \
+                                 ticks {}",
+                                self.accelerate_campaign_reserved_ticks,
+                                self.raft_election_timeout_ticks));
         }
 
         Ok(())

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -167,14 +167,6 @@ impl Config {
         Config::default()
     }
 
-    /// For the peer which is the leader of the region before split,
-    /// `leader_accelerate_campaign_after_split_ticks` specifies the tick number to be accelerated
-    /// after the region split, so that the peer of new split region may campaign and become leader
-    /// earlier than other follower peers.
-    pub fn accelerate_campaign_after_split_ticks(&self) -> usize {
-        self.raft_election_timeout_ticks * 2 - 1
-    }
-
     pub fn validate(&self) -> Result<()> {
         if self.raft_heartbeat_ticks == 0 {
             return Err(box_err!("heartbeat tick must greater than 0"));

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -172,7 +172,7 @@ impl Config {
     /// after the region split, so that the peer of new split region may campaign and become leader
     /// earlier than other follower peers.
     pub fn accelerate_campaign_after_split_ticks(&self) -> usize {
-        self.raft_election_timeout_ticks - 1
+        self.raft_election_timeout_ticks * 2 - 1
     }
 
     pub fn validate(&self) -> Result<()> {

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -491,8 +491,12 @@ impl Peer {
         // To make the best case happen at high degree of possibility, a time gap of
         // `accelerate_campaign_reserved_ticks * raft_base_tick_interval` is reserved for
         // the followers to receive AppendEntries request and to apply them.
-        self.raft_group.raft.get_randomized_election_timeout() -
-        self.cfg.accelerate_campaign_reserved_ticks
+        let ticks = self.raft_group.raft.get_randomized_election_timeout() -
+                    self.cfg.accelerate_campaign_reserved_ticks;
+        debug!("{} about to accelerate {} ticks for fast campaign after split",
+               self.tag,
+               ticks);
+        ticks
     }
 
     #[inline]

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -469,7 +469,28 @@ impl Peer {
     // after the region split. So this peer of new split region may campaign and become leader
     // earlier than other follower peers.
     pub fn accelerate_campaign_ticks(&self) -> usize {
-        self.raft_group.raft.randomized_election_timeout - 1
+        // The best case for the fast campaign after a split is:
+        //   1. The leader of old region commits the log entry which contains the corresponding
+        //      split request.
+        //   2. The leader of old region replicates this log entry at 1 by sending AppendEntries
+        //      requests to the followers.
+        //   3. The leader of old region applies this log entry at 1, and then raftstore
+        //      accelerates ticks for the peer of the new region. This peer shares the same store
+        //      with old leader. It will start to campaign soon and send out RequestVote requests.
+        //   4. The followers receive AppendEntries requests from leader for replication in 2,
+        //      and then make it persistent and applie the split log entry so that
+        //      create a new region.
+        //   5. The followers receive RequestVote requests from leader in 3, and then vote
+        //      the campaign.
+        // However it's possible that 3 happens before 2, if RequestVote requests in 3 is sent
+        // to the followers earlier than AppendEntries requests in 2, the followers would not
+        // be ready to vote the campaign as 5 describes. Then the tick acceleration in 3 would be
+        // useless, so the campaign still happens after the election timeout.
+        // To make the best case happen at high degree of possibility, a time gap of
+        // `heartbeat_timeout * 2` is reserved for the followers to receive AppendEntries request
+        // and to apply them.
+        self.raft_group.raft.randomized_election_timeout -
+        (2 * self.raft_group.raft.heartbeat_timeout)
     }
 
     #[inline]

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -464,6 +464,14 @@ impl Peer {
         self.raft_group.raft.state == StateRole::Leader
     }
 
+    // When this peer is the leader of the region before split,
+    // `accelerate_campaign_ticks` specifies the tick number to be accelerated
+    // after the region split. So this peer of new split region may campaign and become leader
+    // earlier than other follower peers.
+    pub fn accelerate_campaign_ticks(&self) -> usize {
+        self.raft_group.raft.randomized_election_timeout - 1
+    }
+
     #[inline]
     pub fn get_store(&self) -> &PeerStorage {
         self.raft_group.get_store()

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -1087,7 +1087,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                 // since there is no leader established during one election timeout after the split.
                 let is_leader = self.region_peers[&region_id].is_leader();
                 if is_leader && right.get_peers().len() > 1 {
-                    for _ in 0..self.cfg.accelerate_campaign_after_split_ticks() {
+                    for _ in 0..self.region_peers[&region_id].accelerate_campaign_ticks() {
                         new_peer.raft_group.tick();
                     }
                 }

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -1087,7 +1087,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                 // since there is no leader established during one election timeout after the split.
                 let is_leader = self.region_peers[&region_id].is_leader();
                 if is_leader && right.get_peers().len() > 1 {
-                    for _ in 0..self.region_peers[&region_id].accelerate_campaign_ticks() {
+                    for _ in 0..new_peer.accelerate_campaign_ticks() {
                         new_peer.raft_group.tick();
                     }
                 }

--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -242,7 +242,7 @@ impl<T: Simulator> Cluster<T> {
             .map(|region| region.get_peers().into_iter().map(|p| p.get_store_id()).collect())
     }
 
-    fn query_leader(&self, store_id: u64, region_id: u64) -> Option<metapb::Peer> {
+    pub fn query_leader(&self, store_id: u64, region_id: u64) -> Option<metapb::Peer> {
         // To get region leader, we don't care real peer id, so use 0 instead.
         let peer = new_peer(store_id, 0);
         let find_leader = new_status_request(region_id, peer, new_region_leader_cmd());

--- a/tests/raftstore/test_split_region.rs
+++ b/tests/raftstore/test_split_region.rs
@@ -547,3 +547,46 @@ fn test_node_split_stale_epoch() {
     let mut cluster = new_node_cluster(0, 3);
     test_split_stale_epoch(&mut cluster);
 }
+
+
+// For the peer which is the leader of the region before split,
+// it would accelerate ticks for the peer of new region after split, so that the peer of new region
+// could start campaign faster. and then this peer may take the leadership earlier.
+// `test_tick_acceleration_after_split` is a helper function for testing this feature.
+fn test_tick_acceleration_after_split<T: Simulator>(cluster: &mut Cluster<T>) {
+    // Calculate the reserved time before a new campaign after split.
+    let reserved_time = Duration::from_millis(cluster.cfg.raft_store.raft_base_tick_interval) *
+                        cluster.cfg.raft_store.accelerate_campaign_reserved_ticks as u32;
+
+    cluster.run();
+    cluster.must_put(b"k1", b"v1");
+    cluster.must_put(b"k3", b"v3");
+    let region = cluster.get_region(b"k1");
+    let old_leader = cluster.leader_of_region(region.get_id()).unwrap();
+
+    cluster.must_split(&region, b"k2");
+
+    // Wait for the peer of new region to start campaign.
+    thread::sleep(reserved_time);
+
+    // The campaign should always succeeds in the ideal test environment.
+    let new_region = cluster.get_region(b"k3");
+    let store_id = old_leader.get_store_id();
+    // Ensure the new leader is established for the newly split region, and it shares the
+    // same store with the leader of old region.
+    let new_leader = cluster.query_leader(store_id, new_region.get_id());
+    assert!(new_leader.is_some());
+    assert_eq!(new_leader.unwrap().get_store_id(), store_id);
+}
+
+#[test]
+fn test_node_tick_acceleration_after_split() {
+    let mut cluster = new_node_cluster(0, 3);
+    test_tick_acceleration_after_split(&mut cluster);
+}
+
+#[test]
+fn test_server_tick_acceleration_after_split() {
+    let mut cluster = new_server_cluster(0, 3);
+    test_tick_acceleration_after_split(&mut cluster);
+}


### PR DESCRIPTION
Hi,

This PR tries to fix issue #1639 

PTAL @siddontang @BusyJay 