### PR TITLE
*: upgrade rustc and clippy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,14 @@ before_cache:
 matrix:
   include:
     - os: linux
-      rust: nightly-2017-02-12
+      rust: nightly-2017-03-28
       env: COMPILER=g++-4.8 RUSTFMT_VERSION=v0.6.0 CXX=g++-4.8
       addons:
          apt:
             sources: ['ubuntu-toolchain-r-test']
             packages: ['g++-4.8', 'zlib1g-dev', 'libbz2-dev', 'libsnappy-dev', 'curl', 'libdw-dev', 'libelf-dev', 'elfutils', 'binutils-dev']
     - os: osx
-      rust: nightly-2017-02-12
+      rust: nightly-2017-03-28
       env: COMPILER=clang++ SKIP_FORMAT_CHECK=true CXX=clang++
 
 install:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ dependencies = [
  "byteorder 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy 0.0.121 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -159,22 +159,22 @@ dependencies = [
 
 [[package]]
 name = "clippy"
-version = "0.0.114"
+version = "0.0.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cargo_metadata 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy_lints 0.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy_lints 0.0.121 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "clippy_lints"
-version = "0.0.114"
+version = "0.0.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quine-mc_cluskey 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -601,11 +601,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "num"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,11 +856,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "semver"
-version = "0.2.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "nom 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
@@ -1179,8 +1179,8 @@ dependencies = [
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
 "checksum chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9213f7cd7c27e95c2b57c49f0e69b1ea65b27138da84a170133fd21b07659c00"
 "checksum clap 2.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5fa304b03c49ccbb005784fc26e985b5d2310b1d37f2c311ce90dbcd18ea5fde"
-"checksum clippy 0.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "808f9027f62dda9f764f26542a10465a6db221a5bd57981a63a2f84a6518b098"
-"checksum clippy_lints 0.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "e5d58f7fdb30f25e6c4dac79d0156bec6fb69834ba270dc2dc2e12754cebef75"
+"checksum clippy 0.0.121 (registry+https://github.com/rust-lang/crates.io-index)" = "72c1d7d8ad4a41a722c0a09f747f085db980303e68b09dee2880231de4035c50"
+"checksum clippy_lints 0.0.121 (registry+https://github.com/rust-lang/crates.io-index)" = "83e1775d962387976aeae9f97f484e685dc92b05ed305bb62d5a9477722d9210"
 "checksum cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e3d6405328b6edb412158b3b7710e2634e23f3614b9bb1c412df7952489a626"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
@@ -1229,7 +1229,6 @@ dependencies = [
 "checksum nix 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bfb3ddedaa14746434a02041940495bf11325c22f6d36125d3bdd56090d50a79"
 "checksum nix 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a7bb1da2be7da3cbffda73fc681d509ffd9e665af478d2bee1907cee0bc64b2"
 "checksum nix 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0d95c5fa8b641c10ad0b8887454ebaafa3c92b5cd5350f8fc693adafd178e7b"
-"checksum nom 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6caab12c5f97aa316cb249725aa32115118e1522b445e26c257dd77cad5ffd4e"
 "checksum num 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "c04bd954dbf96f76bab6e5bd6cef6f1ce1262d15268ce4f926d2b5b778fa7af2"
 "checksum num-bigint 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "41655c8d667be847a0b72fe0888857a7b3f052f691cf40852be5fcf87b274a65"
 "checksum num-complex 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "ccac67baf893ac97474f8d70eff7761dabb1f6c66e71f8f1c67a6859218db810"
@@ -1261,7 +1260,8 @@ dependencies = [
 "checksum security-framework 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d7c1ff1c71e4e4474b46ded6687f0c28c721de2f5a05577e7f533d36330e4e3a"
 "checksum security-framework-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "5103c988054803538fe4d85333abf4c633f069510ab687dc71a50572104216d0"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
-"checksum semver 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2d5b7638a1f03815d94e88cb3b3c08e87f0db4d683ef499d1836aaf70a45623f"
+"checksum semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
+"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1e0ed773960f90a78567fcfbe935284adf50c5d7cf119aa2cf43bb0b4afa69bb"
 "checksum serde_codegen_internals 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c3172bf2940b975c0e4f6ab42a511c0a4407d4f46ccef87a9d3615db5c26fa96"
 "checksum serde_derive 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6af30425c5161deb200aac4803c62b903eb3be7e889c5823d0e16c4ce0ce989c"

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -16,6 +16,10 @@
 #![cfg_attr(feature = "dev", plugin(clippy))]
 #![cfg_attr(not(feature = "dev"), allow(unknown_lints))]
 
+// TODO: deny it once Manishearth/rust-clippy#1586 is fixed.
+#![allow(never_loop)]
+#![allow(needless_pass_by_value)]
+
 extern crate log;
 extern crate test;
 extern crate mio;

--- a/benches/bin/bench-tikv.rs
+++ b/benches/bin/bench-tikv.rs
@@ -21,6 +21,9 @@
 #![cfg_attr(not(feature = "dev"), allow(unknown_lints))]
 #![feature(btree_range, collections_bound)]
 #![allow(new_without_default)]
+// TODO: deny it once Manishearth/rust-clippy#1586 is fixed.
+#![allow(never_loop)]
+#![allow(needless_pass_by_value)]
 
 #[macro_use]
 extern crate log;

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ machine:
     CPPFLAGS: "-I$HOME/.local/include"
     CXXFLAGS: "-I$HOME/.local/include"
     PKG_CONFIG_PATH: "$PKG_CONFIG_PATH:$HOME/.local/lib/pkgconfig"
-    RUSTC_DATE: "2017-02-12"
+    RUSTC_DATE: "2017-03-28"
     LOCAL_PREFIX: "$HOME/.local"
     # used by cargo
     LIBRARY_PATH: "$LIBRARY_PATH:$HOME/.local/lib"

--- a/docker/release_dockerfile
+++ b/docker/release_dockerfile
@@ -7,7 +7,7 @@ RUN yum update -y && \
     yum install -y devtoolset-4-gcc-c++ python27 && \
     yum clean all
 
-RUN curl -sSf https://static.rust-lang.org/rustup.sh |  sh -s -- --date=2017-02-12 --disable-sudo -y --channel=nightly
+RUN curl -sSf https://static.rust-lang.org/rustup.sh |  sh -s -- --date=2017-03-28 --disable-sudo -y --channel=nightly
 
 ADD https://github.com/pingcap/tikv/archive/master.tar.gz /master.tar.gz
 

--- a/docker/rust_dockerfile
+++ b/docker/rust_dockerfile
@@ -25,4 +25,4 @@ RUN cd / && \
     cd / && \
     rm -rf /rocksdb-5.1.2 /rocksdb.tar.gz
 
-RUN curl -sSf https://static.rust-lang.org/rustup.sh | sh -s  -- --date=2017-02-12 --disable-sudo -y --channel=nightly
+RUN curl -sSf https://static.rust-lang.org/rustup.sh | sh -s  -- --date=2017-03-28 --disable-sudo -y --channel=nightly

--- a/src/bin/tikv-ctl.rs
+++ b/src/bin/tikv-ctl.rs
@@ -13,6 +13,11 @@
 
 #![feature(plugin)]
 #![cfg_attr(feature = "dev", plugin(clippy))]
+#![cfg_attr(not(feature = "dev"), allow(unknown_lints))]
+
+// TODO: deny it once Manishearth/rust-clippy#1586 is fixed.
+#![allow(never_loop)]
+#![allow(needless_pass_by_value)]
 
 extern crate tikv;
 extern crate clap;

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -13,6 +13,11 @@
 
 #![feature(plugin)]
 #![cfg_attr(feature = "dev", plugin(clippy))]
+#![cfg_attr(not(feature = "dev"), allow(unknown_lints))]
+
+// TODO: deny it once Manishearth/rust-clippy#1586 is fixed.
+#![allow(never_loop)]
+#![allow(needless_pass_by_value)]
 
 extern crate tikv;
 extern crate getopts;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@
 
 #![crate_type = "lib"]
 #![feature(test)]
-#![feature(btree_range, collections_bound)]
 #![feature(fnbox)]
 #![feature(alloc)]
 #![feature(slice_patterns)]
@@ -26,6 +25,9 @@
 #![allow(module_inception)]
 #![allow(should_implement_trait)]
 #![allow(large_enum_variant)]
+// TODO: deny it once Manishearth/rust-clippy#1586 is fixed.
+#![allow(never_loop)]
+#![allow(needless_pass_by_value)]
 
 #[macro_use]
 extern crate log;

--- a/src/raft/errors.rs
+++ b/src/raft/errors.rs
@@ -113,17 +113,18 @@ mod tests {
                    Error::Store(StorageError::Compacted));
         assert_eq!(Error::Io(io::Error::new(io::ErrorKind::UnexpectedEof, "oh no!")),
                    Error::Io(io::Error::new(io::ErrorKind::UnexpectedEof, "oh yes!")));
-        assert!(Error::Io(io::Error::new(io::ErrorKind::NotFound, "error")) !=
-                Error::Io(io::Error::new(io::ErrorKind::BrokenPipe, "error")));
+        assert_ne!(Error::Io(io::Error::new(io::ErrorKind::NotFound, "error")),
+                   Error::Io(io::Error::new(io::ErrorKind::BrokenPipe, "error")));
         assert_eq!(Error::StepLocalMsg, Error::StepLocalMsg);
         assert_eq!(Error::ConfigInvalid(String::from("config error")),
                    Error::ConfigInvalid(String::from("config error")));
-        assert!(Error::ConfigInvalid(String::from("config error")) !=
-                Error::ConfigInvalid(String::from("other error")));
+        assert_ne!(Error::ConfigInvalid(String::from("config error")),
+                   Error::ConfigInvalid(String::from("other error")));
         assert_eq!(Error::from(io::Error::new(io::ErrorKind::Other, "oh no!")),
                    Error::from(io::Error::new(io::ErrorKind::Other, "oh yes!")));
-        assert!(Error::StepPeerNotFound != Error::Store(StorageError::Compacted));
-        assert!(Error::Other(box Error::StepLocalMsg) != Error::StepLocalMsg);
+        assert_ne!(Error::StepPeerNotFound,
+                   Error::Store(StorageError::Compacted));
+        assert_ne!(Error::Other(box Error::StepLocalMsg), Error::StepLocalMsg);
     }
 
     #[test]
@@ -134,7 +135,8 @@ mod tests {
                    StorageError::SnapshotOutOfDate);
         assert_eq!(StorageError::SnapshotTemporarilyUnavailable,
                    StorageError::SnapshotTemporarilyUnavailable);
-        assert!(StorageError::Compacted != StorageError::Unavailable);
-        assert!(StorageError::Other(box StorageError::Unavailable) != StorageError::Unavailable);
+        assert_ne!(StorageError::Compacted, StorageError::Unavailable);
+        assert_ne!(StorageError::Other(box StorageError::Unavailable),
+                   StorageError::Unavailable);
     }
 }

--- a/src/raft/raft.rs
+++ b/src/raft/raft.rs
@@ -683,8 +683,9 @@ impl<T: Storage> Raft<T> {
 
     // TODO: revoke pub when there is a better way to test.
     pub fn become_candidate(&mut self) {
-        assert!(self.state != StateRole::Leader,
-                "invalid transition [leader -> candidate]");
+        assert_ne!(self.state,
+                   StateRole::Leader,
+                   "invalid transition [leader -> candidate]");
         let term = self.term + 1;
         self.reset(term);
         let id = self.id;
@@ -694,8 +695,9 @@ impl<T: Storage> Raft<T> {
     }
 
     pub fn become_pre_candidate(&mut self) {
-        assert!(self.state != StateRole::Leader,
-                "invalid transition [leader -> pre-candidate]");
+        assert_ne!(self.state,
+                   StateRole::Leader,
+                   "invalid transition [leader -> pre-candidate]");
         // Becoming a pre-candidate changes our state.
         // but doesn't change anything else. In particular it does not increase
         // self.term or change self.vote.
@@ -705,8 +707,9 @@ impl<T: Storage> Raft<T> {
 
     // TODO: revoke pub when there is a better way to test.
     pub fn become_leader(&mut self) {
-        assert!(self.state != StateRole::Follower,
-                "invalid transition [follower -> leader]");
+        assert_ne!(self.state,
+                   StateRole::Follower,
+                   "invalid transition [follower -> leader]");
         let term = self.term;
         self.reset(term);
         self.leader_id = self.id;

--- a/src/raft/raw_node.rs
+++ b/src/raft/raw_node.rs
@@ -159,7 +159,7 @@ pub struct RawNode<T: Storage> {
 impl<T: Storage> RawNode<T> {
     // NewRawNode returns a new RawNode given configuration and a list of raft peers.
     pub fn new(config: &Config, store: T, peers: &[Peer]) -> Result<RawNode<T>> {
-        assert!(config.id != 0, "config.id must not be zero");
+        assert_ne!(config.id, 0, "config.id must not be zero");
         let r = Raft::new(config, store);
         let mut rn = RawNode {
             raft: r,

--- a/src/raftstore/store/engine.rs
+++ b/src/raftstore/store/engine.rs
@@ -479,7 +479,7 @@ mod tests {
         engine.put_msg(key, &r).unwrap();
         r1 = engine.get_msg(key).unwrap().unwrap();
         r2 = snap.get_msg(key).unwrap().unwrap();
-        assert!(r1 != r2);
+        assert_ne!(r1, r2);
 
         let b: Option<Region> = engine.get_msg(b"missing_key").unwrap();
         assert!(b.is_none());

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -1321,7 +1321,7 @@ mod test {
         let s2 = new_storage(sched, &td2);
         assert_eq!(s2.first_index(), s2.applied_index() + 1);
         let mut ctx = InvokeContext::new(&s2);
-        assert!(ctx.last_term != snap1.get_metadata().get_term());
+        assert_ne!(ctx.last_term, snap1.get_metadata().get_term());
         let mut wb = WriteBatch::new();
         s2.apply_snapshot(&mut ctx, &snap1, &mut wb).unwrap();
         assert_eq!(ctx.last_term, snap1.get_metadata().get_term());

--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -1273,7 +1273,7 @@ mod v2 {
 
     impl Read for Snap {
         fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-            if buf.len() == 0 {
+            if buf.is_empty() {
                 return Ok(0);
             }
             while self.cf_index < self.cf_files.len() {
@@ -1299,7 +1299,7 @@ mod v2 {
 
     impl Write for Snap {
         fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-            if buf.len() == 0 {
+            if buf.is_empty() {
                 return Ok(0);
             }
 
@@ -1498,7 +1498,7 @@ mod v2 {
             let key = SnapKey::new(1, 1, 1);
             let prefix = format!("{}_{}", SNAP_GEN_PREFIX, key);
             let display_path = Snap::get_display_path(&dir.into_path(), &prefix);
-            assert!(display_path != "");
+            assert_ne!(display_path, "");
         }
 
         #[test]

--- a/src/raftstore/store/worker/region.rs
+++ b/src/raftstore/store/worker/region.rs
@@ -233,8 +233,8 @@ impl Runner {
             }
             Err(Error::Abort) => {
                 warn!("applying snapshot for region {} is aborted.", region_id);
-                assert!(status.swap(JOB_STATUS_CANCELLED, Ordering::SeqCst) ==
-                        JOB_STATUS_CANCELLING);
+                assert_eq!(status.swap(JOB_STATUS_CANCELLED, Ordering::SeqCst),
+                           JOB_STATUS_CANCELLING);
                 SNAP_COUNTER_VEC.with_label_values(&["apply", "abort"]).inc();
             }
             Err(e) => {

--- a/src/server/coprocessor/endpoint.rs
+++ b/src/server/coprocessor/endpoint.rs
@@ -695,7 +695,7 @@ impl SelectContextCore {
         // set topn
         let mut topn = false;
         let mut desc_can = false;
-        if sel.get_order_by().len() > 0 {
+        if !sel.get_order_by().is_empty() {
             // order by pk,set desc_scan is enough
             if !sel.get_order_by()[0].has_expr() {
                 desc_can = sel.get_order_by().first().map_or(false, |o| o.get_desc());

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -193,7 +193,7 @@ impl<'a> Cursor<'a> {
     }
 
     pub fn seek(&mut self, key: &Key, statistics: &mut Statistics) -> Result<bool> {
-        assert!(self.scan_mode != ScanMode::Backward);
+        assert_ne!(self.scan_mode, ScanMode::Backward);
         if self.max_key.as_ref().map_or(false, |k| k <= key.encoded()) {
             try!(self.iter.validate_key(key));
             return Ok(false);
@@ -218,7 +218,7 @@ impl<'a> Cursor<'a> {
     /// This method assume the current position of cursor is
     /// around `key`, otherwise you should use `seek` instead.
     pub fn near_seek(&mut self, key: &Key, statistics: &mut Statistics) -> Result<bool> {
-        assert!(self.scan_mode != ScanMode::Backward);
+        assert_ne!(self.scan_mode, ScanMode::Backward);
         if !self.iter.valid() {
             return self.seek(key, statistics);
         }
@@ -272,7 +272,7 @@ impl<'a> Cursor<'a> {
     }
 
     fn seek_for_prev(&mut self, key: &Key, statistics: &mut Statistics) -> Result<bool> {
-        assert!(self.scan_mode != ScanMode::Forward);
+        assert_ne!(self.scan_mode, ScanMode::Forward);
         if self.min_key.as_ref().map_or(false, |k| k >= key.encoded()) {
             try!(self.iter.validate_key(key));
             return Ok(false);
@@ -293,7 +293,7 @@ impl<'a> Cursor<'a> {
 
     /// Find the largest key that is not greater than the specific key.
     pub fn near_seek_for_prev(&mut self, key: &Key, statistics: &mut Statistics) -> Result<bool> {
-        assert!(self.scan_mode != ScanMode::Forward);
+        assert_ne!(self.scan_mode, ScanMode::Forward);
         if !self.iter.valid() {
             return self.seek_for_prev(key, statistics);
         }
@@ -637,9 +637,9 @@ mod tests {
 
     macro_rules! assert_seek {
         ($cursor:ident, $func:ident, $k:expr, $res:ident) => ({
-            let msg = format!("assert_seek {} failed exp {:?}", $k, $res);
             let mut statistics = Statistics::default();
-            assert!($cursor.$func(&$k, &mut statistics).unwrap() == $res.is_some(), msg);
+            assert_eq!($cursor.$func(&$k, &mut statistics).unwrap(), $res.is_some(),
+                       "assert_seek {} failed exp {:?}", $k, $res);
             if let Some((ref k, ref v)) = $res {
                 assert_eq!($cursor.key(), bytes::encode_bytes(k.as_bytes()).as_slice());
                 assert_eq!($cursor.value(), v.as_bytes());

--- a/src/storage/mvcc/write.rs
+++ b/src/storage/mvcc/write.rs
@@ -89,27 +89,27 @@ impl Write {
     }
 
     pub fn parse(mut b: &[u8]) -> Result<Write> {
-        if b.len() == 0 {
+        if b.is_empty() {
             return Err(Error::BadFormatWrite);
         }
         let write_type = try!(WriteType::from_u8(try!(b.read_u8())).ok_or(Error::BadFormatWrite));
         let start_ts = try!(b.decode_var_u64());
-        let short_value = if b.len() > 0 {
-            let flag = try!(b.read_u8());
-            if flag == SHORT_VALUE_PREFIX {
-                let len = try!(b.read_u8());
-                if len as usize != b.len() {
-                    panic!("short value len [{}] not equal to content len [{}]",
-                           len,
-                           b.len());
-                }
-                Some(b.to_vec())
-            } else {
-                panic!("invalid flag [{:?}] in write", flag);
-            }
-        } else {
-            None
-        };
-        Ok(Write::new(write_type, start_ts, short_value))
+        if b.is_empty() {
+            return Ok(Write::new(write_type, start_ts, None));
+        }
+
+        let flag = try!(b.read_u8());
+        assert_eq!(flag,
+                   SHORT_VALUE_PREFIX,
+                   "invalid flag [{:?}] in write",
+                   flag);
+
+        let len = try!(b.read_u8());
+        if len as usize != b.len() {
+            panic!("short value len [{}] not equal to content len [{}]",
+                   len,
+                   b.len());
+        }
+        Ok(Write::new(write_type, start_ts, Some(b.to_vec())))
     }
 }

--- a/src/util/buf.rs
+++ b/src/util/buf.rs
@@ -52,7 +52,7 @@ impl PipeBuffer {
     }
 
     #[inline]
-    unsafe fn buf_as_slice_mut(&self) -> &mut [u8] {
+    unsafe fn buf_as_slice_mut(&mut self) -> &mut [u8] {
         slice::from_raw_parts_mut(self.buf.ptr(), self.buf.cap())
     }
 
@@ -67,6 +67,7 @@ impl PipeBuffer {
     }
 
     #[inline]
+    #[allow(len_zero)]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -381,14 +382,14 @@ mod tests {
                     assert_eq!(s, &expected[0..l]);
                     input = &expected[l..];
                     assert_eq!(len - l, s.read_from(&mut input).unwrap());
-                    assert!(s.start != s.buf.cap());
-                    assert!(s.end != s.buf.cap());
+                    assert_ne!(s.start, s.buf.cap());
+                    assert_ne!(s.end, s.buf.cap());
                     assert_eq!(s, expected.as_slice());
 
                     input = padding.as_slice();
                     assert_eq!(cap - len, s.read_from(&mut input).unwrap());
-                    assert!(s.start != s.buf.cap());
-                    assert!(s.end != s.buf.cap());
+                    assert_ne!(s.start, s.buf.cap());
+                    assert_ne!(s.end, s.buf.cap());
                     let mut exp = expected.clone();
                     exp.extend_from_slice(&padding[..cap - len]);
                     assert_eq!(s, exp.as_slice());
@@ -417,16 +418,16 @@ mod tests {
                     {
                         let mut buf = w.as_mut_slice();
                         assert_eq!(l, s.write_to(&mut buf).unwrap());
-                        assert!(s.start != s.buf.cap());
-                        assert!(s.end != s.buf.cap());
+                        assert_ne!(s.start, s.buf.cap());
+                        assert_ne!(s.end, s.buf.cap());
                     }
                     assert_eq!(w, &expected[..l]);
                     assert_eq!(s, &expected[l..]);
 
                     let mut w = vec![0; cap];
                     assert_eq!(len - l, s.read(&mut w).unwrap());
-                    assert!(s.start != s.buf.cap());
-                    assert!(s.end != s.buf.cap());
+                    assert_ne!(s.start, s.buf.cap());
+                    assert_ne!(s.end, s.buf.cap());
                     assert_eq!(&w[..len - l], &expected[l..]);
                 }
             }
@@ -482,8 +483,8 @@ mod tests {
                     let mut input = expect.as_slice();
                     assert_eq!(l, s.read_from(&mut input).unwrap());
                     s.shrink_to(shrink);
-                    assert!(s.start != s.buf.cap());
-                    assert!(s.end != s.buf.cap());
+                    assert_ne!(s.start, s.buf.cap());
+                    assert_ne!(s.end, s.buf.cap());
 
                     assert_eq!(shrink, s.capacity());
                     if shrink > l {
@@ -513,8 +514,8 @@ mod tests {
                     assert_eq!(init, s.read_from(&mut input).unwrap());
                     assert_eq!(s, example.as_slice());
                     s.ensure(init + l);
-                    assert!(s.start != s.buf.cap());
-                    assert!(s.end != s.buf.cap());
+                    assert_ne!(s.start, s.buf.cap());
+                    assert_ne!(s.end, s.buf.cap());
                     assert_eq!(s, example.as_slice());
                     input = expect.as_slice();
 

--- a/src/util/config.rs
+++ b/src/util/config.rs
@@ -324,28 +324,28 @@ mod test {
     #[test]
     fn test_parse_readable_int() {
         // file size
-        assert!(1_024 == parse_readable_int("1KB").unwrap());
-        assert!(1_048_576 == parse_readable_int("1MB").unwrap());
-        assert!(1_073_741_824 == parse_readable_int("1GB").unwrap());
-        assert!(1_099_511_627_776 == parse_readable_int("1TB").unwrap());
-        assert!(1_125_899_906_842_624 == parse_readable_int("1PB").unwrap());
+        assert_eq!(1_024, parse_readable_int("1KB").unwrap());
+        assert_eq!(1_048_576, parse_readable_int("1MB").unwrap());
+        assert_eq!(1_073_741_824, parse_readable_int("1GB").unwrap());
+        assert_eq!(1_099_511_627_776, parse_readable_int("1TB").unwrap());
+        assert_eq!(1_125_899_906_842_624, parse_readable_int("1PB").unwrap());
 
-        assert!(1_024 == parse_readable_int("1kb").unwrap());
-        assert!(1_048_576 == parse_readable_int("1mb").unwrap());
-        assert!(1_073_741_824 == parse_readable_int("1gb").unwrap());
-        assert!(1_099_511_627_776 == parse_readable_int("1tb").unwrap());
-        assert!(1_125_899_906_842_624 == parse_readable_int("1pb").unwrap());
+        assert_eq!(1_024, parse_readable_int("1kb").unwrap());
+        assert_eq!(1_048_576, parse_readable_int("1mb").unwrap());
+        assert_eq!(1_073_741_824, parse_readable_int("1gb").unwrap());
+        assert_eq!(1_099_511_627_776, parse_readable_int("1tb").unwrap());
+        assert_eq!(1_125_899_906_842_624, parse_readable_int("1pb").unwrap());
 
-        assert!(1_536 == parse_readable_int("1.5KB").unwrap());
-        assert!(1_572_864 == parse_readable_int("1.5MB").unwrap());
-        assert!(1_610_612_736 == parse_readable_int("1.5GB").unwrap());
-        assert!(1_649_267_441_664 == parse_readable_int("1.5TB").unwrap());
-        assert!(1_688_849_860_263_936 == parse_readable_int("1.5PB").unwrap());
+        assert_eq!(1_536, parse_readable_int("1.5KB").unwrap());
+        assert_eq!(1_572_864, parse_readable_int("1.5MB").unwrap());
+        assert_eq!(1_610_612_736, parse_readable_int("1.5GB").unwrap());
+        assert_eq!(1_649_267_441_664, parse_readable_int("1.5TB").unwrap());
+        assert_eq!(1_688_849_860_263_936, parse_readable_int("1.5PB").unwrap());
 
-        assert!(100_663_296 == parse_readable_int("96MB").unwrap());
+        assert_eq!(100_663_296, parse_readable_int("96MB").unwrap());
 
-        assert!(1_429_365_116_108 == parse_readable_int("1.3TB").unwrap());
-        assert!(1_463_669_878_895_411 == parse_readable_int("1.3PB").unwrap());
+        assert_eq!(1_429_365_116_108, parse_readable_int("1.3TB").unwrap());
+        assert_eq!(1_463_669_878_895_411, parse_readable_int("1.3PB").unwrap());
 
         assert!(parse_readable_int("KB").is_err());
         assert!(parse_readable_int("MB").is_err());
@@ -354,20 +354,20 @@ mod test {
         assert!(parse_readable_int("PB").is_err());
 
         // time
-        assert!(1 == parse_readable_int("1ms").unwrap());
-        assert!(1_000 == parse_readable_int("1s").unwrap());
-        assert!(60_000 == parse_readable_int("1m").unwrap());
-        assert!(3_600_000 == parse_readable_int("1h").unwrap());
+        assert_eq!(1, parse_readable_int("1ms").unwrap());
+        assert_eq!(1_000, parse_readable_int("1s").unwrap());
+        assert_eq!(60_000, parse_readable_int("1m").unwrap());
+        assert_eq!(3_600_000, parse_readable_int("1h").unwrap());
 
-        assert!(1 == parse_readable_int("1.3ms").unwrap());
-        assert!(1_000 == parse_readable_int("1000ms").unwrap());
-        assert!(1_300 == parse_readable_int("1.3s").unwrap());
-        assert!(1_500 == parse_readable_int("1.5s").unwrap());
-        assert!(10_000 == parse_readable_int("10s").unwrap());
-        assert!(78_000 == parse_readable_int("1.3m").unwrap());
-        assert!(90_000 == parse_readable_int("1.5m").unwrap());
-        assert!(4_680_000 == parse_readable_int("1.3h").unwrap());
-        assert!(5_400_000 == parse_readable_int("1.5h").unwrap());
+        assert_eq!(1, parse_readable_int("1.3ms").unwrap());
+        assert_eq!(1_000, parse_readable_int("1000ms").unwrap());
+        assert_eq!(1_300, parse_readable_int("1.3s").unwrap());
+        assert_eq!(1_500, parse_readable_int("1.5s").unwrap());
+        assert_eq!(10_000, parse_readable_int("10s").unwrap());
+        assert_eq!(78_000, parse_readable_int("1.3m").unwrap());
+        assert_eq!(90_000, parse_readable_int("1.5m").unwrap());
+        assert_eq!(4_680_000, parse_readable_int("1.3h").unwrap());
+        assert_eq!(5_400_000, parse_readable_int("1.5h").unwrap());
 
         assert!(parse_readable_int("ms").is_err());
         assert!(parse_readable_int("s").is_err());

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -35,7 +35,7 @@ macro_rules! count_args {
     ($head:expr $(, $tail:expr)*) => { 1 + count_args!($($tail),*) };
 }
 
-/// Initial a HashMap with specify key-value pairs.
+/// Initial a `HashMap` with specify key-value pairs.
 ///
 /// # Examples
 ///
@@ -105,10 +105,11 @@ macro_rules! box_err {
     });
 }
 
+#[allow(doc_markdown)]
 /// Recover from panicable closure.
 ///
-/// Please note that this macro assume the closure is able to be forced to implement `RecoverSafe`.
-/// Also see https://doc.rust-lang.org/nightly/std/panic/trait.RecoverSafe.html
+/// Please note that this macro assume the closure is able to be forced to implement `UnwindSafe`.
+/// Also see https://doc.rust-lang.org/std/panic/struct.AssertUnwindSafe.html
 // Maybe we should define a recover macro too.
 #[macro_export]
 macro_rules! recover_safe {

--- a/src/util/sockopt.rs
+++ b/src/util/sockopt.rs
@@ -70,13 +70,13 @@ mod unix {
             let mio_s1 = socket.send_buffer_size().unwrap();
             socket.set_send_buffer_size(8192).unwrap();
             let mio_s2 = socket.send_buffer_size().unwrap();
-            assert!(mio_s2 != mio_s1, "{} should not equal {}", mio_s2, mio_s1);
+            assert_ne!(mio_s2, mio_s1, "{} should not equal {}", mio_s2, mio_s1);
 
             socket.set_recv_buffer_size(4096).unwrap();
             let mio_r1 = socket.recv_buffer_size().unwrap();
             socket.set_recv_buffer_size(8192).unwrap();
             let mio_r2 = socket.recv_buffer_size().unwrap();
-            assert!(mio_r2 != mio_r1, "{} should not equal {}", mio_r2, mio_r1);
+            assert_ne!(mio_r2, mio_r1, "{} should not equal {}", mio_r2, mio_r1);
         }
 
         #[cfg(unix)]

--- a/tests/raft/test_raft.rs
+++ b/tests/raft/test_raft.rs
@@ -328,7 +328,7 @@ impl Network {
                     return false;
                 }
                 // hups never go over the network, so don't drop them but panic
-                assert!(m.get_msg_type() != MessageType::MsgHup, "unexpected msgHup");
+                assert_ne!(m.get_msg_type(), MessageType::MsgHup, "unexpected msgHup");
                 let perc = self.dropm
                     .get(&Connem {
                         from: m.get_from(),
@@ -2242,7 +2242,7 @@ fn test_bcast_beat() {
             }
             want_commit_map.remove(&m.get_to());
         }
-        if m.get_entries().len() != 0 {
+        if !m.get_entries().is_empty() {
             panic!("#{}: entries count = {}, want 0", i, m.get_entries().len());
         }
     }

--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -593,9 +593,10 @@ impl<T: Simulator> Cluster<T> {
         let transfer_leader = new_admin_request(region_id, &epoch, new_transfer_leader_cmd(leader));
         let resp = self.call_command_on_leader(transfer_leader, Duration::from_secs(5))
             .unwrap();
-        assert!(resp.get_admin_response().get_cmd_type() == AdminCmdType::TransferLeader,
-                "{:?}",
-                resp);
+        assert_eq!(resp.get_admin_response().get_cmd_type(),
+                   AdminCmdType::TransferLeader,
+                   "{:?}",
+                   resp);
     }
 
     pub fn must_transfer_leader(&mut self, region_id: u64, leader: metapb::Peer) {

--- a/tests/raftstore/pd.rs
+++ b/tests/raftstore/pd.rs
@@ -216,7 +216,7 @@ impl Cluster {
             // 3) pd is (1, 2), TiKV is (3)
             // 4) pd id (1), TiKV is (2, 3)
 
-            assert!(region_peer_len != cur_region_peer_len);
+            assert_ne!(region_peer_len, cur_region_peer_len);
 
             if cur_region_peer_len > region_peer_len {
                 // must pd is (1, 2), TiKV is (1)

--- a/tests/raftstore/test_multi.rs
+++ b/tests/raftstore/test_multi.rs
@@ -77,7 +77,7 @@ fn test_multi_leader_crash<T: Simulator>(cluster: &mut Cluster<T>) {
     sleep_ms(800);
     cluster.reset_leader_of_region(1);
     let new_leader = cluster.leader_of_region(1).expect("leader should be elected.");
-    assert!(new_leader != last_leader);
+    assert_ne!(new_leader, last_leader);
 
     assert_eq!(cluster.get(key1), Some(value1.to_vec()));
 

--- a/tests/raftstore/test_split_region.rs
+++ b/tests/raftstore/test_split_region.rs
@@ -156,7 +156,7 @@ fn test_auto_split_region<T: Simulator>(cluster: &mut Cluster<T>) {
     let left = pd_client.get_region(b"").unwrap();
     let right = pd_client.get_region(&max_key).unwrap();
 
-    assert!(left != right);
+    assert_ne!(left, right);
     assert_eq!(region.get_start_key(), left.get_start_key());
     assert_eq!(right.get_start_key(), left.get_end_key());
     assert_eq!(region.get_end_key(), right.get_end_key());

--- a/tests/raftstore/test_transport.rs
+++ b/tests/raftstore/test_transport.rs
@@ -38,8 +38,8 @@ fn test_partition_write<T: Simulator>(cluster: &mut Cluster<T>) {
     // leader in minority, new leader should be elected
     cluster.partition(vec![1, 2], vec![3, 4, 5]);
     assert_eq!(cluster.must_get(key), Some(value.to_vec()));
-    assert!(cluster.leader_of_region(region_id).unwrap().get_id() != 1);
-    assert!(cluster.leader_of_region(region_id).unwrap().get_id() != 2);
+    assert_ne!(cluster.leader_of_region(region_id).unwrap().get_id(), 1);
+    assert_ne!(cluster.leader_of_region(region_id).unwrap().get_id(), 2);
     cluster.must_put(key, b"changed");
     cluster.clear_send_filters();
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -23,6 +23,10 @@
 #![allow(new_without_default)]
 #![feature(const_fn)]
 
+// TODO: deny it once Manishearth/rust-clippy#1586 is fixed.
+#![allow(never_loop)]
+#![allow(needless_pass_by_value)]
+
 #[macro_use]
 extern crate log;
 extern crate protobuf;


### PR DESCRIPTION
Now we need to upgrade rustc to 1.17.0-nightly (ccce2c6eb 2017-03-27). If you use rustup, try `rustup override set nightly-2017-03-28`.