### PR TITLE
raftstore: clean callback when peer is destroyed

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -63,6 +63,14 @@ struct ReadIndexRequest {
     renew_lease_time: Timespec,
 }
 
+impl Drop for ReadIndexRequest {
+    fn drop(&mut self) {
+        if !self.cmds.is_empty() {
+            panic!("callback of index read {} is leak.", self.uuid);
+        }
+    }
+}
+
 #[derive(Default)]
 struct ReadIndexQueue {
     reads: VecDeque<ReadIndexRequest>,
@@ -71,8 +79,8 @@ struct ReadIndexQueue {
 
 impl ReadIndexQueue {
     fn clear_uncommitted(&mut self, tag: &str, term: u64) {
-        for read in self.reads.drain(self.ready_cnt..) {
-            for (req, cb) in read.cmds {
+        for mut read in self.reads.drain(self.ready_cnt..) {
+            for (req, cb) in read.cmds.drain(..) {
                 let uuid = util::get_uuid_from_req(&req).unwrap();
                 apply::notify_stale_req(tag, term, uuid, cb);
             }
@@ -362,6 +370,14 @@ impl Peer {
                 error!("{} failed to schedule clear data task: {:?}", self.tag, e);
             }
         }
+
+        for mut read in self.pending_reads.reads.drain(..) {
+            for (req, cb) in read.cmds.drain(..) {
+                let uuid = util::get_uuid_from_req(&req).unwrap();
+                apply::notify_req_region_removed(region.get_id(), self.peer.get_id(), uuid, cb);
+            }
+        }
+
         self.coprocessor_host.shutdown();
         info!("{} destroy itself, takes {:?}", self.tag, t.elapsed());
 
@@ -739,9 +755,9 @@ impl Peer {
         let mut propose_time = None;
         if self.ready_to_handle_read() {
             for state in &ready.read_states {
-                let read = self.pending_reads.reads.pop_front().unwrap();
+                let mut read = self.pending_reads.reads.pop_front().unwrap();
                 assert_eq!(state.request_ctx.as_slice(), read.uuid.as_bytes());
-                for (req, cb) in read.cmds {
+                for (req, cb) in read.cmds.drain(..) {
                     // TODO: we should add test case that a split happens before pending
                     // read-index is handled. To do this we need to control async-apply
                     // procedure precisely.
@@ -807,8 +823,8 @@ impl Peer {
 
         if self.pending_reads.ready_cnt > 0 && self.ready_to_handle_read() {
             for _ in 0..self.pending_reads.ready_cnt {
-                let read = self.pending_reads.reads.pop_front().unwrap();
-                for (req, cb) in read.cmds {
+                let mut read = self.pending_reads.reads.pop_front().unwrap();
+                for (req, cb) in read.cmds.drain(..) {
                     self.handle_read(req, cb);
                 }
             }

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -760,12 +760,10 @@ impl Peer {
 
         // Note that only after handle read_states can we identify what requests are
         // actually stale.
-        if let Some(ref ss) = ready.ss {
-            if ss.raft_state != StateRole::Leader {
-                let term = self.term();
-                // all uncommitted reads will be dropped silently in raft.
-                self.pending_reads.clear_uncommitted(&self.tag, term);
-            }
+        if ready.ss.is_some() {
+            let term = self.term();
+            // all uncommitted reads will be dropped silently in raft.
+            self.pending_reads.clear_uncommitted(&self.tag, term);
         }
 
         if let Some(Either::Right(_)) = self.leader_lease_expired_time {

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -1319,6 +1319,13 @@ impl Peer {
     pub fn term(&self) -> u64 {
         self.raft_group.raft.term
     }
+
+    pub fn stop(&mut self) {
+        self.mut_store().cancel_applying_snap();
+        for mut read in self.pending_reads.reads.drain(..) {
+            read.cmds.clear();
+        }
+    }
 }
 
 pub fn check_epoch(region: &metapb::Region, req: &RaftCmdRequest) -> Result<()> {

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -421,7 +421,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
 
         // Applying snapshot may take an unexpected long time.
         for peer in self.region_peers.values_mut() {
-            peer.mut_store().cancel_applying_snap();
+            peer.stop();
         }
 
         // Wait all workers finish.

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -329,7 +329,7 @@ impl<T: FnOnce()> Drop for DeferContext<T> {
 }
 
 /// Represents a value of one of two possible types (a more generic Result.)
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Either<L, R> {
     Left(L),
     Right(R),

--- a/tests/raftstore/test_lease_read.rs
+++ b/tests/raftstore/test_lease_read.rs
@@ -386,6 +386,8 @@ fn test_server_lease_unsafe_during_leader_transfers() {
     test_lease_unsafe_during_leader_transfers(&mut cluster);
 }
 
+/// test whether the read index callback will be handled when a region is destroyed.
+/// If it's not handled properly, it will cause dead lock in transaction scheduler.
 #[test]
 fn test_node_callback_when_destroyed() {
     let count = 3;


### PR DESCRIPTION
Callback of read index isn't cleared when the peer is destroyed, which will lead to dead lock.

@siddontang @zhangjinpeng1987 @hhkbp2 PTAL
