### PR TITLE
raftstore: make SnapManager not sync

### DIFF
--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -647,7 +647,7 @@ fn build_raftkv(config: &toml::Value,
     let mut snap_path = path.clone();
     snap_path.push("snap");
     let snap_path = snap_path.to_str().unwrap().to_owned();
-    let snap_mgr = store::new_snap_mgr(snap_path, Some(node.get_sendch()));
+    let snap_mgr = SnapManager::new(snap_path, Some(node.get_sendch()));
 
     node.start(event_loop, engine.clone(), trans, snap_mgr.clone()).unwrap();
     let router = ServerRaftStoreRouter::new(node.get_sendch(), node.id());

--- a/src/raftstore/store/mod.rs
+++ b/src/raftstore/store/mod.rs
@@ -38,5 +38,5 @@ pub use self::bootstrap::{bootstrap_store, bootstrap_region, write_region, clear
 pub use self::engine::{Peekable, Iterable, Mutable};
 pub use self::peer_storage::{PeerStorage, do_snapshot, SnapState, RAFT_INIT_LOG_TERM,
                              RAFT_INIT_LOG_INDEX};
-pub use self::snap::{SnapKey, Snapshot, ApplyContext, SnapEntry, SnapManager, new_snap_mgr,
-                     check_abort, copy_snapshot};
+pub use self::snap::{SnapKey, Snapshot, ApplyContext, SnapEntry, SnapManager, check_abort,
+                     copy_snapshot};

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -25,7 +25,6 @@ use kvproto::metapb::{self, Region};
 use kvproto::eraftpb::{Entry, Snapshot, ConfState, HardState};
 use kvproto::raft_serverpb::{RaftSnapshotData, RaftLocalState, RegionLocalState, RaftApplyState,
                              PeerState};
-use util::HandyRwLock;
 use util::worker::Scheduler;
 use util::rocksdb;
 use raft::{self, Storage, RaftState, StorageError, Error as RaftError, Ready};
@@ -862,8 +861,8 @@ pub fn do_snapshot(mgr: SnapManager, snap: &DbSnapshot, region_id: u64) -> raft:
 
     let key = SnapKey::new(region_id, term, idx);
 
-    mgr.wl().register(key.clone(), SnapEntry::Generating);
-    defer!(mgr.wl().deregister(&key, &SnapEntry::Generating));
+    mgr.register(key.clone(), SnapEntry::Generating);
+    defer!(mgr.deregister(&key, &SnapEntry::Generating));
 
     let state: RegionLocalState = try!(snap.get_msg(&keys::region_state_key(key.region_id))
         .and_then(|res| {
@@ -890,7 +889,7 @@ pub fn do_snapshot(mgr: SnapManager, snap: &DbSnapshot, region_id: u64) -> raft:
 
     snapshot.mut_metadata().set_conf_state(conf_state);
 
-    let mut s = try!(mgr.rl().get_snapshot_to_build(&key));
+    let mut s = try!(mgr.get_snapshot_to_build(&key));
 
     // Set snapshot data.
     let mut snap_data = RaftSnapshotData::new();
@@ -973,11 +972,10 @@ mod test {
     use raft::{StorageError, Error as RaftError};
     use tempdir::*;
     use protobuf;
-    use raftstore::store::{bootstrap, new_snap_mgr, SnapKey, copy_snapshot};
+    use raftstore::store::{bootstrap, SnapKey, copy_snapshot};
     use raftstore::store::worker::RegionRunner;
     use raftstore::store::worker::RegionTask;
     use util::worker::{Worker, Scheduler};
-    use util::HandyRwLock;
     use util::rocksdb::new_engine;
     use storage::{CF_DEFAULT, CF_RAFT};
     use kvproto::eraftpb::HardState;
@@ -1125,7 +1123,7 @@ mod test {
 
         let td = TempDir::new("tikv-store-test").unwrap();
         let snap_dir = TempDir::new("snap_dir").unwrap();
-        let mgr = new_snap_mgr(snap_dir.path().to_str().unwrap(), None);
+        let mgr = SnapManager::new(snap_dir.path().to_str().unwrap(), None);
         let mut worker = Worker::new("snap_manager");
         let sched = worker.scheduler();
         let mut s = new_storage_from_ents(sched, &td, &ents);
@@ -1275,7 +1273,7 @@ mod test {
 
         let td1 = TempDir::new("tikv-store-test").unwrap();
         let snap_dir = TempDir::new("snap").unwrap();
-        let mgr = new_snap_mgr(snap_dir.path().to_str().unwrap(), None);
+        let mgr = SnapManager::new(snap_dir.path().to_str().unwrap(), None);
         let mut worker = Worker::new("snap_manager");
         let sched = worker.scheduler();
         let s1 = new_storage_from_ents(sched.clone(), &td1, &ents);
@@ -1290,8 +1288,8 @@ mod test {
         assert_eq!(s1.truncated_term(), 3);
 
         let key = SnapKey::from_snap(&snap1).unwrap();
-        let from = mgr.rl().get_snapshot_for_sending(&key).unwrap();
-        let to = mgr.rl().get_snapshot_for_receiving(&key, b"").unwrap();
+        let from = mgr.get_snapshot_for_sending(&key).unwrap();
+        let to = mgr.get_snapshot_for_receiving(&key, b"").unwrap();
         copy_snapshot(from, to).unwrap();
 
         let td2 = TempDir::new("tikv-store-test").unwrap();

--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -632,27 +632,45 @@ pub struct SnapStats {
     pub receiving_count: usize,
 }
 
-/// `SnapManagerCore` trace all current processing snapshots.
-pub struct SnapManagerCore {
-    // directory to store snapfile.
+struct SnapManagerCore {
     base: String,
     registry: HashMap<SnapKey, Vec<SnapEntry>>,
-    ch: Option<SendCh<Msg>>,
+    // put snap_size under core so we don't need to worry about deadlock.
     snap_size: Arc<RwLock<u64>>,
 }
 
-impl SnapManagerCore {
-    pub fn new<T: Into<String>>(path: T, ch: Option<SendCh<Msg>>) -> SnapManagerCore {
-        SnapManagerCore {
-            base: path.into(),
-            registry: map![],
+fn notify_stats(ch: Option<&SendCh<Msg>>) {
+    if let Some(ch) = ch {
+        if let Err(e) = ch.try_send(Msg::SnapshotStats) {
+            error!("notify snapshot stats failed {:?}", e)
+        }
+    }
+}
+
+/// `SnapManagerCore` trace all current processing snapshots.
+#[derive(Clone)]
+pub struct SnapManager {
+    // directory to store snapfile.
+    core: Arc<RwLock<SnapManagerCore>>,
+    ch: Option<SendCh<Msg>>,
+}
+
+impl SnapManager {
+    pub fn new<T: Into<String>>(path: T, ch: Option<SendCh<Msg>>) -> SnapManager {
+        SnapManager {
+            core: Arc::new(RwLock::new(SnapManagerCore {
+                base: path.into(),
+                registry: map![],
+                snap_size: Arc::new(RwLock::new(0)),
+            })),
             ch: ch,
-            snap_size: Arc::new(RwLock::new(0)),
         }
     }
 
     pub fn init(&self) -> io::Result<()> {
-        let path = Path::new(&self.base);
+        // Use write lock so only one thread initialize the directory at a time.
+        let core = self.core.wl();
+        let path = Path::new(&core.base);
         if !path.exists() {
             try!(fs::create_dir_all(path));
             return Ok(());
@@ -661,7 +679,7 @@ impl SnapManagerCore {
             return Err(io::Error::new(ErrorKind::Other,
                                       format!("{} should be a directory", path.display())));
         }
-        let mut size = self.snap_size.wl();
+        let mut size = core.snap_size.wl();
         for f in try!(fs::read_dir(path)) {
             let p = try!(f);
             if try!(p.file_type()).is_file() {
@@ -678,12 +696,13 @@ impl SnapManagerCore {
     }
 
     pub fn list_snap(&self) -> io::Result<Vec<(SnapKey, bool)>> {
-        let path = Path::new(&self.base);
+        let core = self.core.rl();
+        let path = Path::new(&core.base);
         let read_dir = try!(fs::read_dir(path));
         Ok(read_dir.filter_map(|p| {
                 let p = match p {
                     Err(e) => {
-                        error!("failed to list content of {}: {:?}", self.base, e);
+                        error!("failed to list content of {}: {:?}", core.base, e);
                         return None;
                     }
                     Ok(p) => p,
@@ -717,16 +736,18 @@ impl SnapManagerCore {
 
     #[inline]
     pub fn has_registered(&self, key: &SnapKey) -> bool {
-        self.registry.contains_key(key)
+        self.core.rl().registry.contains_key(key)
     }
 
     pub fn get_snapshot_to_build(&self, key: &SnapKey) -> io::Result<Box<Snapshot>> {
-        let f = try!(v1::Snap::new_for_writing(&self.base, self.snap_size.clone(), true, key));
+        let core = self.core.rl();
+        let f = try!(v1::Snap::new_for_writing(&core.base, core.snap_size.clone(), true, key));
         Ok(Box::new(f))
     }
 
     pub fn get_snapshot_for_sending(&self, key: &SnapKey) -> io::Result<Box<Snapshot>> {
-        let reader = try!(v1::Snap::new_for_reading(&self.base, self.snap_size.clone(), true, key));
+        let core = self.core.rl();
+        let reader = try!(v1::Snap::new_for_reading(&core.base, core.snap_size.clone(), true, key));
         Ok(Box::new(reader))
     }
 
@@ -734,25 +755,31 @@ impl SnapManagerCore {
                                       key: &SnapKey,
                                       _data: &[u8])
                                       -> io::Result<Box<Snapshot>> {
-        let f = try!(v1::Snap::new_for_writing(&self.base, self.snap_size.clone(), false, key));
+        let core = self.core.rl();
+        let f = try!(v1::Snap::new_for_writing(&core.base, core.snap_size.clone(), false, key));
         Ok(Box::new(f))
     }
 
     pub fn get_snapshot_for_applying(&self, key: &SnapKey) -> io::Result<Box<Snapshot>> {
-        let f = try!(v1::Snap::new_for_reading(&self.base, self.snap_size.clone(), false, key));
+        let core = self.core.rl();
+        let f = try!(v1::Snap::new_for_reading(&core.base, core.snap_size.clone(), false, key));
         Ok(Box::new(f))
     }
 
     /// Get the approximate size of snap file exists in snap directory.
     ///
     /// Return value is not guaranteed to be accurate.
+    #[allow(let_and_return)]
     pub fn get_total_snap_size(&self) -> u64 {
-        *self.snap_size.rl()
+        let core = self.core.rl();
+        let size = *core.snap_size.rl();
+        size
     }
 
-    pub fn register(&mut self, key: SnapKey, entry: SnapEntry) {
+    pub fn register(&self, key: SnapKey, entry: SnapEntry) {
         debug!("register [key: {}, entry: {:?}]", key, entry);
-        match self.registry.entry(key) {
+        let mut core = self.core.wl();
+        match core.registry.entry(key) {
             Entry::Occupied(mut e) => {
                 if e.get().contains(&entry) {
                     warn!("{} is registered more than 1 time!!!", e.key());
@@ -765,41 +792,35 @@ impl SnapManagerCore {
             }
         }
 
-        self.notify_stats();
+        notify_stats(self.ch.as_ref());
     }
 
-    pub fn deregister(&mut self, key: &SnapKey, entry: &SnapEntry) {
+    pub fn deregister(&self, key: &SnapKey, entry: &SnapEntry) {
         debug!("deregister [key: {}, entry: {:?}]", key, entry);
         let mut need_clean = false;
         let mut handled = false;
-        if let Some(e) = self.registry.get_mut(key) {
+        let mut core = self.core.wl();
+        if let Some(e) = core.registry.get_mut(key) {
             let last_len = e.len();
             e.retain(|e| e != entry);
             need_clean = e.is_empty();
             handled = last_len > e.len();
         }
         if need_clean {
-            self.registry.remove(key);
+            core.registry.remove(key);
         }
         if handled {
-            self.notify_stats();
+            notify_stats(self.ch.as_ref());
             return;
         }
         warn!("stale deregister key: {} {:?}", key, entry);
     }
 
-    fn notify_stats(&self) {
-        if let Some(ref ch) = self.ch {
-            if let Err(e) = ch.try_send(Msg::SnapshotStats) {
-                error!("notify snapshot stats failed {:?}", e)
-            }
-        }
-    }
-
     pub fn stats(&self) -> SnapStats {
+        let core = self.core.rl();
         // send_count, generating_count, receiving_count, applying_count
         let (mut sending_cnt, mut receiving_cnt) = (0, 0);
-        for v in self.registry.values() {
+        for v in core.registry.values() {
             let (mut is_sending, mut is_receiving) = (false, false);
             for s in v {
                 match *s {
@@ -822,12 +843,6 @@ impl SnapManagerCore {
     }
 }
 
-pub type SnapManager = Arc<RwLock<SnapManagerCore>>;
-
-pub fn new_snap_mgr<T: Into<String>>(path: T, ch: Option<SendCh<Msg>>) -> SnapManager {
-    Arc::new(RwLock::new(SnapManagerCore::new(path, ch)))
-}
-
 #[cfg(test)]
 mod test {
     use std::path::Path;
@@ -837,8 +852,7 @@ mod test {
 
     use tempdir::TempDir;
 
-    use util::HandyRwLock;
-    use super::{SnapKey, Snapshot, new_snap_mgr};
+    use super::*;
     use super::v1::{Snap, CRC32_BYTES_COUNT};
 
     #[test]
@@ -849,15 +863,15 @@ mod test {
         let path1 = path.path().to_str().unwrap().to_owned() + "/snap1";
         let p = Path::new(&path1);
         assert!(!p.exists());
-        let mut mgr = new_snap_mgr(path1.clone(), None);
-        mgr.wl().init().unwrap();
+        let mut mgr = SnapManager::new(path1.clone(), None);
+        mgr.init().unwrap();
         assert!(p.exists());
 
         // if target is a file, an error should be returned.
         let path2 = path.path().to_str().unwrap().to_owned() + "/snap2";
         File::create(&path2).unwrap();
-        mgr = new_snap_mgr(path2, None);
-        assert!(mgr.wl().init().is_err());
+        mgr = SnapManager::new(path2, None);
+        assert!(mgr.init().is_err());
 
         // if temporary files exist, they should be deleted.
         let path3 = path.path().to_str().unwrap().to_owned() + "/snap3";
@@ -874,8 +888,8 @@ mod test {
         assert!(!f2.exists());
         assert!(f3.exists());
         assert!(f4.exists());
-        mgr = new_snap_mgr(path3, None);
-        mgr.wl().init().unwrap();
+        mgr = SnapManager::new(path3, None);
+        mgr.init().unwrap();
         assert!(!f1.exists());
         assert!(!f2.exists());
         assert!(f3.exists());
@@ -886,9 +900,9 @@ mod test {
     fn test_snap_size() {
         let path = TempDir::new("test-snap-mgr").unwrap();
         let path_str = path.path().to_str().unwrap();
-        let mut mgr = new_snap_mgr(path_str, None);
-        mgr.wl().init().unwrap();
-        assert_eq!(mgr.rl().get_total_snap_size(), 0);
+        let mut mgr = SnapManager::new(path_str, None);
+        mgr.init().unwrap();
+        assert_eq!(mgr.get_total_snap_size(), 0);
 
         let key1 = SnapKey::new(1, 1, 1);
         let test_data = b"test_data";
@@ -906,14 +920,14 @@ mod test {
         f4.write_all(test_data).unwrap();
         f4.save_with_checksum().unwrap();
 
-        mgr = new_snap_mgr(path_str, None);
-        mgr.wl().init().unwrap();
+        mgr = SnapManager::new(path_str, None);
+        mgr.init().unwrap();
         // temporary file should not be count in snap size.
-        assert_eq!(mgr.rl().get_total_snap_size(), exp_len * 2);
+        assert_eq!(mgr.get_total_snap_size(), exp_len * 2);
 
-        mgr.rl().get_snapshot_for_sending(&key2).unwrap().delete();
-        assert_eq!(mgr.rl().get_total_snap_size(), exp_len);
-        mgr.rl().get_snapshot_for_applying(&key2).unwrap().delete();
-        assert_eq!(mgr.rl().get_total_snap_size(), 0);
+        mgr.get_snapshot_for_sending(&key2).unwrap().delete();
+        assert_eq!(mgr.get_total_snap_size(), exp_len);
+        mgr.get_snapshot_for_applying(&key2).unwrap().delete();
+        assert_eq!(mgr.get_total_snap_size(), 0);
     }
 }

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -33,7 +33,7 @@ use kvproto::raft_serverpb::{RaftMessage, RaftSnapshotData, RaftTruncatedState, 
                              PeerState};
 use kvproto::eraftpb::{ConfChangeType, MessageType};
 use kvproto::pdpb::StoreStats;
-use util::{HandyRwLock, SlowTimer, duration_to_sec, escape};
+use util::{SlowTimer, duration_to_sec, escape};
 use pd::PdClient;
 use kvproto::raft_cmdpb::{AdminCmdType, AdminRequest, StatusCmdType, StatusResponse,
                           RaftCmdRequest, RaftCmdResponse};
@@ -372,7 +372,7 @@ impl<T, C> Store<T, C> {
 
 impl<T: Transport, C: PdClient> Store<T, C> {
     pub fn run(&mut self, event_loop: &mut EventLoop<Self>) -> Result<()> {
-        try!(self.snap_mgr.wl().init());
+        try!(self.snap_mgr.init());
 
         self.register_raft_base_tick(event_loop);
         self.register_raft_gc_log_tick(event_loop);
@@ -1548,7 +1548,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         stats.set_capacity(capacity);
 
         let mut used_size = flush_engine_properties_and_get_used_size(self.engine.clone());
-        used_size += self.snap_mgr.rl().get_total_snap_size();
+        used_size += self.snap_mgr.get_total_snap_size();
 
         let mut available = if capacity > used_size {
             capacity - used_size
@@ -1567,7 +1567,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         stats.set_available(available);
         stats.set_region_count(self.region_peers.len() as u32);
 
-        let snap_stats = self.snap_mgr.rl().stats();
+        let snap_stats = self.snap_mgr.stats();
         stats.set_sending_snap_count(snap_stats.sending_count as u32);
         stats.set_receiving_snap_count(snap_stats.receiving_count as u32);
 
@@ -1620,7 +1620,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
     }
 
     fn handle_snap_mgr_gc(&mut self) -> Result<()> {
-        let mut snap_keys = try!(self.snap_mgr.wl().list_snap());
+        let mut snap_keys = try!(self.snap_mgr.list_snap());
         if snap_keys.is_empty() {
             return Ok(());
         }
@@ -1628,7 +1628,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         let (mut last_region_id, mut compacted_idx, mut compacted_term) = (0, u64::MAX, u64::MAX);
         let mut is_applying_snap = false;
         for (key, is_sending) in snap_keys {
-            if self.snap_mgr.rl().has_registered(&key) {
+            if self.snap_mgr.has_registered(&key) {
                 continue;
             }
             if last_region_id != key.region_id {
@@ -1650,7 +1650,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             }
 
             if is_sending {
-                let s = try!(self.snap_mgr.rl().get_snapshot_for_sending(&key));
+                let s = try!(self.snap_mgr.get_snapshot_for_sending(&key));
                 if key.term < compacted_term || key.idx < compacted_idx {
                     info!("[region {}] snap file {} has been compacted, delete.",
                           key.region_id,
@@ -1672,7 +1672,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                 info!("[region {}] snap file {} has been applied, delete.",
                       key.region_id,
                       key);
-                let a = try!(self.snap_mgr.rl().get_snapshot_for_applying(&key));
+                let a = try!(self.snap_mgr.get_snapshot_for_applying(&key));
                 a.delete();
             }
         }

--- a/src/raftstore/store/worker/region.rs
+++ b/src/raftstore/store/worker/region.rs
@@ -24,7 +24,7 @@ use kvproto::raft_serverpb::{RaftApplyState, RegionLocalState, PeerState};
 use kvproto::eraftpb::Snapshot as RaftSnapshot;
 
 use util::worker::Runnable;
-use util::{escape, HandyRwLock, rocksdb};
+use util::{escape, rocksdb};
 use raftstore::store::engine::{Mutable, Snapshot, Iterable, IterOption};
 use raftstore::store::peer_storage::{JOB_STATUS_FINISHED, JOB_STATUS_CANCELLED, JOB_STATUS_FAILED,
                                      JOB_STATUS_CANCELLING, JOB_STATUS_PENDING, JOB_STATUS_RUNNING};
@@ -194,10 +194,10 @@ impl Runner {
         let term = apply_state.get_truncated_state().get_term();
         let idx = apply_state.get_truncated_state().get_index();
         let snap_key = SnapKey::new(region_id, term, idx);
-        let mut s = box_try!(self.mgr.rl().get_snapshot_for_applying(&snap_key));
-        self.mgr.wl().register(snap_key.clone(), SnapEntry::Applying);
+        let mut s = box_try!(self.mgr.get_snapshot_for_applying(&snap_key));
+        self.mgr.register(snap_key.clone(), SnapEntry::Applying);
         defer!({
-            self.mgr.wl().deregister(&snap_key, &SnapEntry::Applying);
+            self.mgr.deregister(&snap_key, &SnapEntry::Applying);
         });
         if !s.exists() {
             return Err(box_err!("missing snapshot file {}", s.path()));

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -658,7 +658,7 @@ mod tests {
     use kvproto::msgpb::{Message, MessageType};
     use kvproto::raft_serverpb::RaftMessage;
     use raftstore::Result as RaftStoreResult;
-    use raftstore::store::{self, Msg as StoreMsg};
+    use raftstore::store::Msg as StoreMsg;
 
     struct MockResolver {
         addr: SocketAddr,
@@ -732,7 +732,7 @@ mod tests {
                                      storage,
                                      ch,
                                      resolver,
-                                     store::new_snap_mgr("", None))
+                                     SnapManager::new("", None))
             .unwrap();
 
         for i in 0..10 {

--- a/src/server/snap.rs
+++ b/src/server/snap.rs
@@ -27,7 +27,7 @@ use raftstore::store::{SnapManager, SnapKey, SnapEntry, Snapshot};
 use util::worker::Runnable;
 use util::codec::rpc;
 use util::buf::PipeBuffer;
-use util::{HandyRwLock, HashMap};
+use util::HashMap;
 use util::transport::SendCh;
 
 use super::metrics::*;
@@ -84,10 +84,10 @@ fn send_snap(mgr: SnapManager, addr: SocketAddr, data: ConnData) -> Result<()> {
 
     let snap = data.msg.get_raft().get_message().get_snapshot();
     let key = try!(SnapKey::from_snap(&snap));
-    mgr.wl().register(key.clone(), SnapEntry::Sending);
-    let mut s = box_try!(mgr.rl().get_snapshot_for_sending(&key));
+    mgr.register(key.clone(), SnapEntry::Sending);
+    let mut s = box_try!(mgr.get_snapshot_for_sending(&key));
     defer!({
-        mgr.wl().deregister(&key, &SnapEntry::Sending);
+        mgr.deregister(&key, &SnapEntry::Sending);
     });
     if !s.exists() {
         return Err(box_err!("missing snap file: {:?}", s.path()));
@@ -148,8 +148,7 @@ impl<R: RaftStoreRouter + 'static> Runnable<Task> for Runner<R> {
                 SNAP_TASK_COUNTER.with_label_values(&["register"]).inc();
                 let mgr = self.snap_mgr.clone();
                 match SnapKey::from_snap(meta.get_message().get_snapshot()).and_then(|key| {
-                    mgr.rl()
-                        .get_snapshot_for_receiving(&key,
+                    mgr.get_snapshot_for_receiving(&key,
                                                     meta.get_message().get_snapshot().get_data())
                         .map(|s| (s, key))
                 }) {
@@ -164,7 +163,7 @@ impl<R: RaftStoreRouter + 'static> Runnable<Task> for Runner<R> {
                             return;
                         }
                         debug!("begin to receive snap {:?}", meta);
-                        mgr.wl().register(key, SnapEntry::Receiving);
+                        mgr.register(key, SnapEntry::Receiving);
                         self.files.insert(token, (snap, meta));
                     }
                     Err(e) => {
@@ -188,7 +187,7 @@ impl<R: RaftStoreRouter + 'static> Runnable<Task> for Runner<R> {
                                    err);
                             let (_, msg) = e.remove();
                             let key = SnapKey::from_snap(msg.get_message().get_snapshot()).unwrap();
-                            self.snap_mgr.wl().deregister(&key, &SnapEntry::Receiving);
+                            self.snap_mgr.deregister(&key, &SnapEntry::Receiving);
                             should_close = true;
                         }
                     }
@@ -205,7 +204,7 @@ impl<R: RaftStoreRouter + 'static> Runnable<Task> for Runner<R> {
                         let key = SnapKey::from_snap(msg.get_message().get_snapshot()).unwrap();
                         info!("saving snapshot to {}", snap.path());
                         defer!({
-                            self.snap_mgr.wl().deregister(&key, &SnapEntry::Receiving);
+                            self.snap_mgr.deregister(&key, &SnapEntry::Receiving);
                             self.close(token);
                         });
                         if let Err(e) = snap.save() {
@@ -229,7 +228,7 @@ impl<R: RaftStoreRouter + 'static> Runnable<Task> for Runner<R> {
                     debug!("discard snapshot: {:?}", msg);
                     // because token is inserted, following can't panic.
                     let key = SnapKey::from_snap(msg.get_message().get_snapshot()).unwrap();
-                    self.snap_mgr.wl().deregister(&key, &SnapEntry::Receiving);
+                    self.snap_mgr.deregister(&key, &SnapEntry::Receiving);
                 }
             }
             Task::SendTo { addr, data, cb } => {

--- a/tests/raftstore/node.rs
+++ b/tests/raftstore/node.rs
@@ -28,7 +28,7 @@ use tikv::raftstore::store::*;
 use kvproto::raft_cmdpb::*;
 use kvproto::raft_serverpb::{self, RaftMessage};
 use kvproto::eraftpb::MessageType;
-use tikv::raftstore::{store, Result, Error};
+use tikv::raftstore::{Result, Error};
 use tikv::util::HandyRwLock;
 use tikv::util::transport::SendCh;
 use tikv::server::Config as ServerConfig;
@@ -82,24 +82,24 @@ impl Channel<RaftMessage> for ChannelTransport {
             let key = SnapKey::from_snap(snap).unwrap();
             let from = match self.rl().snap_paths.get(&from_store) {
                 Some(p) => {
-                    p.0.wl().register(key.clone(), SnapEntry::Sending);
-                    p.0.rl().get_snapshot_for_sending(&key).unwrap()
+                    p.0.register(key.clone(), SnapEntry::Sending);
+                    p.0.get_snapshot_for_sending(&key).unwrap()
                 }
                 None => return Err(box_err!("missing temp dir for store {}", from_store)),
             };
             let to = match self.rl().snap_paths.get(&to_store) {
                 Some(p) => {
-                    p.0.wl().register(key.clone(), SnapEntry::Receiving);
+                    p.0.register(key.clone(), SnapEntry::Receiving);
                     let data = msg.get_message().get_snapshot().get_data();
-                    p.0.rl().get_snapshot_for_receiving(&key, data).unwrap()
+                    p.0.get_snapshot_for_receiving(&key, data).unwrap()
                 }
                 None => return Err(box_err!("missing temp dir for store {}", to_store)),
             };
 
             defer!({
                 let core = self.rl();
-                core.snap_paths[&from_store].0.wl().deregister(&key, &SnapEntry::Sending);
-                core.snap_paths[&to_store].0.wl().deregister(&key, &SnapEntry::Receiving);
+                core.snap_paths[&from_store].0.deregister(&key, &SnapEntry::Sending);
+                core.snap_paths[&to_store].0.deregister(&key, &SnapEntry::Receiving);
             });
 
             try!(copy_snapshot(from, to));
@@ -167,8 +167,7 @@ impl Simulator for NodeCluster {
         let (snap_mgr, tmp) = if node_id == 0 ||
                                  !self.trans.rl().snap_paths.contains_key(&node_id) {
             let tmp = TempDir::new("test_cluster").unwrap();
-            let snap_mgr = store::new_snap_mgr(tmp.path().to_str().unwrap(),
-                                               Some(node.get_sendch()));
+            let snap_mgr = SnapManager::new(tmp.path().to_str().unwrap(), Some(node.get_sendch()));
             (snap_mgr, Some(tmp))
         } else {
             let trans = self.trans.rl();

--- a/tests/raftstore/server.rs
+++ b/tests/raftstore/server.rs
@@ -27,7 +27,7 @@ use tikv::server::{self, ServerChannel, Server, ServerTransport, create_event_lo
 use tikv::server::{Node, Config, create_raft_storage, PdStoreAddrResolver};
 use tikv::server::transport::ServerRaftStoreRouter;
 use tikv::raftstore::{Error, Result, store};
-use tikv::raftstore::store::Msg as StoreMsg;
+use tikv::raftstore::store::{Msg as StoreMsg, SnapManager};
 use tikv::util::codec::{Error as CodecError, rpc};
 use tikv::util::transport::SendCh;
 use tikv::storage::{Engine, CfName, ALL_CFS};
@@ -154,7 +154,7 @@ impl Simulator for ServerCluster {
         let mut store_event_loop = store::create_event_loop(&cfg.raft_store).unwrap();
         let simulate_trans = SimulateTransport::new(trans.clone());
         let mut node = Node::new(&mut store_event_loop, &cfg, self.pd_client.clone());
-        let snap_mgr = store::new_snap_mgr(tmp_str, Some(node.get_sendch()));
+        let snap_mgr = SnapManager::new(tmp_str, Some(node.get_sendch()));
 
         node.start(store_event_loop,
                    engine.clone(),


### PR DESCRIPTION
When `SnapManager` is sync, it will require internal channel to be sync too, which can not be always satisfied (especially when using latest mio). So let's make `SnapManager` not sync.

@siddontang @zhangjinpeng1987 @hhkbp2 PTAL