### PR TITLE
pd: fix a deadlock

### DIFF
--- a/src/pd/async/client.rs
+++ b/src/pd/async/client.rs
@@ -202,7 +202,8 @@ fn do_request<F, R>(client: &RpcClient, f: F) -> Result<R>
             }
             Err(e) => {
                 error!("fail to request: {:?}", e);
-                match try_connect_leader(&client.leader_client.inner.rl().members) {
+                let result = try_connect_leader(&client.leader_client.inner.rl().members);
+                match result {
                     Ok((cli, mbrs)) => {
                         let mut inner = client.leader_client.inner.wl();
                         inner.client = cli;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -555,7 +555,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rwlock() {
+    fn test_rwlock_deadlock() {
         // If the test runs over 60s, then there is a deadlock.
         let mu = RwLock::new(Some(1));
         {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -553,4 +553,30 @@ mod tests {
         defer!(assert!(!sp.load(Ordering::SeqCst)));
         should_panic.store(false, Ordering::SeqCst);
     }
+
+    #[test]
+    fn test_rwlock() {
+        // If the test runs over 60s, then there is a deadlock.
+        let mu = RwLock::new(Some(1));
+        {
+            let _clone = foo(&mu.rl());
+            let mut data = mu.wl();
+            assert!(data.is_some());
+            *data = None;
+        }
+
+        {
+            match foo(&mu.rl()) {
+                Some(_) | None => {
+                    let res = mu.try_write();
+                    assert!(res.is_err());
+                }
+            }
+        }
+
+        #[allow(clone_on_copy)]
+        fn foo(a: &Option<usize>) -> Option<usize> {
+            a.clone()
+        }
+    }
 }


### PR DESCRIPTION
This PR fix deadlock pitfall. Reading then writing a `RwLock` in a match block will cause a deadlock.

Demo: 

```rust
use std::sync::RwLock;

fn main() {
    let mu = RwLock::new(Some(1));
    {
        let clone = foo(&mu.read().unwrap());
        let mut data = mu.write().unwrap();
        *data = Some(2);
        println!("none match: {:?}", clone);
    }

    {
        match foo(&mu.read().unwrap()) {
            Some(_) | None => {
                let mut data = mu.write().unwrap();
                *data = Some(2);
                println!("in match");
            }
        }
    }

    println!("done");
}

fn foo(a: &Option<usize>) -> Option<usize> {
    a.clone()
}
```

[Playground](https://play.rust-lang.org/?gist=10e3fc41ce939cc7ab7a1c1341fc59c6&version=stable&backtrace=0)
