### PR TITLE
Add RocksDB options for in memory configurations.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#9d9efd30235d702684e598e2f04bd9bb82bb55c8"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#b52deee8acfd2e10fa615608740be4116d101419"
 dependencies = [
  "gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -558,7 +558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#9d9efd30235d702684e598e2f04bd9bb82bb55c8"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#b52deee8acfd2e10fa615608740be4116d101419"
 dependencies = [
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "librocksdb_sys 0.1.0 (git+https://github.com/pingcap/rust-rocksdb.git)",

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -140,11 +140,11 @@ wal-recovery-mode = 2
 
 # The following two fields affect how archived write-ahead logs will be deleted.
 # 1. If both set to 0, logs will be deleted asap and will not get into the archive.
-# 2. If wal-ttl-seconds is 0 and wal-size-limit-mb is not 0,
+# 2. If wal-ttl-seconds is 0 and wal-size-limit is not 0,
 #    WAL files will be checked every 10 min and if total size is greater
-#    then wal-size-limit-mb, they will be deleted starting with the
+#    then wal-size-limit, they will be deleted starting with the
 #    earliest until size_limit is met. All empty files will be deleted.
-# 3. If wal-ttl-seconds is not 0 and wal-size-limit-mb is 0, then
+# 3. If wal-ttl-seconds is not 0 and wal-size-limit is 0, then
 #    WAL files will be checked every wal-ttl-seconds / 2 and those that
 #    are older than wal-ttl-seconds will be deleted.
 # 4. If both are not 0, WAL files will be checked every 10 min and both
@@ -153,7 +153,7 @@ wal-recovery-mode = 2
 # wal-ttl-seconds to a value greater than 0 (like 86400) and backup your db on a regular basis.
 # See https://github.com/facebook/rocksdb/wiki/How-to-persist-in-memory-RocksDB-database
 wal-ttl-seconds = 0
-wal-size-limit-mb = 0
+wal-size-limit = 0
 
 # rocksdb max total wal size
 # max-total-wal-size = "4GB"

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -130,6 +130,31 @@ create-if-missing = true
 # 3 : SkipAnyCorruptedRecords, Recovery after a disaster;
 wal-recovery-mode = 2
 
+# rocksdb write-ahead logs dir path
+# This specifies the absolute dir path for write-ahead logs (WAL).
+# If it is empty, the log files will be in the same dir as data.
+# When you set the path to rocksdb directory in memory like in /dev/shm, you may want to set
+# wal-dir to a directory on a persistent storage.
+# See https://github.com/facebook/rocksdb/wiki/How-to-persist-in-memory-RocksDB-database
+# wal-dir = "/tmp/tikv/store"
+
+# The following two fields affect how archived write-ahead logs will be deleted.
+# 1. If both set to 0, logs will be deleted asap and will not get into the archive.
+# 2. If wal-ttl-seconds is 0 and wal-size-limit-mb is not 0,
+#    WAL files will be checked every 10 min and if total size is greater
+#    then wal-size-limit-mb, they will be deleted starting with the
+#    earliest until size_limit is met. All empty files will be deleted.
+# 3. If wal-ttl-seconds is not 0 and wal-size-limit-mb is 0, then
+#    WAL files will be checked every wal-ttl-seconds / 2 and those that
+#    are older than wal-ttl-seconds will be deleted.
+# 4. If both are not 0, WAL files will be checked every 10 min and both
+#    checks will be performed with ttl being first.
+# When you set the path to rocksdb directory in memory like in /dev/shm, you may want to set
+# wal-ttl-seconds to a value greater than 0 (like 86400) and backup your db on a regular basis.
+# See https://github.com/facebook/rocksdb/wiki/How-to-persist-in-memory-RocksDB-database
+wal-ttl-seconds = 0
+wal-size-limit-mb = 0
+
 # rocksdb max total wal size
 # max-total-wal-size = "4GB"
 

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -152,8 +152,8 @@ wal-recovery-mode = 2
 # When you set the path to rocksdb directory in memory like in /dev/shm, you may want to set
 # wal-ttl-seconds to a value greater than 0 (like 86400) and backup your db on a regular basis.
 # See https://github.com/facebook/rocksdb/wiki/How-to-persist-in-memory-RocksDB-database
-wal-ttl-seconds = 0
-wal-size-limit = 0
+# wal-ttl-seconds = 0
+# wal-size-limit = 0
 
 # rocksdb max total wal size
 # max-total-wal-size = "4GB"

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -65,6 +65,7 @@ use tikv::util::time_monitor::TimeMonitor;
 const RAFTCF_MIN_MEM: u64 = 256 * 1024 * 1024;
 const RAFTCF_MAX_MEM: u64 = 2 * 1024 * 1024 * 1024;
 const KB: u64 = 1024;
+const MB: u64 = KB * 1024;
 const DEFAULT_BLOCK_CACHE_RATIO: &'static [f64] = &[0.4, 0.15, 0.01];
 
 fn sanitize_memory_usage() -> bool {
@@ -282,7 +283,9 @@ fn get_rocksdb_db_option(config: &toml::Value) -> RocksdbOptions {
     let wal_ttl_seconds = get_toml_int(config, "rocksdb.wal-ttl-seconds", Some(0));
     opts.set_wal_ttl_seconds(wal_ttl_seconds as u64);
 
-    let wal_size_limit_mb = get_toml_int(config, "rocksdb.wal-size-limit-mb", Some(0));
+    let wal_size_limit = get_toml_int(config, "rocksdb.wal-size-limit", Some(0));
+    // return size in MB
+    let wal_size_limit_mb = align_to_mb(wal_size_limit as u64) / MB;
     opts.set_wal_size_limit_mb(wal_size_limit_mb as u64);
 
     let max_total_wal_size = get_toml_int(config,

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -276,6 +276,15 @@ fn get_rocksdb_db_option(config: &toml::Value) -> RocksdbOptions {
     let wal_recovery_mode = util::config::parse_rocksdb_wal_recovery_mode(rmode).unwrap();
     opts.set_wal_recovery_mode(wal_recovery_mode);
 
+    let wal_dir = get_toml_string(config, "rocksdb.wal-dir", Some("".to_owned()));
+    if !wal_dir.is_empty() { opts.set_wal_dir(&wal_dir) };
+
+    let wal_ttl_seconds = get_toml_int(config, "rocksdb.wal-ttl-seconds", Some(0));
+    opts.set_wal_ttl_seconds(wal_ttl_seconds as u64);
+
+    let wal_size_limit_mb = get_toml_int(config, "rocksdb.wal-size-limit-mb", Some(0));
+    opts.set_wal_size_limit_mb(wal_size_limit_mb as u64);
+
     let max_total_wal_size = get_toml_int(config,
                                           "rocksdb.max-total-wal-size",
                                           Some(4 * 1024 * 1024 * 1024));

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -278,7 +278,9 @@ fn get_rocksdb_db_option(config: &toml::Value) -> RocksdbOptions {
     opts.set_wal_recovery_mode(wal_recovery_mode);
 
     let wal_dir = get_toml_string(config, "rocksdb.wal-dir", Some("".to_owned()));
-    if !wal_dir.is_empty() { opts.set_wal_dir(&wal_dir) };
+    if !wal_dir.is_empty() {
+        opts.set_wal_dir(&wal_dir)
+    };
 
     let wal_ttl_seconds = get_toml_int(config, "rocksdb.wal-ttl-seconds", Some(0));
     opts.set_wal_ttl_seconds(wal_ttl_seconds as u64);


### PR DESCRIPTION
When you set the path to rocksdb directory in memory like in /dev/shm,
you need to set the wal_dir and WAL_ttl_seconds options if you want to
recover your in-memory RocksDB database after a machine reboot.

See: https://github.com/facebook/rocksdb/wiki/How-to-persist-in-memory-RocksDB-database

This PR depends on https://github.com/pingcap/rust-rocksdb/pull/29 too.