### PR TITLE
[WIP] *: asynchronous pd client, take 3

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -39,7 +39,7 @@ use raftstore::store::Config;
 use raftstore::store::worker::{apply, PdTask};
 use raftstore::store::worker::apply::ExecResult;
 
-use util::worker::{Worker, Scheduler};
+use util::worker::{Scheduler, AsyncWorker as Worker};
 use raftstore::store::worker::{ApplyTask, ApplyRes};
 use util::{clocktime, Either, HashMap, HashSet, strftimespec};
 

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -41,7 +41,7 @@ use protobuf::Message;
 use raft::{self, SnapshotStatus, INVALID_INDEX};
 use raftstore::{Result, Error};
 use kvproto::metapb;
-use util::worker::{Worker, Scheduler};
+use util::worker::{Worker, Scheduler, AsyncWorker};
 use util::transport::SendCh;
 use util::{rocksdb, HashMap, HashSet, RingQueue};
 use storage::{CF_DEFAULT, CF_LOCK, CF_WRITE};
@@ -96,7 +96,7 @@ pub struct Store<T, C: 'static> {
     region_worker: Worker<RegionTask>,
     raftlog_gc_worker: Worker<RaftlogGcTask>,
     compact_worker: Worker<CompactTask>,
-    pd_worker: Worker<PdTask>,
+    pd_worker: AsyncWorker<PdTask>,
     consistency_check_worker: Worker<ConsistencyCheckTask>,
 
     pub apply_worker: Worker<ApplyTask>,
@@ -178,7 +178,7 @@ impl<T, C> Store<T, C> {
             region_worker: Worker::new("snapshot worker"),
             raftlog_gc_worker: Worker::new("raft gc worker"),
             compact_worker: Worker::new("compact worker"),
-            pd_worker: Worker::new("pd worker"),
+            pd_worker: AsyncWorker::new("pd worker"),
             consistency_check_worker: Worker::new("consistency check worker"),
             apply_worker: Worker::new("apply worker"),
             apply_res_receiver: None,

--- a/src/raftstore/store/worker/pd.rs
+++ b/src/raftstore/store/worker/pd.rs
@@ -16,6 +16,7 @@ use std::fmt::{self, Formatter, Display};
 
 use uuid::Uuid;
 use futures::Future;
+use futures::future::BoxFuture;
 
 use kvproto::metapb;
 use kvproto::eraftpb::ConfChangeType;
@@ -23,7 +24,7 @@ use kvproto::raft_cmdpb::{RaftCmdRequest, AdminRequest, AdminCmdType};
 use kvproto::raft_serverpb::RaftMessage;
 use kvproto::pdpb;
 
-use util::worker::Runnable;
+use util::worker::AsyncRunnable as Runnable;
 use util::escape;
 use util::transport::SendCh;
 use pd::PdClient;
@@ -97,47 +98,38 @@ impl<T: PdClient> Runner<T> {
         }
     }
 
