### PR TITLE
raftstore: speedup transfer leader

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -943,7 +943,8 @@ impl Peer {
             Ok(RequestPolicy::ProposeNormal) => self.propose_normal(req, metrics),
             Ok(RequestPolicy::ProposeTransferLeader) => {
                 self.propose_transfer_leader(req, cb, metrics);
-                return false;
+                // return true to let raftstore send out the message immediately.
+                return true;
             }
             Ok(RequestPolicy::ProposeConfChange) => {
                 is_conf_change = true;

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -942,9 +942,7 @@ impl Peer {
             Ok(RequestPolicy::ReadIndex) => return self.read_index(meta.uuid, req, cb, metrics),
             Ok(RequestPolicy::ProposeNormal) => self.propose_normal(req, metrics),
             Ok(RequestPolicy::ProposeTransferLeader) => {
-                self.propose_transfer_leader(req, cb, metrics);
-                // return true to let raftstore send out the message immediately.
-                return true;
+                return self.propose_transfer_leader(req, cb, metrics)
             }
             Ok(RequestPolicy::ProposeConfChange) => {
                 is_conf_change = true;
@@ -1240,26 +1238,32 @@ impl Peer {
         Ok(())
     }
 
+    // Return true to if the transfer leader request is accepted.
     fn propose_transfer_leader(&mut self,
                                req: RaftCmdRequest,
                                cb: Callback,
-                               metrics: &mut RaftProposeMetrics) {
+                               metrics: &mut RaftProposeMetrics)
+                               -> bool {
         metrics.transfer_leader += 1;
 
         let transfer_leader = get_transfer_leader_cmd(&req).unwrap();
         let peer = transfer_leader.get_peer();
 
-        if self.is_tranfer_leader_allowed(peer) {
+        let transfered = if self.is_tranfer_leader_allowed(peer) {
             self.transfer_leader(peer);
+            true
         } else {
             info!("{} transfer leader message {:?} ignored directly",
                   self.tag,
                   req);
-        }
+            false
+        };
 
         // transfer leader command doesn't need to replicate log and apply, so we
         // return immediately. Note that this command may fail, we can view it just as an advice
         cb(make_transfer_leader_response());
+
+        transfered
     }
 
     fn propose_conf_change(&mut self,

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -90,8 +90,8 @@ pub struct Store<T, C: 'static> {
     pending_raft_groups: HashSet<u64>,
     // region end key -> region id
     region_ranges: BTreeMap<Key, u64>,
-    // the pending snapshots between two mio ticks.
-    pending_regions: Vec<metapb::Region>,
+    // the regions with pending snapshots between two mio ticks.
+    pending_snapshot_regions: Vec<metapb::Region>,
     split_check_worker: Worker<SplitCheckTask>,
     region_worker: Worker<RegionTask>,
     raftlog_gc_worker: Worker<RaftlogGcTask>,
@@ -183,7 +183,7 @@ impl<T, C> Store<T, C> {
             apply_worker: Worker::new("apply worker"),
             apply_res_receiver: None,
             region_ranges: BTreeMap::new(),
-            pending_regions: vec![],
+            pending_snapshot_regions: vec![],
             trans: trans,
             pd_client: pd_client,
             peer_cache: Rc::new(RefCell::new(peer_cache)),
@@ -836,7 +836,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                 return Ok(false);
             }
         }
-        for region in &self.pending_regions {
+        for region in &self.pending_snapshot_regions {
             if enc_start_key(region) < enc_end_key(&snap_region) &&
                enc_end_key(region) > enc_start_key(&snap_region) &&
                // Same region can overlap, we will apply the latest version of snapshot.
@@ -845,7 +845,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                 return Ok(false);
             }
         }
-        self.pending_regions.push(snap_region);
+        self.pending_snapshot_regions.push(snap_region);
 
         Ok(true)
     }
@@ -2002,7 +2002,7 @@ impl<T: Transport, C: PdClient> mio::Handler for Store<T, C> {
 
         self.poll_apply();
 
-        self.pending_regions.clear();
+        self.pending_snapshot_regions.clear();
     }
 }
 

--- a/tests/raftstore/test_split_region.rs
+++ b/tests/raftstore/test_split_region.rs
@@ -555,9 +555,7 @@ fn test_node_split_stale_epoch() {
 // `test_quick_election_after_split` is a helper function for testing this feature.
 fn test_quick_election_after_split<T: Simulator>(cluster: &mut Cluster<T>) {
     // Calculate the reserved time before a new campaign after split.
-    let reserved_time = Duration::from_millis(cluster.cfg.raft_store.raft_base_tick_interval) *
-                        cluster.cfg.raft_store.raft_election_timeout_ticks as u32 /
-                        2;
+    let reserved_time = Duration::from_millis(cluster.cfg.raft_store.raft_base_tick_interval);
 
     cluster.run();
     cluster.must_put(b"k1", b"v1");

--- a/tests/raftstore/test_split_region.rs
+++ b/tests/raftstore/test_split_region.rs
@@ -555,7 +555,7 @@ fn test_node_split_stale_epoch() {
 // `test_quick_election_after_split` is a helper function for testing this feature.
 fn test_quick_election_after_split<T: Simulator>(cluster: &mut Cluster<T>) {
     // Calculate the reserved time before a new campaign after split.
-    let reserved_time = Duration::from_millis(cluster.cfg.raft_store.raft_base_tick_interval);
+    let reserved_time = Duration::from_millis(cluster.cfg.raft_store.raft_base_tick_interval * 2);
 
     cluster.run();
     cluster.must_put(b"k1", b"v1");

--- a/tests/raftstore/test_transfer_leader.rs
+++ b/tests/raftstore/test_transfer_leader.rs
@@ -20,7 +20,7 @@ use kvproto::eraftpb::MessageType;
 use std::time::Duration;
 use std::thread;
 
-fn test_transfer_leader<T: Simulator>(cluster: &mut Cluster<T>) {
+fn test_basic_transfer_leader<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.cfg.raft_store.raft_heartbeat_ticks = 20;
     let reserved_time = Duration::from_millis(cluster.cfg.raft_store.raft_base_tick_interval);
     cluster.run();
@@ -55,15 +55,15 @@ fn test_transfer_leader<T: Simulator>(cluster: &mut Cluster<T>) {
 }
 
 #[test]
-fn test_server_transfer_leader() {
+fn test_server_basic_transfer_leader() {
     let mut cluster = new_server_cluster(0, 5);
-    test_transfer_leader(&mut cluster);
+    test_basic_transfer_leader(&mut cluster);
 }
 
 #[test]
-fn test_node_transfer_leader() {
+fn test_node_basic_transfer_leader() {
     let mut cluster = new_node_cluster(0, 5);
-    test_transfer_leader(&mut cluster);
+    test_basic_transfer_leader(&mut cluster);
 }
 
 fn test_pd_transfer_leader<T: Simulator>(cluster: &mut Cluster<T>) {

--- a/tests/raftstore/test_transfer_leader.rs
+++ b/tests/raftstore/test_transfer_leader.rs
@@ -18,17 +18,30 @@ use super::node::new_node_cluster;
 use super::server::new_server_cluster;
 use kvproto::eraftpb::MessageType;
 use std::time::Duration;
+use std::thread;
 
 fn test_transfer_leader<T: Simulator>(cluster: &mut Cluster<T>) {
+    cluster.cfg.raft_store.raft_heartbeat_ticks = 20;
+    let reserved_time = Duration::from_millis(cluster.cfg.raft_store.raft_base_tick_interval);
     cluster.run();
 
     // transfer leader to (2, 2)
     cluster.must_transfer_leader(1, new_peer(2, 2));
 
-    // transfer leader to (3, 3)
-    cluster.must_transfer_leader(1, new_peer(3, 3));
-
     let mut region = cluster.get_region(b"k3");
+
+    // check if transfer leader is fast enough.
+    let admin_req = new_transfer_leader_cmd(new_peer(3, 3));
+    let mut req = new_admin_request(1, region.get_region_epoch(), admin_req);
+    req.mut_header().set_peer(new_peer(2, 2));
+    cluster.call_command(req, Duration::from_secs(3)).unwrap();
+    thread::sleep(reserved_time);
+    let status_req = new_region_leader_cmd();
+    let req = new_status_request(1, new_peer(3, 3), status_req);
+    let resp = cluster.call_command(req, Duration::from_secs(1)).unwrap();
+    assert_eq!(resp.get_status_response().get_region_leader().get_leader(),
+               &new_peer(3, 3));
+
     let mut req = new_request(region.get_id(),
                               region.take_region_epoch(),
                               vec![new_put_cmd(b"k3", b"v3")],
@@ -107,7 +120,7 @@ fn test_server_pd_transfer_leader() {
 }
 
 #[test]
-fn test_node_pd_transfer_leader() {
+fn test_node_pd_transfer_leader_v() {
     let mut cluster = new_node_cluster(0, 3);
     test_pd_transfer_leader(&mut cluster);
 }

--- a/tests/raftstore/test_transfer_leader.rs
+++ b/tests/raftstore/test_transfer_leader.rs
@@ -36,11 +36,7 @@ fn test_basic_transfer_leader<T: Simulator>(cluster: &mut Cluster<T>) {
     req.mut_header().set_peer(new_peer(2, 2));
     cluster.call_command(req, Duration::from_secs(3)).unwrap();
     thread::sleep(reserved_time);
-    let status_req = new_region_leader_cmd();
-    let req = new_status_request(1, new_peer(3, 3), status_req);
-    let resp = cluster.call_command(req, Duration::from_secs(1)).unwrap();
-    assert_eq!(resp.get_status_response().get_region_leader().get_leader(),
-               &new_peer(3, 3));
+    assert_eq!(cluster.query_leader(3, 1), Some(new_peer(3, 3)));
 
     let mut req = new_request(region.get_id(),
                               region.take_region_epoch(),

--- a/tests/raftstore/test_transfer_leader.rs
+++ b/tests/raftstore/test_transfer_leader.rs
@@ -120,7 +120,7 @@ fn test_server_pd_transfer_leader() {
 }
 
 #[test]
-fn test_node_pd_transfer_leader_v() {
+fn test_node_pd_transfer_leader() {
     let mut cluster = new_node_cluster(0, 3);
     test_pd_transfer_leader(&mut cluster);
 }


### PR DESCRIPTION
When doing transfer leader, it will need to wait for at most a round of heartbeat to send out the request, during which the old leader will drop all the requests.

@siddontang @hhkbp2 PTAL