### PR TITLE
endpoint: collect scanned key count

### DIFF
--- a/src/server/coprocessor/endpoint.rs
+++ b/src/server/coprocessor/endpoint.rs
@@ -31,7 +31,7 @@ use kvproto::msgpb::{MessageType, Message};
 use kvproto::coprocessor::{Request, Response, KeyRange};
 use kvproto::errorpb::{self, ServerIsBusy};
 
-use storage::{self, Engine, SnapshotStore, ScanMetrics, engine, Snapshot, Key, ScanMode};
+use storage::{self, Engine, SnapshotStore, engine, Snapshot, Key, ScanMode, Statistics};
 use util::codec::table::{RowColsDict, TableDecoder};
 use util::codec::number::NumberDecoder;
 use util::codec::{Datum, table, datum, mysql};
@@ -108,10 +108,10 @@ pub struct RequestTask {
     req: Request,
     start_ts: Option<u64>,
     wait_time: Option<f64>,
-    scan_metrics: ScanMetrics,
     timer: Instant,
     // The deadline before which the task should be responded.
     deadline: Instant,
+    statistics: Statistics,
     on_resp: OnResponse,
 }
 
@@ -123,9 +123,9 @@ impl RequestTask {
             req: req,
             start_ts: None,
             wait_time: None,
-            scan_metrics: Default::default(),
             timer: timer,
             deadline: deadline,
+            statistics: Default::default(),
             on_resp: on_resp,
         }
     }
