### PR TITLE
enlarge scheduler too busy threshold

### DIFF
--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -16,7 +16,7 @@ const DEFAULT_SCHED_CAPACITY: usize = 10240;
 const DEFAULT_SCHED_MSG_PER_TICK: usize = 1024;
 const DEFAULT_SCHED_CONCURRENCY: usize = 102400;
 const DEFAULT_SCHED_WORKER_POOL_SIZE: usize = 4;
-const DEFAULT_SCHED_TOO_BUSY_THRESHOLD: usize = 500;
+const DEFAULT_SCHED_TOO_BUSY_THRESHOLD: usize = 1000;
 
 #[derive(Clone, Debug)]
 pub struct Config {


### PR DESCRIPTION
Enlarge default value from 500 to 1000, that push more write to `raftstore`.
@siddontang @BusyJay PTAL