### PR TITLE
check_commit_tso:return error when commit_ts < start_tso

### DIFF
--- a/src/server/kv.rs
+++ b/src/server/kv.rs
@@ -633,6 +633,18 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_error_illegal_tso() {
+        let err = StorageError::from(txn::Error::InvalidTxnTso {
+            start_ts: 5,
+            commit_ts: 4,
+        });
+        let key_error = extract_key_error(&err);
+        assert!(key_error.has_abort());
+        assert!(!key_error.has_locked());
+        assert!(!key_error.has_retryable());
+    }
+
+    #[test]
     fn test_cleanup_done_ok() {
         let resp = build_resp(Ok(()), StoreHandler::cmd_cleanup_done);
         assert_eq!(MessageType::CmdCleanup, resp.get_field_type());

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -55,6 +55,12 @@ quick_error! {
             cause(err)
             description(err.description())
         }
+        InvalidTxnTso {start_ts: u64, commit_ts: u64} {
+            description("Invalid transaction tso")
+            display("Invalid transaction tso with start_ts:{},commit_ts:{}",
+                        start_ts,
+                        commit_ts)
+        }
     }
 }
 

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -479,6 +479,12 @@ fn process_write_impl(cid: u64,
             }
         }
         Command::Commit { ref keys, lock_ts, commit_ts, .. } => {
+            if lock_ts > commit_ts {
+                return Err(Error::InvalidTxnTso {
+                    start_ts: lock_ts,
+                    commit_ts: commit_ts,
+                });
+            }
             let mut txn = MvccTxn::new(snapshot, &mut statistics, lock_ts, None);
             for k in keys {
                 try!(txn.commit(&k, commit_ts));
@@ -504,6 +510,14 @@ fn process_write_impl(cid: u64,
             (pr, txn.modifies())
         }
         Command::ResolveLock { ref ctx, start_ts, commit_ts, ref mut scan_key, ref keys } => {
+            if let Some(cts) = commit_ts {
+                if cts < start_ts {
+                    return Err(Error::InvalidTxnTso {
+                        start_ts: start_ts,
+                        commit_ts: cts,
+                    });
+                }
+            }
             let mut scan_key = scan_key.take();
             let mut txn = MvccTxn::new(snapshot, &mut statistics, start_ts, None);
             for k in keys {

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -479,7 +479,7 @@ fn process_write_impl(cid: u64,
             }
         }
         Command::Commit { ref keys, lock_ts, commit_ts, .. } => {
-            if lock_ts > commit_ts {
+            if commit_ts <= lock_ts {
                 return Err(Error::InvalidTxnTso {
                     start_ts: lock_ts,
                     commit_ts: commit_ts,
@@ -511,7 +511,7 @@ fn process_write_impl(cid: u64,
         }
         Command::ResolveLock { ref ctx, start_ts, commit_ts, ref mut scan_key, ref keys } => {
             if let Some(cts) = commit_ts {
-                if cts < start_ts {
+                if cts <= start_ts {
                     return Err(Error::InvalidTxnTso {
                         start_ts: start_ts,
                         commit_ts: cts,

--- a/tests/storage/assert_storage.rs
+++ b/tests/storage/assert_storage.rs
@@ -291,6 +291,22 @@ impl AssertionStorage {
         self.store.resolve_lock(self.ctx.clone(), start_ts, commit_ts).unwrap();
     }
 
+    pub fn resolve_lock_with_illegal_tso(&self, sts: u64, cmt_ts: Option<u64>) {
+        let resp = self.store.resolve_lock(self.ctx.clone(), sts, cmt_ts);
+        assert!(resp.is_err());
+        let err = resp.unwrap_err();
+        match err {
+            storage::Error::Txn(txn::Error::InvalidTxnTso { start_ts, commit_ts }) => {
+                assert_eq!(sts, start_ts);
+                assert_eq!(cmt_ts.unwrap(), commit_ts);
+            }
+            _ => {
+                panic!("expect invalid tso error, but got {:?}", err);
+            }
+        }
+    }
+
+
     pub fn gc_ok(&self, safe_point: u64) {
         self.store.gc(self.ctx.clone(), safe_point).unwrap();
     }

--- a/tests/storage/test_storage.rs
+++ b/tests/storage/test_storage.rs
@@ -319,6 +319,19 @@ fn test_txn_store_resolve_lock2() {
 }
 
 #[test]
+fn test_txn_store_commit_illegal_tso() {
+    let store = AssertionStorage::default();
+    let commit_ts = 4;
+    let start_ts = 5;
+    store.prewrite_ok(vec![Mutation::Put((make_key(b"primary"), b"p-5".to_vec())),
+                           Mutation::Put((make_key(b"secondary"), b"s-5".to_vec()))],
+                      b"primary",
+                      start_ts);
+
+    store.commit_with_illegal_tso(vec![b"primary"], start_ts, commit_ts);
+}
+
+#[test]
 fn test_txn_store_gc() {
     let key = "k";
     let store = AssertionStorage::default();

--- a/tests/storage/test_storage.rs
+++ b/tests/storage/test_storage.rs
@@ -332,6 +332,18 @@ fn test_txn_store_commit_illegal_tso() {
 }
 
 #[test]
+fn test_store_resolve_with_illegal_tso() {
+    let store = AssertionStorage::default();
+    let commit_ts = Some(4);
+    let start_ts = 5;
+    store.prewrite_ok(vec![Mutation::Put((make_key(b"primary"), b"p-5".to_vec())),
+                           Mutation::Put((make_key(b"secondary"), b"s-5".to_vec()))],
+                      b"primary",
+                      start_ts);
+    store.resolve_lock_with_illegal_tso(start_ts, commit_ts);
+}
+
+#[test]
 fn test_txn_store_gc() {
     let key = "k";
     let store = AssertionStorage::default();


### PR DESCRIPTION
Hi,all,
    This PR is used to fix [issue_1688] (https://github.com/pingcap/tikv/issues/1688) and would check tso in commit for transaction. @disksing @zhangjinpeng1987 PTAL