### PR TITLE
raftstore: queue vote

### DIFF
--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -584,9 +584,6 @@ fn build_cfg(matches: &Matches,
     cfg_u64(&mut cfg.raft_store.consistency_check_tick_interval,
             config,
             "raftstore.consistency-check-interval");
-    cfg_usize(&mut cfg.raft_store.accelerate_campaign_reserved_ticks,
-              config,
-              "raftstore.accelerate-campaign-reserved-ticks");
     cfg_usize(&mut cfg.storage.sched_notify_capacity,
               config,
               "storage.scheduler-notify-capacity");

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -56,8 +56,6 @@ const DEFAULT_REPORT_REGION_FLOW_INTERVAL: u64 = 30000; // 30 seconds
 
 const DEFAULT_RAFT_STORE_LEASE_SEC: i64 = 9; // 9 seconds
 
-const DEFAULT_ACCELERATE_CAMPAIGN_RESERVED_TICKS: usize = 1;
-
 #[derive(Debug, Clone)]
 pub struct Config {
     // store capacity.
@@ -125,15 +123,6 @@ pub struct Config {
     pub report_region_flow_interval: u64,
     // The lease provided by a successfully proposed and applied entry.
     pub raft_store_max_leader_lease: TimeDuration,
-
-    // For the peer which is the leader of the region before split,
-    // it would accelerate ticks for the peer of new region after split, so that
-    // the peer of new region could start campaign faster. And then this peer may take
-    // the leadership earlier and shorten the leading missing time to gain higher availability.
-    // To make sure followers are replicated up-to-date and be ready to vote this peer's campaign,
-    // The time interval specified by `accelerate_campaign_reserved_ticks * raft_base_tick_interval`
-    // would be reserved before the peer of new region starts to campaign.
-    pub accelerate_campaign_reserved_ticks: usize,
 }
 
 impl Default for Config {
@@ -169,7 +158,6 @@ impl Default for Config {
             consistency_check_tick_interval: DEFAULT_CONSISTENCY_CHECK_INTERVAL,
             report_region_flow_interval: DEFAULT_REPORT_REGION_FLOW_INTERVAL,
             raft_store_max_leader_lease: TimeDuration::seconds(DEFAULT_RAFT_STORE_LEASE_SEC),
-            accelerate_campaign_reserved_ticks: DEFAULT_ACCELERATE_CAMPAIGN_RESERVED_TICKS,
         }
     }
 }
@@ -210,13 +198,6 @@ impl Config {
             return Err(box_err!("election timeout {} ms is less than lease {} ms",
                                 election_timeout,
                                 lease));
-        }
-
-        if self.accelerate_campaign_reserved_ticks >= self.raft_election_timeout_ticks {
-            return Err(box_err!("accelerate campaign reserved ticks {} must < election timeout \
-                                 ticks {}",
-                                self.accelerate_campaign_reserved_ticks,
-                                self.raft_election_timeout_ticks));
         }
 
         Ok(())

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -912,13 +912,6 @@ impl Peer {
             return;
         }
 
-        if self.region().get_peers().len() == 3 {
-            // All followers of a region with only 3 peers can start campaign immediately.
-            let _ = self.raft_group.campaign();
-            self.mark_to_be_checked(pending_raft_groups);
-            return;
-        }
-
         let smallest_peer =
             self.region().get_peers().iter().min_by_key(|p| p.get_id()).unwrap().to_owned();
         if smallest_peer.get_id() == self.peer_id() {

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -879,6 +879,8 @@ impl Peer {
             return false;
         }
 
+        // If last peer is the leader of the region before split, it's intuitional for
+        // it to become the leader of new split region.
         let _ = self.raft_group.campaign();
         self.mark_to_be_checked(pending_raft_groups);
 

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -912,6 +912,12 @@ impl Peer {
             return;
         }
 
+        if self.region().get_peers().len() == 3 {
+            // All followers of a region with only 3 peers can start campaign immediately.
+            let _ = self.raft_group.campaign();
+            return;
+        }
+
         let smallest_peer =
             self.region().get_peers().iter().min_by_key(|p| p.get_id()).unwrap().to_owned();
         if smallest_peer.get_id() == self.peer_id() {

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -110,8 +110,6 @@ pub struct PeerStorage {
     pub region: metapb::Region,
     pub raft_state: RaftLocalState,
     pub apply_state: RaftApplyState,
-    // The term of last applied entry. This value may not be correct if the peer is
-    // just split.
     pub applied_index_term: u64,
     pub last_term: u64,
 

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -110,6 +110,8 @@ pub struct PeerStorage {
     pub region: metapb::Region,
     pub raft_state: RaftLocalState,
     pub apply_state: RaftApplyState,
+    // The term of last applied entry. This value may not be correct if the peer is
+    // just split.
     pub applied_index_term: u64,
     pub last_term: u64,
 

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -1062,11 +1062,9 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                 // In this worst case scenario, the new split raft group will not be available
                 // since there is no leader established during one election timeout after the split.
                 if let Some(left) = self.region_peers.get(&region_id) {
-                    if left.is_leader() {
-                        if right.get_peers().len() > 1 {
-                            let _ = new_peer.raft_group.campaign();
-                        }
+                    new_peer.maybe_campaign(left);
 
+                    if left.is_leader() {
                         // Notify pd immediately to let it update the region meta.
                         self.report_split_pd(left, &new_peer);
                     }

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -43,7 +43,7 @@ use raftstore::{Result, Error};
 use kvproto::metapb;
 use util::worker::{Worker, Scheduler};
 use util::transport::SendCh;
-use util::{rocksdb, HashMap, HashSet, FixedRingQueue};
+use util::{rocksdb, HashMap, HashSet, RingQueue};
 use storage::{CF_DEFAULT, CF_LOCK, CF_WRITE};
 
 use super::worker::{SplitCheckRunner, SplitCheckTask, RegionTask, RegionRunner, CompactTask,
@@ -115,7 +115,7 @@ pub struct Store<T, C: 'static> {
     start_time: Timespec,
     is_busy: bool,
 
-    pending_votes: FixedRingQueue<RaftMessage>,
+    pending_votes: RingQueue<RaftMessage>,
 
     region_written_bytes: LocalHistogram,
     region_written_keys: LocalHistogram,
@@ -187,7 +187,7 @@ impl<T, C> Store<T, C> {
             peer_cache: Rc::new(RefCell::new(peer_cache)),
             snap_mgr: mgr,
             raft_metrics: RaftMetrics::default(),
-            pending_votes: FixedRingQueue::with_capacity(PENDING_VOTES_CAP),
+            pending_votes: RingQueue::with_capacity(PENDING_VOTES_CAP),
             tag: tag,
             start_time: time::get_time(),
             is_busy: false,

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -1062,7 +1062,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                 // In this worst case scenario, the new split raft group will not be available
                 // since there is no leader established during one election timeout after the split.
                 if let Some(left) = self.region_peers.get(&region_id) {
-                    new_peer.maybe_campaign(left);
+                    new_peer.maybe_campaign(left, &mut self.pending_raft_groups);
 
                     if left.is_leader() {
                         // Notify pd immediately to let it update the region meta.

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -1066,6 +1066,8 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                 if right.get_peers().into_iter().all(|p| p.get_id() >= my_id) {
                     if right.get_peers().len() > 1 {
                         new_peer.raft_group.raft.term -= 1;
+                        // Use a smaller term so the assigned leader won't have lease.
+                        new_peer.mut_store().applied_index_term -= 1;
                         new_peer.raft_group.raft.become_candidate();
                         new_peer.raft_group.raft.become_leader();
                     }

--- a/src/raftstore/store/worker/apply.rs
+++ b/src/raftstore/store/worker/apply.rs
@@ -656,8 +656,7 @@ impl ApplyDelegate {
                                 new_peer_ids.len()));
         }
 
-        for (index, peer) in new_region.mut_peers().iter_mut().enumerate() {
-            let peer_id = new_peer_ids[index];
+        for (peer, &peer_id) in new_region.mut_peers().iter_mut().zip(new_peer_ids) {
             peer.set_id(peer_id);
         }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -423,21 +423,26 @@ pub fn monitor_threads<S: Into<String>>(_: S) -> io::Result<()> {
 }
 
 /// A simple ring queue with fixed capacity.
-pub struct FixRingQueue<T> {
+pub struct FixedRingQueue<T> {
     buf: VecDeque<T>,
     cap: usize,
 }
 
-impl<T> FixRingQueue<T> {
-    pub fn with_capacity(cap: usize) -> FixRingQueue<T> {
-        FixRingQueue {
+impl<T> FixedRingQueue<T> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.buf.len()
+    }
+
+    pub fn with_capacity(cap: usize) -> FixedRingQueue<T> {
+        FixedRingQueue {
             buf: VecDeque::with_capacity(cap),
             cap: cap,
         }
     }
 
     pub fn push(&mut self, t: T) {
-        if self.buf.len() == self.cap {
+        if self.len() == self.cap {
             self.buf.pop_front();
         }
         self.buf.push_back(t);
@@ -457,7 +462,7 @@ mod tests {
     use std::net::{SocketAddr, AddrParseError};
     use std::time::Duration;
     use std::rc::Rc;
-    use std::f64;
+    use std::{f64, cmp};
     use std::sync::atomic::{AtomicBool, Ordering};
     use super::*;
 
@@ -484,6 +489,26 @@ mod tests {
             let ret: Result<SocketAddr, AddrParseError> = addr.parse();
             assert_eq!(ret.is_ok(), ok);
         }
+    }
+
+    #[test]
+    fn test_fixed_ring_queue() {
+        let mut queue = FixedRingQueue::with_capacity(10);
+        for num in 0..20 {
+            queue.push(num);
+            assert_eq!(queue.len(), cmp::min(num + 1, 10));
+        }
+        assert_eq!(None, queue.swap_remove_front(10));
+        for i in 0..6 {
+            assert_eq!(Some(12 + i), queue.swap_remove_front(2));
+            assert_eq!(queue.len(), 9 - i);
+        }
+        let left: Vec<_> = queue.iter().cloned().collect();
+        assert_eq!(vec![10, 11, 18, 19], left);
+        for _ in 0..4 {
+            queue.swap_remove_front(0).unwrap();
+        }
+        assert_eq!(None, queue.swap_remove_front(0));
     }
 
     #[test]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -423,19 +423,19 @@ pub fn monitor_threads<S: Into<String>>(_: S) -> io::Result<()> {
 }
 
 /// A simple ring queue with fixed capacity.
-pub struct FixedRingQueue<T> {
+pub struct RingQueue<T> {
     buf: VecDeque<T>,
     cap: usize,
 }
 
-impl<T> FixedRingQueue<T> {
+impl<T> RingQueue<T> {
     #[inline]
     fn len(&self) -> usize {
         self.buf.len()
     }
 
-    pub fn with_capacity(cap: usize) -> FixedRingQueue<T> {
-        FixedRingQueue {
+    pub fn with_capacity(cap: usize) -> RingQueue<T> {
+        RingQueue {
             buf: VecDeque::with_capacity(cap),
             cap: cap,
         }
@@ -493,7 +493,7 @@ mod tests {
 
     #[test]
     fn test_fixed_ring_queue() {
-        let mut queue = FixedRingQueue::with_capacity(10);
+        let mut queue = RingQueue::with_capacity(10);
         for num in 0..20 {
             queue.push(num);
             assert_eq!(queue.len(), cmp::min(num + 1, 10));

--- a/tests/raftstore/test_split_region.rs
+++ b/tests/raftstore/test_split_region.rs
@@ -558,7 +558,7 @@ fn test_quick_election_after_split<T: Simulator>(cluster: &mut Cluster<T>) {
     // Calculate the reserved time before a new campaign after split.
     let reserved_time = Duration::from_millis(cluster.cfg.raft_store.raft_base_tick_interval) *
                         cluster.cfg.raft_store.raft_election_timeout_ticks as u32 /
-                        3 * 2;
+                        2;
 
     cluster.run();
     cluster.must_put(b"k1", b"v1");

--- a/tests/raftstore/test_split_region.rs
+++ b/tests/raftstore/test_split_region.rs
@@ -554,7 +554,7 @@ fn test_node_split_stale_epoch() {
 // it would accelerate ticks for the peer of new region after split, so that the peer of new region
 // could start campaign faster. and then this peer may take the leadership earlier.
 // `test_tick_acceleration_after_split` is a helper function for testing this feature.
-fn test_tick_acceleration_after_split<T: Simulator>(cluster: &mut Cluster<T>) {
+fn test_quick_election_after_split<T: Simulator>(cluster: &mut Cluster<T>) {
     // Calculate the reserved time before a new campaign after split.
     let reserved_time = Duration::from_millis(cluster.cfg.raft_store.raft_base_tick_interval) *
                         cluster.cfg.raft_store.accelerate_campaign_reserved_ticks as u32;
@@ -572,22 +572,20 @@ fn test_tick_acceleration_after_split<T: Simulator>(cluster: &mut Cluster<T>) {
 
     // The campaign should always succeeds in the ideal test environment.
     let new_region = cluster.get_region(b"k3");
-    let store_id = old_leader.get_store_id();
     // Ensure the new leader is established for the newly split region, and it shares the
     // same store with the leader of old region.
-    let new_leader = cluster.query_leader(store_id, new_region.get_id());
+    let new_leader = cluster.query_leader(old_leader.get_store_id(), new_region.get_id());
     assert!(new_leader.is_some());
-    assert_eq!(new_leader.unwrap().get_store_id(), store_id);
 }
 
 #[test]
-fn test_node_tick_acceleration_after_split() {
+fn test_node_quick_election_after_split() {
     let mut cluster = new_node_cluster(0, 3);
-    test_tick_acceleration_after_split(&mut cluster);
+    test_quick_election_after_split(&mut cluster);
 }
 
 #[test]
-fn test_server_tick_acceleration_after_split() {
+fn test_server_quick_election_after_split() {
     let mut cluster = new_server_cluster(0, 3);
-    test_tick_acceleration_after_split(&mut cluster);
+    test_quick_election_after_split(&mut cluster);
 }

--- a/tests/raftstore/test_split_region.rs
+++ b/tests/raftstore/test_split_region.rs
@@ -551,9 +551,8 @@ fn test_node_split_stale_epoch() {
 
 
 // For the peer which is the leader of the region before split,
-// it would accelerate ticks for the peer of new region after split, so that the peer of new region
-// could start campaign faster. and then this peer may take the leadership earlier.
-// `test_tick_acceleration_after_split` is a helper function for testing this feature.
+// it should campaigns immediately. and then this peer may take the leadership earlier.
+// `test_quick_election_after_split` is a helper function for testing this feature.
 fn test_quick_election_after_split<T: Simulator>(cluster: &mut Cluster<T>) {
     // Calculate the reserved time before a new campaign after split.
     let reserved_time = Duration::from_millis(cluster.cfg.raft_store.raft_base_tick_interval) *

--- a/tests/raftstore/test_split_region.rs
+++ b/tests/raftstore/test_split_region.rs
@@ -557,7 +557,8 @@ fn test_node_split_stale_epoch() {
 fn test_quick_election_after_split<T: Simulator>(cluster: &mut Cluster<T>) {
     // Calculate the reserved time before a new campaign after split.
     let reserved_time = Duration::from_millis(cluster.cfg.raft_store.raft_base_tick_interval) *
-                        cluster.cfg.raft_store.accelerate_campaign_reserved_ticks as u32;
+                        cluster.cfg.raft_store.raft_election_timeout_ticks as u32 /
+                        3 * 2;
 
     cluster.run();
     cluster.must_put(b"k1", b"v1");

--- a/tests/raftstore/test_tombstone.rs
+++ b/tests/raftstore/test_tombstone.rs
@@ -85,7 +85,11 @@ fn test_tombstone<T: Simulator>(cluster: &mut Cluster<T>) {
     let mut state: RegionLocalState =
         engine_3.get_msg(&keys::region_state_key(r1)).unwrap().unwrap();
     state.set_state(PeerState::Tombstone);
-    assert_eq!(state.write_to_bytes().unwrap(), existing_kvs[1].1);
+    if state.write_to_bytes().unwrap() != existing_kvs[1].1 {
+        let mut existing_state = RegionLocalState::new();
+        existing_state.merge_from_bytes(&existing_kvs[1].1).unwrap();
+        panic!("{:?} != {:?}", state, existing_state);
+    }
 
     // Send a stale raft message to peer (2, 2)
     let mut raft_msg = raft_serverpb::RaftMessage::new();


### PR DESCRIPTION
If leader starts campaign after split immediately, follower may not apply the split yet. But if the follower is ready to apply the split, leader should probably apply the split already, so it should be more efficient to let follower start campaign than leader.

ref #1639 

@siddontang @zhangjinpeng1987 @hhkbp2 PTAL