-    fn send_admin_request(&self,
-                          mut region: metapb::Region,
-                          peer: metapb::Peer,
-                          request: AdminRequest) {
-        let region_id = region.get_id();
-        let cmd_type = request.get_cmd_type();
-
-        let mut req = RaftCmdRequest::new();
-        req.mut_header().set_region_id(region_id);
-        req.mut_header().set_region_epoch(region.take_region_epoch());
-        req.mut_header().set_peer(peer);
-        req.mut_header().set_uuid(Uuid::new_v4().as_bytes().to_vec());
-
-        req.set_admin_request(request);
-
-        if let Err(e) = self.ch.try_send(Msg::new_raft_cmd(req, Box::new(|_| {}))) {
-            error!("[region {}] send {:?} request err {:?}",
-                   region_id,
-                   cmd_type,
-                   e);
-        }
-    }
-
-    fn handle_ask_split(&self, region: metapb::Region, split_key: Vec<u8>, peer: metapb::Peer) {
+    fn handle_ask_split(&self,
+                        region: metapb::Region,
+                        split_key: Vec<u8>,
+                        peer: metapb::Peer)
+                        -> BoxFuture<(), ()> {
         PD_REQ_COUNTER_VEC.with_label_values(&["ask split", "all"]).inc();
 
-        match self.pd_client.ask_split(region.clone()).wait() {
-            Ok(mut resp) => {
-                info!("[region {}] try to split with new region id {} for region {:?}",
-                      region.get_id(),
-                      resp.get_new_region_id(),
-                      region);
-                PD_REQ_COUNTER_VEC.with_label_values(&["ask split", "success"]).inc();
+        let ch = self.ch.clone();
+        self.pd_client
+            .ask_split(region.clone())
+            .then(move |resp| {
+                match resp {
+                    Ok(mut resp) => {
+                        info!("[region {}] try to split with new region id {} for region {:?}",
+                              region.get_id(),
+                              resp.get_new_region_id(),
+                              region);
+                        PD_REQ_COUNTER_VEC.with_label_values(&["ask split", "success"]).inc();
 
-                let req = new_split_region_request(split_key,
-                                                   resp.get_new_region_id(),
-                                                   resp.take_new_peer_ids());
-                self.send_admin_request(region, peer, req);
-            }
-            Err(e) => debug!("[region {}] failed to ask split: {:?}", region.get_id(), e),
-        }
+                        let req = new_split_region_request(split_key,
+                                                           resp.get_new_region_id(),
+                                                           resp.take_new_peer_ids());
+                        send_admin_request(&ch, region, peer, req);
+                        Ok(())
+                    }
+                    Err(e) => {
+                        debug!("[region {}] failed to ask split: {:?}", region.get_id(), e);
+                        Err(())
+                    }
+                }
+            })
+            .boxed()
     }
 
     fn handle_heartbeat(&self,
@@ -145,135 +137,155 @@ impl<T: PdClient> Runner<T> {
                         peer: metapb::Peer,
                         down_peers: Vec<pdpb::PeerStats>,
                         pending_peers: Vec<metapb::Peer>,
-                        written_bytes: u64) {
+                        written_bytes: u64)
+                        -> BoxFuture<(), ()> {
         PD_REQ_COUNTER_VEC.with_label_values(&["heartbeat", "all"]).inc();
 
+        let ch = self.ch.clone();
+
         // Now we use put region protocol for heartbeat.
-        match self.pd_client
+        self.pd_client
             .region_heartbeat(region.clone(),
                               peer.clone(),
                               down_peers,
                               pending_peers,
                               written_bytes)
-            .wait() {
-            Ok(mut resp) => {
-                PD_REQ_COUNTER_VEC.with_label_values(&["heartbeat", "success"]).inc();
+            .then(move |resp| {
+                match resp {
+                    Ok(mut resp) => {
+                        PD_REQ_COUNTER_VEC.with_label_values(&["heartbeat", "success"]).inc();
 
-                if resp.has_change_peer() {
-                    PD_HEARTBEAT_COUNTER_VEC.with_label_values(&["change peer"]).inc();
+                        if resp.has_change_peer() {
+                            PD_HEARTBEAT_COUNTER_VEC.with_label_values(&["change peer"]).inc();
 
-                    let mut change_peer = resp.take_change_peer();
-                    info!("[region {}] try to change peer {:?} {:?} for region {:?}",
-                          region.get_id(),
-                          change_peer.get_change_type(),
-                          change_peer.get_peer(),
-                          region);
-                    let req = new_change_peer_request(change_peer.get_change_type().into(),
-                                                      change_peer.take_peer());
-                    self.send_admin_request(region, peer, req);
-                } else if resp.has_transfer_leader() {
-                    PD_HEARTBEAT_COUNTER_VEC.with_label_values(&["transfer leader"]).inc();
+                            let mut change_peer = resp.take_change_peer();
+                            info!("[region {}] try to change peer {:?} {:?} for region {:?}",
+                                  region.get_id(),
+                                  change_peer.get_change_type(),
+                                  change_peer.get_peer(),
+                                  region);
+                            let req = new_change_peer_request(change_peer.get_change_type().into(),
+                                                              change_peer.take_peer());
+                            send_admin_request(&ch, region, peer, req);
+                        } else if resp.has_transfer_leader() {
+                            PD_HEARTBEAT_COUNTER_VEC.with_label_values(&["transfer leader"]).inc();
 
-                    let mut transfer_leader = resp.take_transfer_leader();
-                    info!("[region {}] try to transfer leader from {:?} to {:?}",
-                          region.get_id(),
-                          peer,
-                          transfer_leader.get_peer());
-                    let req = new_transfer_leader_request(transfer_leader.take_peer());
-                    self.send_admin_request(region, peer, req)
+                            let mut transfer_leader = resp.take_transfer_leader();
+                            info!("[region {}] try to transfer leader from {:?} to {:?}",
+                                  region.get_id(),
+                                  peer,
+                                  transfer_leader.get_peer());
+                            let req = new_transfer_leader_request(transfer_leader.take_peer());
+                            send_admin_request(&ch, region, peer, req)
+                        }
+                        Ok(())
+                    }
+                    Err(e) => {
+                        debug!("[region {}] failed to send heartbeat: {:?}",
+                               region.get_id(),
+                               e);
+                        Err(())
+                    }
                 }
-            }
-            Err(e) => {
-                debug!("[region {}] failed to send heartbeat: {:?}",
-                       region.get_id(),
-                       e)
-            }
-        }
+            })
+            .boxed()
     }
 
-    fn handle_store_heartbeat(&self, stats: pdpb::StoreStats) {
-        if let Err(e) = self.pd_client.store_heartbeat(stats).wait() {
-            error!("store heartbeat failed {:?}", e);
-        }
+    fn handle_store_heartbeat(&self, stats: pdpb::StoreStats) -> BoxFuture<(), ()> {
+        self.pd_client
+            .store_heartbeat(stats)
+            .map_err(|e| {
+                error!("store heartbeat failed {:?}", e);
+            })
+            .boxed()
     }
 
-    fn handle_report_split(&self, left: metapb::Region, right: metapb::Region) {
+    fn handle_report_split(&self,
+                           left: metapb::Region,
+                           right: metapb::Region)
+                           -> BoxFuture<(), ()> {
         PD_REQ_COUNTER_VEC.with_label_values(&["report split", "all"]).inc();
 
-        if let Err(e) = self.pd_client.report_split(left, right).wait() {
-            error!("report split failed {:?}", e);
-        }
-        PD_REQ_COUNTER_VEC.with_label_values(&["report split", "success"]).inc();
-    }
-
-    // send a raft message to destroy the specified stale peer
-    fn send_destroy_peer_message(&self,
-                                 local_region: metapb::Region,
-                                 peer: metapb::Peer,
-                                 pd_region: metapb::Region) {
-        let mut message = RaftMessage::new();
-        message.set_region_id(local_region.get_id());
-        message.set_from_peer(peer.clone());
-        message.set_to_peer(peer.clone());
-        message.set_region_epoch(pd_region.get_region_epoch().clone());
-        message.set_is_tombstone(true);
-        if let Err(e) = self.ch.try_send(Msg::RaftMessage(message)) {
-            error!("send gc peer request to region {} err {:?}",
-                   local_region.get_id(),
-                   e)
-        }
-    }
-
-    fn handle_validate_peer(&self, local_region: metapb::Region, peer: metapb::Peer) {
-        PD_REQ_COUNTER_VEC.with_label_values(&["get region", "all"]).inc();
-        match self.pd_client.get_region_by_id(local_region.get_id()).wait() {
-            Ok(Some(pd_region)) => {
-                PD_REQ_COUNTER_VEC.with_label_values(&["get region", "success"]).inc();
-                if is_epoch_stale(pd_region.get_region_epoch(),
-                                  local_region.get_region_epoch()) {
-                    // The local region epoch is fresher than region epoch in PD
-                    // This means the region info in PD is not updated to the latest even
-                    // after max_leader_missing_duration. Something is wrong in the system.
-                    // Just add a log here for this situation.
-                    error!("[region {}] {} the local region epoch: {:?} is greater the region \
-                            epoch in PD: {:?}. Something is wrong!",
-                           local_region.get_id(),
-                           peer.get_id(),
-                           local_region.get_region_epoch(),
-                           pd_region.get_region_epoch());
-                    PD_VALIDATE_PEER_COUNTER_VEC.with_label_values(&["region epoch error"]).inc();
-                    return;
+        self.pd_client
+            .report_split(left, right)
+            .then(move |resp| {
+                match resp {
+                    Ok(_) => {
+                        PD_REQ_COUNTER_VEC.with_label_values(&["report split", "success"]).inc();
+                        Ok(())
+                    }
+                    Err(e) => {
+                        error!("report split failed {:?}", e);
+                        Err(())
+                    }
                 }
+            })
+            .boxed()
+    }
 
-                if pd_region.get_peers().into_iter().all(|p| p != &peer) {
-                    // Peer is not a member of this region anymore. Probably it's removed out.
-                    // Send it a raft massage to destroy it since it's obsolete.
-                    info!("[region {}] {} is not a valid member of region {:?}. To be destroyed \
-                           soon.",
+    fn handle_validate_peer(&self,
+                            local_region: metapb::Region,
+                            peer: metapb::Peer)
+                            -> BoxFuture<(), ()> {
+        PD_REQ_COUNTER_VEC.with_label_values(&["get region", "all"]).inc();
+
+        let ch = self.ch.clone();
+        self.pd_client.get_region_by_id(local_region.get_id()).then(move |resp| {
+            match resp {
+                Ok(Some(pd_region)) => {
+                    PD_REQ_COUNTER_VEC.with_label_values(&["get region", "success"]).inc();
+                    if is_epoch_stale(pd_region.get_region_epoch(),
+                                      local_region.get_region_epoch()) {
+                        // The local region epoch is fresher than region epoch in PD
+                        // This means the region info in PD is not updated to the latest even
+                        // after max_leader_missing_duration. Something is wrong in the system.
+                        // Just add a log here for this situation.
+                        error!("[region {}] {} the local region epoch: {:?} is greater the \
+                                region epoch in PD: {:?}. Something is wrong!",
+                               local_region.get_id(),
+                               peer.get_id(),
+                               local_region.get_region_epoch(),
+                               pd_region.get_region_epoch());
+                        PD_VALIDATE_PEER_COUNTER_VEC.with_label_values(&["region epoch error"])
+                            .inc();
+                        return Err(());
+                    }
+
+                    if pd_region.get_peers().into_iter().all(|p| p != &peer) {
+                        // Peer is not a member of this region anymore. Probably it's removed out.
+                        // Send it a raft massage to destroy it since it's obsolete.
+                        info!("[region {}] {} is not a valid member of region {:?}. To be \
+                               destroyed soon.",
+                              local_region.get_id(),
+                              peer.get_id(),
+                              pd_region);
+                        PD_VALIDATE_PEER_COUNTER_VEC.with_label_values(&["peer stale"]).inc();
+                        send_destroy_peer_message(&ch, local_region, peer, pd_region);
+                        return Ok(());
+                    }
+                    info!("[region {}] {} is still valid in region {:?}",
                           local_region.get_id(),
                           peer.get_id(),
                           pd_region);
-                    PD_VALIDATE_PEER_COUNTER_VEC.with_label_values(&["peer stale"]).inc();
-                    self.send_destroy_peer_message(local_region, peer, pd_region);
-                    return;
+                    PD_VALIDATE_PEER_COUNTER_VEC.with_label_values(&["peer valid"]).inc();
+                    Ok(())
                 }
-                info!("[region {}] {} is still valid in region {:?}",
-                      local_region.get_id(),
-                      peer.get_id(),
-                      pd_region);
-                PD_VALIDATE_PEER_COUNTER_VEC.with_label_values(&["peer valid"]).inc();
+                Ok(None) => {
+                    // split region has not yet report to pd.
+                    // TODO: handle merge
+                    Ok(())
+                }
+                Err(e) => {
+                    error!("get region failed {:?}", e);
+                    Err(())
+                }
             }
-            Ok(None) => {
-                // split region has not yet report to pd.
-                // TODO: handle merge
-            }
-            Err(e) => error!("get region failed {:?}", e),
-        }
+        }).boxed()
     }
 }
 
 impl<T: PdClient> Runnable<Task> for Runner<T> {
-    fn run(&mut self, task: Task) {
+    fn run(&mut self, task: Task) -> BoxFuture<(), ()> {
         debug!("executing task {}", task);
 
         match task {
@@ -286,7 +298,7 @@ impl<T: PdClient> Runnable<Task> for Runner<T> {
             Task::StoreHeartbeat { stats } => self.handle_store_heartbeat(stats),
             Task::ReportSplit { left, right } => self.handle_report_split(left, right),
             Task::ValidatePeer { region, peer } => self.handle_validate_peer(region, peer),
-        };
+        }
     }
 }
 
@@ -315,4 +327,45 @@ fn new_transfer_leader_request(peer: metapb::Peer) -> AdminRequest {
     req.set_cmd_type(AdminCmdType::TransferLeader);
     req.mut_transfer_leader().set_peer(peer);
     req
+}
+
+fn send_admin_request(ch: &SendCh<Msg>,
+                      mut region: metapb::Region,
+                      peer: metapb::Peer,
+                      request: AdminRequest) {
+    let region_id = region.get_id();
+    let cmd_type = request.get_cmd_type();
+
+    let mut req = RaftCmdRequest::new();
+    req.mut_header().set_region_id(region_id);
+    req.mut_header().set_region_epoch(region.take_region_epoch());
+    req.mut_header().set_peer(peer);
+    req.mut_header().set_uuid(Uuid::new_v4().as_bytes().to_vec());
+
+    req.set_admin_request(request);
+
+    if let Err(e) = ch.try_send(Msg::new_raft_cmd(req, Box::new(|_| {}))) {
+        error!("[region {}] send {:?} request err {:?}",
+               region_id,
+               cmd_type,
+               e);
+    }
+}
+
+// send a raft message to destroy the specified stale peer
+fn send_destroy_peer_message(ch: &SendCh<Msg>,
+                             local_region: metapb::Region,
+                             peer: metapb::Peer,
+                             pd_region: metapb::Region) {
+    let mut message = RaftMessage::new();
+    message.set_region_id(local_region.get_id());
+    message.set_from_peer(peer.clone());
+    message.set_to_peer(peer.clone());
+    message.set_region_epoch(pd_region.get_region_epoch().clone());
+    message.set_is_tombstone(true);
+    if let Err(e) = ch.try_send(Msg::RaftMessage(message)) {
+        error!("send gc peer request to region {} err {:?}",
+               local_region.get_id(),
+               e)
+    }
 }

--- a/src/util/worker/async.rs
+++ b/src/util/worker/async.rs
@@ -83,7 +83,7 @@ fn poll<R, T>(mut runner: R, rx: UnboundedReceiver<Option<T>>)
     let mut core = Core::new().unwrap();
     let handle = core.handle();
     {
-        let f = rx.for_each(|t| {
+        let f = rx.take_while(|t| Ok(t.is_some())).for_each(|t| {
             if let Some(t) = t {
                 let f = runner.run(t);
                 handle.spawn(f);

--- a/src/util/worker/async.rs
+++ b/src/util/worker/async.rs
@@ -1,0 +1,162 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle, Builder};
+use std::io;
+use std::fmt::Display;
+
+use futures::Stream;
+use futures::future::BoxFuture;
+use futures::sync::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
+use tokio_core::reactor::Core;
+
+use super::Stopped;
+
+pub trait Runnable<T: Display> {
+    fn run(&mut self, t: T) -> BoxFuture<(), ()>;
+    fn shutdown(&mut self) {}
+}
+
+/// Scheduler provides interface to schedule task to underlying workers.
+pub struct Scheduler<T> {
+    name: Arc<String>,
+    sender: UnboundedSender<Option<T>>,
+}
+
+impl<T: Display> Scheduler<T> {
+    fn new<S: Into<String>>(name: S, sender: UnboundedSender<Option<T>>) -> Scheduler<T> {
+        Scheduler {
+            name: Arc::new(name.into()),
+            sender: sender,
+        }
+    }
+
+    /// Schedule a task to run.
+    ///
+    /// If the worker is stopped, an error will return.
+    pub fn schedule(&self, task: T) -> Result<(), Stopped<T>> {
+        debug!("scheduling task {}", task);
+        if let Err(err) = self.sender.send(Some(task)) {
+            return Err(Stopped(err.into_inner().unwrap()));
+        }
+        Ok(())
+    }
+
+    // TODO: remove it.
+    /// Check if underlying worker can't handle task immediately.
+    pub fn is_busy(&self) -> bool {
+        false
+    }
+}
+
+impl<T: Display> Clone for Scheduler<T> {
+    fn clone(&self) -> Scheduler<T> {
+        Scheduler {
+            name: self.name.clone(),
+            sender: self.sender.clone(),
+        }
+    }
+}
+
+/// A worker that can schedule time consuming tasks.
+pub struct Worker<T: Display> {
+    scheduler: Scheduler<T>,
+    receiver: Mutex<Option<UnboundedReceiver<Option<T>>>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+fn poll<R, T>(mut runner: R, rx: UnboundedReceiver<Option<T>>)
+    where R: Runnable<T> + Send + 'static,
+          T: Display + Send + 'static
+{
+    let mut core = Core::new().unwrap();
+    let handle = core.handle();
+    {
+        let f = rx.for_each(|t| {
+            if let Some(t) = t {
+                let f = runner.run(t);
+                handle.spawn(f);
+            }
+            Ok(())
+        });
+        core.run(f).ok();
+    }
+    runner.shutdown();
+}
+
+impl<T: Display + Send + 'static> Worker<T> {
+    /// Create a worker.
+    pub fn new<S: Into<String>>(name: S) -> Worker<T> {
+        let (tx, rx) = unbounded();
+        Worker {
+            scheduler: Scheduler::new(name, tx),
+            receiver: Mutex::new(Some(rx)),
+            handle: None,
+        }
+    }
+
+    /// Start the worker.
+    pub fn start<R>(&mut self, runner: R) -> Result<(), io::Error>
+        where R: Runnable<T> + Send + 'static
+    {
+        let mut receiver = self.receiver.lock().unwrap();
+        info!("starting working thread: {}", self.scheduler.name);
+        if receiver.is_none() {
+            warn!("worker {} has been started.", self.scheduler.name);
+            return Ok(());
+        }
+
+        let rx = receiver.take().unwrap();
+        let h = try!(Builder::new()
+            .name(thd_name!(self.scheduler.name.as_ref()))
+            .spawn(move || poll(runner, rx)));
+
+        self.handle = Some(h);
+        Ok(())
+    }
+
+    /// Get a scheduler to schedule task.
+    pub fn scheduler(&self) -> Scheduler<T> {
+        self.scheduler.clone()
+    }
+
+    /// Schedule a task to run.
+    ///
+    /// If the worker is stopped, an error will return.
+    pub fn schedule(&self, task: T) -> Result<(), Stopped<T>> {
+        self.scheduler.schedule(task)
+    }
+
+    /// Check if underlying worker can't handle task immediately.
+    pub fn is_busy(&self) -> bool {
+        self.handle.is_none() || self.scheduler.is_busy()
+    }
+
+    pub fn name(&self) -> &str {
+        self.scheduler.name.as_str()
+    }
+
+    /// Stop the worker thread.
+    pub fn stop(&mut self) -> Option<thread::JoinHandle<()>> {
+        // close sender explicitly so the background thread will exit.
+        info!("stoping {}", self.scheduler.name);
+        if self.handle.is_none() {
+            return None;
+        }
+        if let Err(e) = self.scheduler.sender.send(None) {
+            warn!("failed to stop worker thread: {:?}", e);
+        }
+        self.handle.take()
+    }
+}

--- a/src/util/worker/mod.rs
+++ b/src/util/worker/mod.rs
@@ -15,6 +15,7 @@
 /// Worker contains all workers that do the expensive job in background.
 
 mod metrics;
+mod async;
 
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle, Builder};
@@ -26,6 +27,10 @@ use std::error::Error;
 
 use util::SlowTimer;
 use self::metrics::*;
+
+pub use self::async::Runnable as AsyncRunnable;
+pub use self::async::Scheduler as AsyncScheduler;
+pub use self::async::Worker as AsyncWorker;
 
 pub struct Stopped<T>(pub T);
 


### PR DESCRIPTION
This is the third part of using an asynchronous PD client. It contains the following changes:

 - [x] Add an AsyncWorker, it runs a tokio core. (Address https://github.com/pingcap/tikv/pull/1712#issuecomment-290088819)
 - [x] Refactor PdWorker as AsyncWorker. (Address https://github.com/pingcap/tikv/pull/1712#issuecomment-290102625)

Done:
 - [x] Asynchronous retry. #1712 
 - [x] Refactor trait `PdClient`.  #1745 

Next PRs:
 - Add some metrics about asynchronous tasks.
 - Try to replace boxed `Future` with `impl Future` . (Address https://github.com/pingcap/tikv/pull/1712#issuecomment-290329925)