### PR TITLE
pd: always update client

### DIFF
--- a/src/pd/async/util.rs
+++ b/src/pd/async/util.rs
@@ -106,14 +106,11 @@ impl<Req, Resp, F> Request<Req, Resp, F>
         warn!("updating PD client, block the tokio core");
 
         let start = Instant::now();
-        let members = self.inner.rl().members.clone();
-        match try_connect_leader(&members) {
+        match try_connect_leader(&self.inner.rl().members) {
             Ok((client, members)) => {
                 let mut inner = self.inner.wl();
-                if members != inner.members {
-                    inner.client = client;
-                    inner.members = members;
-                }
+                inner.client = client;
+                inner.members = members;
                 warn!("updating PD client done, spent {:?}", start.elapsed());
             }
 

--- a/src/pd/async/util.rs
+++ b/src/pd/async/util.rs
@@ -106,7 +106,8 @@ impl<Req, Resp, F> Request<Req, Resp, F>
         warn!("updating PD client, block the tokio core");
 
         let start = Instant::now();
-        match try_connect_leader(&self.inner.rl().members) {
+        let members = self.inner.rl().members.clone();
+        match try_connect_leader(&members) {
             Ok((client, members)) => {
                 let mut inner = self.inner.wl();
                 inner.client = client;

--- a/tests/pd/test_rpc_client.rs
+++ b/tests/pd/test_rpc_client.rs
@@ -156,6 +156,7 @@ fn test_restart_leader() {
         "http://127.0.0.1:62978".to_owned(),
     ];
 
+    // Service has only one GetMembersResponse, so the leader never changes.
     let se = Arc::new(Service::new(eps.clone()));
     // Start mock servers.
     let _server_a = MockServer::run("127.0.0.1:42978", se.clone(), Some(se.clone()));


### PR DESCRIPTION
For one node PD cluster, tikv pd client will fail to make a request if the pd leader restarts. Similarly, if the member response doesn't change, tikv pd client will always skip updating the inner grpc client.


PTAL @siddontang @nolouch @BusyJay @zhangjinpeng1987 