@@ -155,10 +155,10 @@ impl RequestTask {
         COPR_REQ_HANDLE_TIME.with_label_values(&["select", type_str])
             .observe(handle_time - wait_time);
 
-        let scanned_keys = self.scan_metrics.scanned_keys as f64;
+        let scanned_keys = self.statistics.total_op_count() as f64;
         COPR_SCAN_KEYS.with_label_values(&["select", type_str]).observe(scanned_keys);
-        let efficiency = self.scan_metrics.efficiency();
-        COPR_SCAN_EFFICIENCY.with_label_values(&["select", type_str]).observe(efficiency);
+        let inefficiency = self.statistics.inefficiency();
+        COPR_SCAN_INEFFICIENCY.with_label_values(&["select", type_str]).observe(inefficiency);
 
         if handle_time > SLOW_QUERY_LOWER_BOUND {
             info!("[region {}] handle {:?} [{}] takes {:?} [waiting: {:?}, keys: {}, hit: {}, \
@@ -168,8 +168,8 @@ impl RequestTask {
                   type_str,
                   handle_time,
                   wait_time,
-                  self.scan_metrics.scanned_keys,
-                  efficiency,
+                  scanned_keys,
+                  inefficiency,
                   self.req.get_ranges().len(),
                   self.req.get_ranges().get(0));
         }
@@ -360,7 +360,7 @@ impl TiDbEndPoint {
 
     pub fn handle_select(&self, t: &mut RequestTask, sel: SelectRequest) -> Result<Response> {
         let snap = SnapshotStore::new(self.snap.as_ref(), sel.get_start_ts());
-        let mut ctx = try!(SelectContext::new(sel, snap, t.deadline, &mut t.scan_metrics));
+        let mut ctx = try!(SelectContext::new(sel, snap, t.deadline, &mut t.statistics));
         let mut range = t.req.get_ranges().to_vec();
         debug!("scanning range: {:?}", range);
         if ctx.core.desc_scan {
@@ -928,7 +928,7 @@ fn collect_col_in_expr(cols: &mut HashMap<i64, ColumnInfo>,
 
 pub struct SelectContext<'a> {
     snap: SnapshotStore<'a>,
-    scan_metrics: &'a mut ScanMetrics,
+    statistics: &'a mut Statistics,
     core: SelectContextCore,
     deadline: Instant,
 }
@@ -937,13 +937,13 @@ impl<'a> SelectContext<'a> {
     fn new(sel: SelectRequest,
            snap: SnapshotStore<'a>,
            deadline: Instant,
-           scan_metrics: &'a mut ScanMetrics)
+           statistics: &'a mut Statistics)
            -> Result<SelectContext<'a>> {
         Ok(SelectContext {
             core: try!(SelectContextCore::new(sel)),
             snap: snap,
             deadline: deadline,
-            scan_metrics: scan_metrics,
+            statistics: statistics,
         })
     }
 
@@ -980,8 +980,8 @@ impl<'a> SelectContext<'a> {
     fn get_rows_from_range(&mut self, range: KeyRange) -> Result<usize> {
         let mut row_count = 0;
         if is_point(&range) {
-            self.scan_metrics.scanned_keys += 1;
-            let value = match try!(self.snap.get(&Key::from_raw(range.get_start()))) {
+            let value = match try!(self.snap
+                .get(&Key::from_raw(range.get_start()), &mut self.statistics)) {
                 None => return Ok(0),
                 Some(v) => v,
             };
@@ -1008,15 +1008,16 @@ impl<'a> SelectContext<'a> {
                                                          ScanMode::Forward
                                                      },
                                                      self.key_only(),
-                                                     upper_bound));
+                                                     upper_bound,
+                                                     self.statistics));
             while self.core.limit > row_count {
                 if row_count & REQUEST_CHECKPOINT == 0 {
                     try!(check_if_outdated(self.deadline, REQ_TYPE_SELECT));
                 }
                 let kv = if self.core.desc_scan {
-                    try!(scanner.reverse_seek(Key::from_raw(&seek_key), self.scan_metrics))
+                    try!(scanner.reverse_seek(Key::from_raw(&seek_key)))
                 } else {
-                    try!(scanner.seek(Key::from_raw(&seek_key), self.scan_metrics))
+                    try!(scanner.seek(Key::from_raw(&seek_key)))
                 };
                 let (key, value) = match kv {
                     Some((key, value)) => (box_try!(key.raw()), value),
@@ -1081,15 +1082,16 @@ impl<'a> SelectContext<'a> {
                                                      ScanMode::Forward
                                                  },
                                                  self.key_only(),
-                                                 upper_bound));
+                                                 upper_bound,
+                                                 self.statistics));
         while row_cnt < self.core.limit {
             if row_cnt & REQUEST_CHECKPOINT == 0 {
                 try!(check_if_outdated(self.deadline, REQ_TYPE_SELECT));
             }
             let nk = if self.core.desc_scan {
-                try!(scanner.reverse_seek(Key::from_raw(&seek_key), self.scan_metrics))
+                try!(scanner.reverse_seek(Key::from_raw(&seek_key)))
             } else {
-                try!(scanner.seek(Key::from_raw(&seek_key), self.scan_metrics))
+                try!(scanner.seek(Key::from_raw(&seek_key)))
             };
             let (key, val) = match nk {
                 Some((key, val)) => (box_try!(key.raw()), val),

--- a/src/server/coprocessor/metrics.rs
+++ b/src/server/coprocessor/metrics.rs
@@ -64,10 +64,10 @@ lazy_static! {
             exponential_buckets(1.0, 2.0, 20).unwrap()
         ).unwrap();
 
-    pub static ref COPR_SCAN_EFFICIENCY: HistogramVec =
+    pub static ref COPR_SCAN_INEFFICIENCY: HistogramVec =
         register_histogram_vec!(
-            "tikv_coprocessor_scan_efficiency",
-            "Bucketed histogram of coprocessor scan efficiency",
+            "tikv_coprocessor_scan_inefficiency",
+            "Bucketed histogram of coprocessor scan inefficiency",
             &["type", "req"],
             vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
         ).unwrap();

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -143,6 +143,37 @@ pub enum ScanMode {
     Mixed,
 }
 
+/// Statistics collects the ops taken when fetching data.
+#[derive(Default)]
+pub struct Statistics {
+    // How many keys that's effective to user. This counter should be increased
+    // by the caller.
+    pub processed: usize,
+    pub get: usize,
+    pub next: usize,
+    pub prev: usize,
+    pub seek: usize,
+    pub seek_for_prev: usize,
+}
+
+impl Statistics {
+    #[inline]
+    pub fn total_op_count(&self) -> usize {
+        self.get + self.next + self.prev + self.seek + self.seek_for_prev
+    }
+
+    // Calculate how the operation performs.
+    #[inline]
+    pub fn inefficiency(&self) -> f64 {
+        let total_op_cnt = self.total_op_count();
+        if total_op_cnt == 0 {
+            0f64
+        } else {
+            (total_op_cnt as f64 - self.processed as f64) / total_op_cnt as f64
+        }
+    }
+}
+
 pub struct Cursor<'a> {
     iter: Box<Iterator + 'a>,
     scan_mode: ScanMode,
@@ -161,7 +192,7 @@ impl<'a> Cursor<'a> {
         }
     }
 
-    pub fn seek(&mut self, key: &Key) -> Result<bool> {
+    pub fn seek(&mut self, key: &Key, statistics: &mut Statistics) -> Result<bool> {
         assert!(self.scan_mode != ScanMode::Backward);
         if self.max_key.as_ref().map_or(false, |k| k <= key.encoded()) {
             try!(self.iter.validate_key(key));
@@ -171,6 +202,8 @@ impl<'a> Cursor<'a> {
         if self.scan_mode == ScanMode::Forward && self.valid() && self.iter.key() >= key.encoded() {
             return Ok(true);
         }
+
+        statistics.seek += 1;
 
         if !try!(self.iter.seek(key)) {
             self.max_key = Some(key.encoded().to_owned());
@@ -183,10 +216,10 @@ impl<'a> Cursor<'a> {
     ///
     /// This method assume the current position of cursor is
     /// around `key`, otherwise you should use `seek` instead.
-    pub fn near_seek(&mut self, key: &Key) -> Result<bool> {
+    pub fn near_seek(&mut self, key: &Key, statistics: &mut Statistics) -> Result<bool> {
         assert!(self.scan_mode != ScanMode::Backward);
         if !self.iter.valid() {
-            return self.seek(key);
+            return self.seek(key, statistics);
         }
         let ord = self.iter.key().cmp(key.encoded());
         if ord == Ordering::Equal ||
@@ -198,20 +231,20 @@ impl<'a> Cursor<'a> {
             return Ok(false);
         }
         if ord == Ordering::Greater {
-            near_loop!(self.iter.prev() && self.iter.key() > key.encoded(),
-                       self.seek(key));
+            near_loop!(self.prev(statistics) && self.iter.key() > key.encoded(),
+                       self.seek(key, statistics));
             if self.iter.valid() {
                 if self.iter.key() < key.encoded() {
-                    self.iter.next();
+                    self.next(statistics);
                 }
             } else {
-                assert!(self.iter.seek_to_first());
+                assert!(self.seek_to_first(statistics));
                 return Ok(true);
             }
         } else {
             // ord == Less
-            near_loop!(self.iter.next() && self.iter.key() < key.encoded(),
-                       self.seek(key));
+            near_loop!(self.next(statistics) && self.iter.key() < key.encoded(),
+                       self.seek(key, statistics));
         }
         if !self.iter.valid() {
             self.max_key = Some(key.encoded().to_owned());
@@ -224,20 +257,20 @@ impl<'a> Cursor<'a> {
     ///
     /// This method assume the current position of cursor is
     /// around `key`, otherwise you should `seek` first.
-    pub fn get(&mut self, key: &Key) -> Result<Option<&[u8]>> {
+    pub fn get(&mut self, key: &Key, statistics: &mut Statistics) -> Result<Option<&[u8]>> {
         if self.scan_mode != ScanMode::Backward {
-            if try!(self.near_seek(key)) && self.iter.key() == &**key.encoded() {
+            if try!(self.near_seek(key, statistics)) && self.iter.key() == &**key.encoded() {
                 return Ok(Some(self.iter.value()));
             }
             return Ok(None);
         }
-        if try!(self.near_seek_for_prev(key)) && self.iter.key() == &**key.encoded() {
+        if try!(self.near_seek_for_prev(key, statistics)) && self.iter.key() == &**key.encoded() {
             return Ok(Some(self.iter.value()));
         }
         Ok(None)
     }
 
-    fn seek_for_prev(&mut self, key: &Key) -> Result<bool> {
+    fn seek_for_prev(&mut self, key: &Key, statistics: &mut Statistics) -> Result<bool> {
         assert!(self.scan_mode != ScanMode::Forward);
         if self.min_key.as_ref().map_or(false, |k| k >= key.encoded()) {
             try!(self.iter.validate_key(key));
@@ -249,6 +282,7 @@ impl<'a> Cursor<'a> {
             return Ok(true);
         }
 
+        statistics.seek_for_prev += 1;
         if !try!(self.iter.seek_for_prev(key)) {
             self.min_key = Some(key.encoded().to_owned());
             return Ok(false);
@@ -257,10 +291,10 @@ impl<'a> Cursor<'a> {
     }
 
     /// Find the largest key that is not greater than the specific key.
-    pub fn near_seek_for_prev(&mut self, key: &Key) -> Result<bool> {
+    pub fn near_seek_for_prev(&mut self, key: &Key, statistics: &mut Statistics) -> Result<bool> {
         assert!(self.scan_mode != ScanMode::Forward);
         if !self.iter.valid() {
-            return self.seek_for_prev(key);
+            return self.seek_for_prev(key, statistics);
         }
         let ord = self.iter.key().cmp(key.encoded());
         if ord == Ordering::Equal ||
@@ -274,19 +308,19 @@ impl<'a> Cursor<'a> {
         }
 
         if ord == Ordering::Less {
-            near_loop!(self.iter.next() && self.iter.key() < key.encoded(),
-                       self.seek_for_prev(key));
+            near_loop!(self.next(statistics) && self.iter.key() < key.encoded(),
+                       self.seek_for_prev(key, statistics));
             if self.iter.valid() {
                 if self.iter.key() > key.encoded() {
-                    self.iter.prev();
+                    self.prev(statistics);
                 }
             } else {
-                assert!(self.iter.seek_to_last());
+                assert!(self.seek_to_last(statistics));
                 return Ok(true);
             }
         } else {
-            near_loop!(self.iter.prev() && self.iter.key() > key.encoded(),
-                       self.seek_for_prev(key));
+            near_loop!(self.prev(statistics) && self.iter.key() > key.encoded(),
+                       self.seek_for_prev(key, statistics));
         }
 
         if !self.iter.valid() {
@@ -296,15 +330,15 @@ impl<'a> Cursor<'a> {
         Ok(true)
     }
 
-    pub fn reverse_seek(&mut self, key: &Key) -> Result<bool> {
-        if !try!(self.seek_for_prev(key)) {
+    pub fn reverse_seek(&mut self, key: &Key, statistics: &mut Statistics) -> Result<bool> {
+        if !try!(self.seek_for_prev(key, statistics)) {
             return Ok(false);
         }
 
         if self.iter.key() == &**key.encoded() {
             // should not update min_key here. otherwise reverse_seek_le may not
             // work as expected.
-            return Ok(self.iter.prev());
+            return Ok(self.prev(statistics));
         }
 
         Ok(true)
@@ -314,13 +348,13 @@ impl<'a> Cursor<'a> {
     ///
     /// This method assume the current position of cursor is
     /// around `key`, otherwise you should use `reverse_seek` instead.
-    pub fn near_reverse_seek(&mut self, key: &Key) -> Result<bool> {
-        if !try!(self.near_seek_for_prev(key)) {
+    pub fn near_reverse_seek(&mut self, key: &Key, statistics: &mut Statistics) -> Result<bool> {
+        if !try!(self.near_seek_for_prev(key, statistics)) {
             return Ok(false);
         }
 
         if self.iter.key() == &**key.encoded() {
-            return Ok(self.iter.prev());
+            return Ok(self.prev(statistics));
         }
 
         Ok(true)
@@ -337,22 +371,26 @@ impl<'a> Cursor<'a> {
     }
 
     #[inline]
-    pub fn seek_to_first(&mut self) -> bool {
+    pub fn seek_to_first(&mut self, statistics: &mut Statistics) -> bool {
+        statistics.seek += 1;
         self.iter.seek_to_first()
     }
 
     #[inline]
-    pub fn seek_to_last(&mut self) -> bool {
+    pub fn seek_to_last(&mut self, statistics: &mut Statistics) -> bool {
+        statistics.seek += 1;
         self.iter.seek_to_last()
     }
 
     #[inline]
-    pub fn next(&mut self) -> bool {
+    pub fn next(&mut self, statistics: &mut Statistics) -> bool {
+        statistics.next += 1;
         self.iter.next()
     }
 
     #[inline]
-    pub fn prev(&mut self) -> bool {
+    pub fn prev(&mut self, statistics: &mut Statistics) -> bool {
+        statistics.prev += 1;
         self.iter.prev()
     }
 
@@ -475,7 +513,8 @@ mod tests {
         let snapshot = engine.snapshot(&Context::new()).unwrap();
         let mut iter = snapshot.iter(IterOption::default(), ScanMode::Mixed)
             .unwrap();
-        iter.seek(&make_key(key)).unwrap();
+        let mut statistics = Statistics::default();
+        iter.seek(&make_key(key), &mut statistics).unwrap();
         assert_eq!((iter.key(), iter.value()),
                    (&*bytes::encode_bytes(pair.0), pair.1));
     }
@@ -484,19 +523,23 @@ mod tests {
         let snapshot = engine.snapshot(&Context::new()).unwrap();
         let mut iter = snapshot.iter(IterOption::default(), ScanMode::Mixed)
             .unwrap();
-        iter.reverse_seek(&make_key(key)).unwrap();
+        let mut statistics = Statistics::default();
+        iter.reverse_seek(&make_key(key), &mut statistics).unwrap();
         assert_eq!((iter.key(), iter.value()),
                    (&*bytes::encode_bytes(pair.0), pair.1));
     }
 
     fn assert_near_seek(cursor: &mut Cursor, key: &[u8], pair: (&[u8], &[u8])) {
-        assert!(cursor.near_seek(&make_key(key)).unwrap(), escape(key));
+        let mut statistics = Statistics::default();
+        assert!(cursor.near_seek(&make_key(key), &mut statistics).unwrap(),
+                escape(key));
         assert_eq!((cursor.key(), cursor.value()),
                    (&*bytes::encode_bytes(pair.0), pair.1));
     }
 
     fn assert_near_reverse_seek(cursor: &mut Cursor, key: &[u8], pair: (&[u8], &[u8])) {
-        assert!(cursor.near_reverse_seek(&make_key(key)).unwrap(),
+        let mut statistics = Statistics::default();
+        assert!(cursor.near_reverse_seek(&make_key(key), &mut statistics).unwrap(),
                 escape(key));
         assert_eq!((cursor.key(), cursor.value()),
                    (&*bytes::encode_bytes(pair.0), pair.1));
@@ -539,8 +582,9 @@ mod tests {
         let snapshot = engine.snapshot(&Context::new()).unwrap();
         let mut iter = snapshot.iter(IterOption::default(), ScanMode::Mixed)
             .unwrap();
-        assert!(!iter.seek(&make_key(b"z\x00")).unwrap());
-        assert!(!iter.reverse_seek(&make_key(b"x")).unwrap());
+        let mut statistics = Statistics::default();
+        assert!(!iter.seek(&make_key(b"z\x00"), &mut statistics).unwrap());
+        assert!(!iter.reverse_seek(&make_key(b"x"), &mut statistics).unwrap());
         must_delete(engine, b"x");
         must_delete(engine, b"z");
     }
@@ -557,7 +601,8 @@ mod tests {
         assert_near_reverse_seek(&mut cursor, b"x1", (b"x", b"1"));
         assert_near_seek(&mut cursor, b"y", (b"z", b"2"));
         assert_near_seek(&mut cursor, b"x\x00", (b"z", b"2"));
-        assert!(!cursor.near_seek(&make_key(b"z\x00")).unwrap());
+        let mut statistics = Statistics::default();
+        assert!(!cursor.near_seek(&make_key(b"z\x00"), &mut statistics).unwrap());
         // Insert many key-values between 'x' and 'z' then near_seek will fallback to seek.
         for i in 0..super::SEEK_BOUND {
             let key = format!("y{}", i);
@@ -580,18 +625,20 @@ mod tests {
         let snapshot = engine.snapshot(&Context::new()).unwrap();
         let mut cursor = snapshot.iter(IterOption::default(), ScanMode::Mixed)
             .unwrap();
-        assert!(!cursor.near_reverse_seek(&make_key(b"x")).unwrap());
-        assert!(!cursor.near_reverse_seek(&make_key(b"z")).unwrap());
-        assert!(!cursor.near_reverse_seek(&make_key(b"w")).unwrap());
-        assert!(!cursor.near_seek(&make_key(b"x")).unwrap());
-        assert!(!cursor.near_seek(&make_key(b"z")).unwrap());
-        assert!(!cursor.near_seek(&make_key(b"w")).unwrap());
+        let mut statistics = Statistics::default();
+        assert!(!cursor.near_reverse_seek(&make_key(b"x"), &mut statistics).unwrap());
+        assert!(!cursor.near_reverse_seek(&make_key(b"z"), &mut statistics).unwrap());
+        assert!(!cursor.near_reverse_seek(&make_key(b"w"), &mut statistics).unwrap());
+        assert!(!cursor.near_seek(&make_key(b"x"), &mut statistics).unwrap());
+        assert!(!cursor.near_seek(&make_key(b"z"), &mut statistics).unwrap());
+        assert!(!cursor.near_seek(&make_key(b"w"), &mut statistics).unwrap());
     }
 
     macro_rules! assert_seek {
         ($cursor:ident, $func:ident, $k:expr, $res:ident) => ({
             let msg = format!("assert_seek {} failed exp {:?}", $k, $res);
-            assert!($cursor.$func(&$k).unwrap() == $res.is_some(), msg);
+            let mut statistics = Statistics::default();
+            assert!($cursor.$func(&$k, &mut statistics).unwrap() == $res.is_some(), msg);
             if let Some((ref k, ref v)) = $res {
                 assert_eq!($cursor.key(), bytes::encode_bytes(k.as_bytes()).as_slice());
                 assert_eq!($cursor.value(), v.as_bytes());

--- a/src/storage/metrics.rs
+++ b/src/storage/metrics.rs
@@ -63,10 +63,10 @@ lazy_static! {
             exponential_buckets(1.0, 2.0, 21).unwrap()
         ).unwrap();
 
-    pub static ref KV_COMMAND_SCAN_EFFICIENCY: Histogram =
+    pub static ref KV_COMMAND_SCAN_INEFFICIENCY: Histogram =
         register_histogram!(
-            "tikv_scheudler_kv_scan_efficiency",
-            "Bucketed histogram of kv keys scan efficiency",
+            "tikv_scheudler_kv_scan_inefficiency",
+            "Bucketed histogram of kv keys scan inefficiency",
             vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
         ).unwrap();
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -31,10 +31,9 @@ mod metrics;
 
 pub use self::config::Config;
 pub use self::engine::{Engine, Snapshot, TEMP_DIR, new_local_engine, Modify, Cursor,
-                       Error as EngineError, ScanMode};
+                       Error as EngineError, ScanMode, Statistics};
 pub use self::engine::raftkv::RaftKv;
 pub use self::txn::{SnapshotStore, Scheduler, Msg};
-pub use self::mvcc::ScanMetrics;
 pub use self::types::{Key, Value, KvPair, make_key};
 pub type Callback<T> = Box<FnBox(Result<T>) + Send>;
 

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -19,7 +19,7 @@ mod metrics;
 
 use std::io;
 pub use self::txn::{MvccTxn, MAX_TXN_WRITE_SIZE};
-pub use self::reader::{ScanMetrics, MvccReader};
+pub use self::reader::MvccReader;
 pub use self::lock::{Lock, LockType};
 pub use self::write::{Write, WriteType};
 use util::escape;

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -12,7 +12,8 @@
 // limitations under the License.
 
 use std::fmt;
-use storage::{Key, Value, Mutation, CF_DEFAULT, CF_LOCK, CF_WRITE, Options, is_short_value};
+use storage::{Key, Value, Mutation, CF_DEFAULT, CF_LOCK, CF_WRITE, Options, is_short_value,
+              Statistics};
 use storage::engine::{Snapshot, Modify, ScanMode};
 use super::reader::MvccReader;
 use super::lock::{LockType, Lock};
@@ -36,10 +37,14 @@ impl<'a> fmt::Debug for MvccTxn<'a> {
 }
 
 impl<'a> MvccTxn<'a> {
-    pub fn new(snapshot: &'a Snapshot, start_ts: u64, mode: Option<ScanMode>) -> MvccTxn<'a> {
+    pub fn new(snapshot: &'a Snapshot,
+               statistics: &'a mut Statistics,
+               start_ts: u64,
+               mode: Option<ScanMode>)
+               -> MvccTxn<'a> {
         MvccTxn {
             // Todo: use session variable to indicate fill cache or not
-            reader: MvccReader::new(snapshot, mode, true /* fill_cache */, None),
+            reader: MvccReader::new(snapshot, statistics, mode, true /* fill_cache */, None),
             start_ts: start_ts,
             writes: vec![],
             write_size: 0,
@@ -280,7 +285,8 @@ mod tests {
     use super::MvccTxn;
     use super::super::MvccReader;
     use super::super::write::{Write, WriteType};
-    use storage::{make_key, Mutation, ALL_CFS, CF_WRITE, ScanMode, Options, SHORT_VALUE_MAX_LEN};
+    use storage::{make_key, Mutation, ALL_CFS, CF_WRITE, ScanMode, Options, SHORT_VALUE_MAX_LEN,
+                  Statistics};
     use storage::engine::{self, Engine, TEMP_DIR};
 
     fn gen_value(v: u8, len: usize) -> Vec<u8> {
@@ -641,7 +647,8 @@ mod tests {
         let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
         let ctx = Context::new();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot.as_ref(), 10, None);
+        let mut statistics = Statistics::default();
+        let mut txn = MvccTxn::new(snapshot.as_ref(), &mut statistics, 10, None);
         let key = make_key(k);
         assert_eq!(txn.write_size, 0);
 
@@ -656,7 +663,8 @@ mod tests {
         engine.write(&ctx, txn.modifies()).unwrap();
 
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot.as_ref(), 10, None);
+        let mut statistics = Statistics::default();
+        let mut txn = MvccTxn::new(snapshot.as_ref(), &mut statistics, 10, None);
         txn.commit(&key, 15).unwrap();
         assert!(txn.write_size() > 0);
         engine.write(&ctx, txn.modifies()).unwrap();
@@ -680,7 +688,8 @@ mod tests {
 
         let ctx = Context::new();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot.as_ref(), 5, None);
+        let mut statistics = Statistics::default();
+        let mut txn = MvccTxn::new(snapshot.as_ref(), &mut statistics, 5, None);
         txn.prewrite(Mutation::Put((make_key(key), value.to_vec())),
                       key,
                       &Options::default())
@@ -688,7 +697,8 @@ mod tests {
 
         let ctx = Context::new();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot.as_ref(), 5, None);
+        let mut statistics = Statistics::default();
+        let mut txn = MvccTxn::new(snapshot.as_ref(), &mut statistics, 5, None);
         txn.prewrite(Mutation::Put((make_key(key), value.to_vec())),
                       key,
                       &Options::default())
@@ -698,28 +708,32 @@ mod tests {
     fn must_get(engine: &Engine, key: &[u8], ts: u64, expect: &[u8]) {
         let ctx = Context::new();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot.as_ref(), ts, None);
+        let mut statistics = Statistics::default();
+        let mut txn = MvccTxn::new(snapshot.as_ref(), &mut statistics, ts, None);
         assert_eq!(txn.get(&make_key(key)).unwrap().unwrap(), expect);
     }
 
     fn must_get_none(engine: &Engine, key: &[u8], ts: u64) {
         let ctx = Context::new();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot.as_ref(), ts, None);
+        let mut statistics = Statistics::default();
+        let mut txn = MvccTxn::new(snapshot.as_ref(), &mut statistics, ts, None);
         assert!(txn.get(&make_key(key)).unwrap().is_none());
     }
 
     fn must_get_err(engine: &Engine, key: &[u8], ts: u64) {
         let ctx = Context::new();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot.as_ref(), ts, None);
+        let mut statistics = Statistics::default();
+        let mut txn = MvccTxn::new(snapshot.as_ref(), &mut statistics, ts, None);
         assert!(txn.get(&make_key(key)).is_err());
     }
 
     fn must_prewrite_put(engine: &Engine, key: &[u8], value: &[u8], pk: &[u8], ts: u64) {
         let ctx = Context::new();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot.as_ref(), ts, None);
+        let mut statistics = Statistics::default();
+        let mut txn = MvccTxn::new(snapshot.as_ref(), &mut statistics, ts, None);
         txn.prewrite(Mutation::Put((make_key(key), value.to_vec())),
                       pk,
                       &Options::default())
@@ -730,7 +744,8 @@ mod tests {
     fn must_prewrite_delete(engine: &Engine, key: &[u8], pk: &[u8], ts: u64) {
         let ctx = Context::new();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot.as_ref(), ts, None);
+        let mut statistics = Statistics::default();
+        let mut txn = MvccTxn::new(snapshot.as_ref(), &mut statistics, ts, None);
         txn.prewrite(Mutation::Delete(make_key(key)), pk, &Options::default()).unwrap();
         engine.write(&ctx, txn.modifies()).unwrap();
     }
@@ -738,7 +753,8 @@ mod tests {
     fn must_prewrite_lock(engine: &Engine, key: &[u8], pk: &[u8], ts: u64) {
         let ctx = Context::new();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot.as_ref(), ts, None);
+        let mut statistics = Statistics::default();
+        let mut txn = MvccTxn::new(snapshot.as_ref(), &mut statistics, ts, None);
         txn.prewrite(Mutation::Lock(make_key(key)), pk, &Options::default()).unwrap();
         engine.write(&ctx, txn.modifies()).unwrap();
     }
@@ -746,14 +762,16 @@ mod tests {
     fn must_prewrite_lock_err(engine: &Engine, key: &[u8], pk: &[u8], ts: u64) {
         let ctx = Context::new();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot.as_ref(), ts, None);
+        let mut statistics = Statistics::default();
+        let mut txn = MvccTxn::new(snapshot.as_ref(), &mut statistics, ts, None);
         assert!(txn.prewrite(Mutation::Lock(make_key(key)), pk, &Options::default()).is_err());
     }
 
     fn must_commit(engine: &Engine, key: &[u8], start_ts: u64, commit_ts: u64) {
         let ctx = Context::new();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot.as_ref(), start_ts, None);
+        let mut statistics = Statistics::default();
+        let mut txn = MvccTxn::new(snapshot.as_ref(), &mut statistics, start_ts, None);
         txn.commit(&make_key(key), commit_ts).unwrap();
         engine.write(&ctx, txn.modifies()).unwrap();
     }
@@ -761,14 +779,16 @@ mod tests {
     fn must_commit_err(engine: &Engine, key: &[u8], start_ts: u64, commit_ts: u64) {
         let ctx = Context::new();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot.as_ref(), start_ts, None);
+        let mut statistics = Statistics::default();
+        let mut txn = MvccTxn::new(snapshot.as_ref(), &mut statistics, start_ts, None);
         assert!(txn.commit(&make_key(key), commit_ts).is_err());
     }
 
     fn must_rollback(engine: &Engine, key: &[u8], start_ts: u64) {
         let ctx = Context::new();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot.as_ref(), start_ts, None);
+        let mut statistics = Statistics::default();
+        let mut txn = MvccTxn::new(snapshot.as_ref(), &mut statistics, start_ts, None);
         txn.rollback(&make_key(key)).unwrap();
         engine.write(&ctx, txn.modifies()).unwrap();
     }
@@ -776,28 +796,32 @@ mod tests {
     fn must_rollback_err(engine: &Engine, key: &[u8], start_ts: u64) {
         let ctx = Context::new();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot.as_ref(), start_ts, None);
+        let mut statistics = Statistics::default();
+        let mut txn = MvccTxn::new(snapshot.as_ref(), &mut statistics, start_ts, None);
         assert!(txn.rollback(&make_key(key)).is_err());
     }
 
     fn must_gc(engine: &Engine, key: &[u8], safe_point: u64) {
         let ctx = Context::new();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot.as_ref(), 0, None);
+        let mut statistics = Statistics::default();
+        let mut txn = MvccTxn::new(snapshot.as_ref(), &mut statistics, 0, None);
         txn.gc(&make_key(key), safe_point).unwrap();
         engine.write(&ctx, txn.modifies()).unwrap();
     }
 
     fn must_locked(engine: &Engine, key: &[u8], start_ts: u64) {
         let snapshot = engine.snapshot(&Context::new()).unwrap();
-        let mut reader = MvccReader::new(snapshot.as_ref(), None, true, None);
+        let mut statistics = Statistics::default();
+        let mut reader = MvccReader::new(snapshot.as_ref(), &mut statistics, None, true, None);
         let lock = reader.load_lock(&make_key(key)).unwrap().unwrap();
         assert_eq!(lock.ts, start_ts);
     }
 
     fn must_unlocked(engine: &Engine, key: &[u8]) {
         let snapshot = engine.snapshot(&Context::new()).unwrap();
-        let mut reader = MvccReader::new(snapshot.as_ref(), None, true, None);
+        let mut statistics = Statistics::default();
+        let mut reader = MvccReader::new(snapshot.as_ref(), &mut statistics, None, true, None);
         assert!(reader.load_lock(&make_key(key)).unwrap().is_none());
     }
 
@@ -812,7 +836,8 @@ mod tests {
 
     fn must_seek_write_none(engine: &Engine, key: &[u8], ts: u64) {
         let snapshot = engine.snapshot(&Context::new()).unwrap();
-        let mut reader = MvccReader::new(snapshot.as_ref(), None, true, None);
+        let mut statistics = Statistics::default();
+        let mut reader = MvccReader::new(snapshot.as_ref(), &mut statistics, None, true, None);
         assert!(reader.seek_write(&make_key(key), ts).unwrap().is_none());
     }
 
@@ -823,7 +848,8 @@ mod tests {
                        commit_ts: u64,
                        write_type: WriteType) {
         let snapshot = engine.snapshot(&Context::new()).unwrap();
-        let mut reader = MvccReader::new(snapshot.as_ref(), None, true, None);
+        let mut statistics = Statistics::default();
+        let mut reader = MvccReader::new(snapshot.as_ref(), &mut statistics, None, true, None);
         let (t, write) = reader.seek_write(&make_key(key), ts).unwrap().unwrap();
         assert_eq!(t, commit_ts);
         assert_eq!(write.start_ts, start_ts);
@@ -832,7 +858,8 @@ mod tests {
 
     fn must_reverse_seek_write_none(engine: &Engine, key: &[u8], ts: u64) {
         let snapshot = engine.snapshot(&Context::new()).unwrap();
-        let mut reader = MvccReader::new(snapshot.as_ref(), None, true, None);
+        let mut statistics = Statistics::default();
+        let mut reader = MvccReader::new(snapshot.as_ref(), &mut statistics, None, true, None);
         assert!(reader.reverse_seek_write(&make_key(key), ts).unwrap().is_none());
     }
 
@@ -843,7 +870,8 @@ mod tests {
                                commit_ts: u64,
                                write_type: WriteType) {
         let snapshot = engine.snapshot(&Context::new()).unwrap();
-        let mut reader = MvccReader::new(snapshot.as_ref(), None, true, None);
+        let mut statistics = Statistics::default();
+        let mut reader = MvccReader::new(snapshot.as_ref(), &mut statistics, None, true, None);
         let (t, write) = reader.reverse_seek_write(&make_key(key), ts).unwrap().unwrap();
         assert_eq!(t, commit_ts);
         assert_eq!(write.start_ts, start_ts);
@@ -852,14 +880,16 @@ mod tests {
 
     fn must_get_commit_ts(engine: &Engine, key: &[u8], start_ts: u64, commit_ts: u64) {
         let snapshot = engine.snapshot(&Context::new()).unwrap();
-        let mut reader = MvccReader::new(snapshot.as_ref(), None, true, None);
+        let mut statistics = Statistics::default();
+        let mut reader = MvccReader::new(snapshot.as_ref(), &mut statistics, None, true, None);
         assert_eq!(reader.get_txn_commit_ts(&make_key(key), start_ts).unwrap().unwrap(),
                    commit_ts);
     }
 
     fn must_get_commit_ts_none(engine: &Engine, key: &[u8], start_ts: u64) {
         let snapshot = engine.snapshot(&Context::new()).unwrap();
-        let mut reader = MvccReader::new(snapshot.as_ref(), None, true, None);
+        let mut statistics = Statistics::default();
+        let mut reader = MvccReader::new(snapshot.as_ref(), &mut statistics, None, true, None);
         assert!(reader.get_txn_commit_ts(&make_key(key), start_ts).unwrap().is_none());
     }
 
@@ -871,7 +901,12 @@ mod tests {
         let expect = (keys.into_iter().map(make_key).collect(),
                       next_start.map(|x| make_key(x).append_ts(0)));
         let snapshot = engine.snapshot(&Context::new()).unwrap();
-        let mut reader = MvccReader::new(snapshot.as_ref(), Some(ScanMode::Mixed), false, None);
+        let mut statistics = Statistics::default();
+        let mut reader = MvccReader::new(snapshot.as_ref(),
+                                         &mut statistics,
+                                         Some(ScanMode::Mixed),
+                                         false,
+                                         None);
         assert_eq!(reader.scan_keys(start.map(make_key), limit).unwrap(),
                    expect);
     }

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -40,8 +40,8 @@ use mio::{self, EventLoop};
 use kvproto::kvrpcpb::{Context, LockInfo};
 
 use storage::{Engine, Command, Snapshot, StorageCb, Result as StorageResult,
-              Error as StorageError, ScanMode};
-use storage::mvcc::{MvccTxn, ScanMetrics, MvccReader, Error as MvccError, MAX_TXN_WRITE_SIZE};
+              Error as StorageError, ScanMode, Statistics};
+use storage::mvcc::{MvccTxn, MvccReader, Error as MvccError, MAX_TXN_WRITE_SIZE};
 use storage::{Key, Value, KvPair, CMD_TAG_GC};
 use storage::engine::{CbContext, Result as EngineResult, Callback as EngineCallback, Modify};
 use util::transport::{SendCh, Error as TransportError};
@@ -271,12 +271,14 @@ fn process_read(cid: u64, mut cmd: Command, ch: SendCh<Msg>, snapshot: Box<Snaps
     SCHED_WORKER_COUNTER_VEC.with_label_values(&[cmd.tag(), "read"]).inc();
     let tag = cmd.tag();
 
+    let mut statistics = Statistics::default();
+
     let pr = match cmd {
         // Gets from the snapshot.
         Command::Get { ref key, start_ts, .. } => {
             KV_COMMAND_KEYREAD_HISTOGRAM_VEC.with_label_values(&[tag]).observe(1f64);
             let snap_store = SnapshotStore::new(snapshot.as_ref(), start_ts);
-            let res = snap_store.get(key);
+            let res = snap_store.get(key, &mut statistics);
             match res {
                 Ok(val) => ProcessResult::Value { value: val },
                 Err(e) => ProcessResult::Failed { err: StorageError::from(e) },
@@ -287,7 +289,7 @@ fn process_read(cid: u64, mut cmd: Command, ch: SendCh<Msg>, snapshot: Box<Snaps
             KV_COMMAND_KEYREAD_HISTOGRAM_VEC.with_label_values(&[tag])
                 .observe(keys.len() as f64);
             let snap_store = SnapshotStore::new(snapshot.as_ref(), start_ts);
-            match snap_store.batch_get(keys) {
+            match snap_store.batch_get(keys, &mut statistics) {
                 Ok(results) => {
                     let mut res = vec![];
                     for (k, v) in keys.into_iter().zip(results) {
@@ -305,15 +307,14 @@ fn process_read(cid: u64, mut cmd: Command, ch: SendCh<Msg>, snapshot: Box<Snaps
         // Scans a range starting with `start_key` up to `limit` rows from the snapshot.
         Command::Scan { ref start_key, limit, start_ts, ref options, .. } => {
             let snap_store = SnapshotStore::new(snapshot.as_ref(), start_ts);
-            let mut metrics = ScanMetrics::default();
-            let res = snap_store.scanner(ScanMode::Forward, options.key_only, None)
-                .and_then(|mut scanner| scanner.scan(start_key.clone(), limit, &mut metrics))
+            let res = snap_store.scanner(ScanMode::Forward, options.key_only, None, &mut statistics)
+                .and_then(|mut scanner| scanner.scan(start_key.clone(), limit))
                 .and_then(|mut results| {
                     KV_COMMAND_KEYREAD_HISTOGRAM_VEC.with_label_values(&[tag])
                         .observe(results.len() as f64);
                     Ok(results.drain(..).map(|x| x.map_err(StorageError::from)).collect())
                 });
-            KV_COMMAND_SCAN_EFFICIENCY.observe(metrics.efficiency());
+            KV_COMMAND_SCAN_INEFFICIENCY.observe(statistics.inefficiency());
             match res {
                 Ok(pairs) => ProcessResult::MultiKvpairs { pairs: pairs },
                 Err(e) => ProcessResult::Failed { err: e.into() },
@@ -321,8 +322,11 @@ fn process_read(cid: u64, mut cmd: Command, ch: SendCh<Msg>, snapshot: Box<Snaps
         }
         // Scans locks with timestamp <= `max_ts`
         Command::ScanLock { max_ts, .. } => {
-            let mut reader =
-                MvccReader::new(snapshot.as_ref(), Some(ScanMode::Forward), true, None);
+            let mut reader = MvccReader::new(snapshot.as_ref(),
+                                             &mut statistics,
+                                             Some(ScanMode::Forward),
+                                             true,
+                                             None);
             let res = reader.scan_lock(None, |lock| lock.ts <= max_ts, None)
                 .map_err(Error::from)
                 .and_then(|(v, _)| {
@@ -346,8 +350,11 @@ fn process_read(cid: u64, mut cmd: Command, ch: SendCh<Msg>, snapshot: Box<Snaps
         // Scan the locks with timestamp `start_ts`, then either commit them if the command has
         // commit timestamp populated or rollback otherwise.
         Command::ResolveLock { ref ctx, start_ts, commit_ts, ref mut scan_key, .. } => {
-            let mut reader =
-                MvccReader::new(snapshot.as_ref(), Some(ScanMode::Forward), true, None);
+            let mut reader = MvccReader::new(snapshot.as_ref(),
+                                             &mut statistics,
+                                             Some(ScanMode::Forward),
+                                             true,
+                                             None);
             let res = reader.scan_lock(scan_key.take(),
                            |lock| lock.ts == start_ts,
                            Some(RESOLVE_LOCK_BATCH_SIZE))
@@ -376,8 +383,11 @@ fn process_read(cid: u64, mut cmd: Command, ch: SendCh<Msg>, snapshot: Box<Snaps
         }
         // Collects garbage.
         Command::Gc { ref ctx, safe_point, ref mut scan_key, .. } => {
-            let mut reader =
-                MvccReader::new(snapshot.as_ref(), Some(ScanMode::Forward), true, None);
+            let mut reader = MvccReader::new(snapshot.as_ref(),
+                                             &mut statistics,
+                                             Some(ScanMode::Forward),
+                                             true,
+                                             None);
             // scan_key is used as start_key here,and Range start gc with scan_key=none.
             let is_range_start_key = scan_key.is_none();
             let res = reader.scan_keys(scan_key.take(), GC_BATCH_SIZE)
@@ -441,9 +451,10 @@ fn process_write_impl(cid: u64,
                       ch: SendCh<Msg>,
                       snapshot: &Snapshot)
                       -> Result<()> {
+    let mut statistics = Statistics::default();
     let (pr, modifies) = match cmd {
         Command::Prewrite { ref mutations, ref primary, start_ts, ref options, .. } => {
-            let mut txn = MvccTxn::new(snapshot, start_ts, None);
+            let mut txn = MvccTxn::new(snapshot, &mut statistics, start_ts, None);
             let mut locks = vec![];
             for m in mutations {
                 match txn.prewrite(m.clone(), primary, options) {
@@ -464,7 +475,7 @@ fn process_write_impl(cid: u64,
             }
         }
         Command::Commit { ref keys, lock_ts, commit_ts, .. } => {
-            let mut txn = MvccTxn::new(snapshot, lock_ts, None);
+            let mut txn = MvccTxn::new(snapshot, &mut statistics, lock_ts, None);
             for k in keys {
                 try!(txn.commit(&k, commit_ts));
             }
@@ -473,14 +484,14 @@ fn process_write_impl(cid: u64,
             (pr, txn.modifies())
         }
         Command::Cleanup { ref key, start_ts, .. } => {
-            let mut txn = MvccTxn::new(snapshot, start_ts, None);
+            let mut txn = MvccTxn::new(snapshot, &mut statistics, start_ts, None);
             try!(txn.rollback(&key));
 
             let pr = ProcessResult::Res;
             (pr, txn.modifies())
         }
         Command::Rollback { ref keys, start_ts, .. } => {
-            let mut txn = MvccTxn::new(snapshot, start_ts, None);
+            let mut txn = MvccTxn::new(snapshot, &mut statistics, start_ts, None);
             for k in keys {
                 try!(txn.rollback(&k));
             }
@@ -490,7 +501,7 @@ fn process_write_impl(cid: u64,
         }
         Command::ResolveLock { ref ctx, start_ts, commit_ts, ref mut scan_key, ref keys } => {
             let mut scan_key = scan_key.take();
-            let mut txn = MvccTxn::new(snapshot, start_ts, None);
+            let mut txn = MvccTxn::new(snapshot, &mut statistics, start_ts, None);
             for k in keys {
                 match commit_ts {
                     Some(ts) => try!(txn.commit(&k, ts)),
@@ -518,7 +529,7 @@ fn process_write_impl(cid: u64,
         }
         Command::Gc { ref ctx, safe_point, ref mut scan_key, ref keys } => {
             let mut scan_key = scan_key.take();
-            let mut txn = MvccTxn::new(snapshot, 0, Some(ScanMode::Mixed));
+            let mut txn = MvccTxn::new(snapshot, &mut statistics, 0, Some(ScanMode::Mixed));
             for k in keys {
                 try!(txn.gc(k, safe_point));
                 if txn.write_size() >= MAX_TXN_WRITE_SIZE {


### PR DESCRIPTION
This pr counts all the operation taken when handling a request. The collected result can be used to report Pd or Prometheus.

See also #1548, #1567 and #1555.

@siddontang @disksing PTAL