### PR TITLE
coprocessor: support default value.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "tipb"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/tipb.git#e2bf6e488202d5f4cec42d12d079b2eebddfdc6f"
+source = "git+https://github.com/pingcap/tipb.git#979fbca78d449e3c52de37b6fdd1dfbf0977b462"
 dependencies = [
  "protobuf 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/server/coprocessor/endpoint.rs
+++ b/src/server/coprocessor/endpoint.rs
@@ -458,6 +458,7 @@ fn inflate_with_col<'a, T>(eval: &mut Evaluator,
             } else {
                 let value = match values.get(col_id) {
                     None if col.has_default_val() => {
+                        // TODO: optimize it to decode default value only once.
                         box_try!(col.get_default_val().decode_col_value(ctx, col))
                     }
                     None if mysql::has_not_null_flag(col.get_flag() as u64) => {

--- a/tests/coprocessor/test_select.rs
+++ b/tests/coprocessor/test_select.rs
@@ -89,7 +89,7 @@ struct Column {
     col_type: i32,
     // negative means not a index key, 0 means primary key, positive means normal index key.
     index: i64,
-    default_val: Option<i64>,
+    default_val: Option<i64>, // TODO: change it to Vec<u8> if other type value is needed for test.
 }
 
 struct ColumnBuilder {


### PR DESCRIPTION
When default value is provided in column info, use that value if not found.