### PR TITLE
transport: make channel not sync

### DIFF
--- a/src/util/transport.rs
+++ b/src/util/transport.rs
@@ -97,7 +97,6 @@ pub struct RetryableSendCh<T, C: Sender<T>> {
 // We only care about self.ch. When using built-in derive, the T will be
 // also taken into consideration.
 unsafe impl<T, C: Sender<T> + Send> Send for RetryableSendCh<T, C> {}
-unsafe impl<T, C: Sender<T> + Sync> Sync for RetryableSendCh<T, C> {}
 
 impl<T: Debug, C: Sender<T>> RetryableSendCh<T, C> {
     pub fn new(ch: C, name: &'static str) -> RetryableSendCh<T, C> {


### PR DESCRIPTION
After upgrading the mio, we will use std sender instead, which is not sync.

@siddontang @zhangjinpeng1987 PTAL