### PR TITLE
travis: specifiy rustc version explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,15 @@ before_cache:
 matrix:
   include:
     - os: linux
-      rust: nightly
-      env: COMPILER=g++-4.8 RUSTC_DATE=2017-02-12 RUSTFMT_VERSION=v0.6.0 CXX=g++-4.8
+      rust: nightly-2017-02-12
+      env: COMPILER=g++-4.8 RUSTFMT_VERSION=v0.6.0 CXX=g++-4.8
       addons:
          apt:
             sources: ['ubuntu-toolchain-r-test']
             packages: ['g++-4.8', 'zlib1g-dev', 'libbz2-dev', 'libsnappy-dev', 'curl', 'libdw-dev', 'libelf-dev', 'elfutils', 'binutils-dev']
     - os: osx
-      rust: nightly
-      env: COMPILER=clang++ RUSTC_DATE=2017-02-12 SKIP_FORMAT_CHECK=true CXX=clang++
+      rust: nightly-2017-02-12
+      env: COMPILER=clang++ SKIP_FORMAT_CHECK=true CXX=clang++
 
 install:
   - export LOCAL_DIR=$HOME/.cache/

--- a/travis-build/Makefile
+++ b/travis-build/Makefile
@@ -54,21 +54,18 @@ ${LOCAL_DIR}/bin/pd-server:
 	mkdir -p ${LOCAL_DIR}/bin && \
 	cp bin/pd-server ${LOCAL_DIR}/bin/pd-server
 
-prepare_rust:
-	sh ~/rust/lib/rustlib/uninstall.sh && sh ~/rust-installer/rustup.sh --date=${RUSTC_DATE} --prefix=~/rust --disable-sudo --channel=nightly
-
-prepare-rustfmt: | prepare_rust
+prepare-rustfmt:
 	curl -L https://github.com/tennix/rustfmt/releases/download/v0.6/rustfmt-${RUSTFMT_VERSION}-linux-amd64.tar.gz -o rustfmt-${RUSTFMT_VERSION}-linux-amd64.tar.gz && \
 	mkdir -p ${HOME}/.cargo/bin && tar xzf rustfmt-${RUSTFMT_VERSION}-linux-amd64.tar.gz -C ${HOME}/.cargo/bin --strip-components=1
 	# cargo install --vers =0.6.0 rustfmt || exit 0
 
-prepare_linux: ${LOCAL_DIR}/lib/librocksdb.so ${LOCAL_DIR}/bin/kcov ${LOCAL_DIR}/bin/pd-server prepare-rustfmt | prepare_rust
+prepare_linux: ${LOCAL_DIR}/lib/librocksdb.so ${LOCAL_DIR}/bin/kcov ${LOCAL_DIR}/bin/pd-server prepare-rustfmt
 
 prepare_brew:
 	brew update && \
 	brew install gflags snappy rocksdb
 
-prepare_osx: ${LOCAL_DIR}/bin/pd-server | prepare_brew prepare_rust
+prepare_osx: ${LOCAL_DIR}/bin/pd-server | prepare_brew
 
 test_linux test_osx:
 	export CI=true && ${CI_BUILD_DIR}/test.sh


### PR DESCRIPTION
So we don't need to uninstall rustc then install it again.

@siddontang @hhkbp2 PTAL