### PR TITLE
use SSE by default.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#9d9efd30235d702684e598e2f04bd9bb82bb55c8"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#99f4edd601725190acc1aacf76d4509946bad4be"
 dependencies = [
  "gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -558,7 +558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#9d9efd30235d702684e598e2f04bd9bb82bb55c8"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#99f4edd601725190acc1aacf76d4509946bad4be"
 dependencies = [
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "librocksdb_sys 0.1.0 (git+https://github.com/pingcap/rust-rocksdb.git)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ default = []
 dev = ["clippy"]
 static-link = ["rocksdb/static-link"]
 portable = ["rocksdb/portable"]
+sse = ["rocksdb/sse"]
 
 [lib]
 name = "tikv"

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ ifeq ($(ROCKSDB_SYS_PORTABLE),1)
 ENABLE_FEATURES += portable
 endif
 
+ifeq ($(ROCKSDB_SYS_SSE),1)
+ENABLE_FEATURES += sse
+endif
+
 PROJECT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 DEPS_PATH = $(CURDIR)/tmp
@@ -36,7 +40,7 @@ release:
 	cp -f ${CARGO_TARGET_DIR}/release/tikv-ctl ${CARGO_TARGET_DIR}/release/tikv-server ${BIN_PATH}/
 
 static_release:
-	ROCKSDB_SYS_STATIC=1 ROCKSDB_SYS_PORTABLE=1 make release
+	ROCKSDB_SYS_STATIC=1 ROCKSDB_SYS_PORTABLE=1 ROCKSDB_SYS_SSE=1  make release
 
 # unlike test, this target will trace tests and output logs when fail test is detected.
 trace_test:


### PR DESCRIPTION
SSE is supported in Intel and AMD CPU, so we can use it directly.

@iamxy @BusyJay @zhangjinpeng1987 