### PR TITLE
grpc server [3]: impl raftMsg client and snapshot send.

### DIFF
--- a/src/server/errors.rs
+++ b/src/server/errors.rs
@@ -18,7 +18,7 @@ use std::io::Error as IoError;
 use std::net::AddrParseError;
 
 use protobuf::ProtobufError;
-
+use grpc::error::GrpcError;
 use util::codec::Error as CodecError;
 use raftstore::Error as RaftServerError;
 use storage::engine::Error as EngineError;
@@ -41,6 +41,11 @@ quick_error!{
             description(err.description())
         }
         Protobuf(err: ProtobufError) {
+            from()
+            cause(err)
+            description(err.description())
+        }
+        Grpc(err: GrpcError) {
             from()
             cause(err)
             description(err.description())

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -23,6 +23,7 @@ use kvproto::eraftpb::MessageType as RaftMessageType;
 use kvproto::raft_serverpb::RaftMessage;
 use kvproto::coprocessor::Response;
 mod handle;
+mod raft_client;
 mod conn;
 mod metrics;
 

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -1,0 +1,90 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+use std::net::SocketAddr;
+use futures::{future, Future, Stream};
+use futures::sync::mpsc;
+use tokio_core::reactor::Handle;
+use grpc::error::GrpcError;
+use kvproto::raft_serverpb::RaftMessage;
+use kvproto::tikvpb_grpc::TiKVAsyncClient;
+use kvproto::tikvpb_grpc::TiKVAsync;
+use util::worker::FutureRunnable;
+use util::{HashMap, TryInsertWith};
+use super::Result;
+
+// SendTask delivers a raft message to other store.
+pub struct SendTask {
+    pub addr: SocketAddr,
+    pub msg: RaftMessage,
+}
+
+impl fmt::Display for SendTask {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "send raft message to {:?}", self.addr)
+    }
+}
+
+struct Conn {
+    _client: TiKVAsyncClient,
+    stream: mpsc::UnboundedSender<RaftMessage>,
+}
+
+impl Conn {
+    fn new(addr: SocketAddr, handle: &Handle) -> Result<Conn> {
+        let host = format!("{}", addr.ip());
+        let client = box_try!(TiKVAsyncClient::new(&*host, addr.port(), false, Default::default()));
+        let (tx, rx) = mpsc::unbounded();
+        handle.spawn(client.Raft(box rx.map_err(|_| GrpcError::Other("canceled")))
+            .then(|_| future::ok(())));
+        Ok(Conn {
+            _client: client,
+            stream: tx,
+        })
+    }
+}
+
+// SendRunner is used for sending raft messages to other stores.
+pub struct SendRunner {
+    conns: HashMap<SocketAddr, Conn>,
+}
+
+impl Default for SendRunner {
+    fn default() -> SendRunner {
+        SendRunner { conns: HashMap::default() }
+    }
+}
+
+impl SendRunner {
+    fn get_conn(&mut self, addr: SocketAddr, handle: &Handle) -> Result<&Conn> {
+        let conn = try!(self.conns.entry(addr).or_try_insert_with(|| Conn::new(addr, handle)));
+        Ok(conn)
+    }
+
+    fn send(&mut self, t: SendTask, handle: &Handle) -> Result<()> {
+        let conn = try!(self.get_conn(t.addr, handle));
+        box_try!(conn.stream.send(t.msg));
+        Ok(())
+    }
+}
+
+impl FutureRunnable<SendTask> for SendRunner {
+    fn run(&mut self, t: SendTask, handle: &Handle) {
+        let addr = t.addr;
+        if let Err(e) = self.send(t, handle) {
+            error!("send raft message error: {:?}", e);
+            self.conns.remove(&addr);
+        }
+    }
+}

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -13,12 +13,14 @@
 
 use std::fmt;
 use std::net::SocketAddr;
+
 use futures::{future, Future, Stream};
 use futures::sync::mpsc;
 use tokio_core::reactor::Handle;
 use grpc::error::GrpcError;
 use kvproto::raft_serverpb::RaftMessage;
 use kvproto::tikvpb_grpc::{TiKVAsync, TiKVAsyncClient};
+
 use util::worker::FutureRunnable;
 use util::{HashMap, TryInsertWith};
 use super::Result;

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -18,13 +18,12 @@ use futures::sync::mpsc;
 use tokio_core::reactor::Handle;
 use grpc::error::GrpcError;
 use kvproto::raft_serverpb::RaftMessage;
-use kvproto::tikvpb_grpc::TiKVAsyncClient;
-use kvproto::tikvpb_grpc::TiKVAsync;
+use kvproto::tikvpb_grpc::{TiKVAsync, TiKVAsyncClient};
 use util::worker::FutureRunnable;
 use util::{HashMap, TryInsertWith};
 use super::Result;
 
-// SendTask delivers a raft message to other store.
+// SendTask delivers a raft message to other stores.
 pub struct SendTask {
     pub addr: SocketAddr,
     pub msg: RaftMessage,

--- a/src/server/snap.rs
+++ b/src/server/snap.rs
@@ -134,9 +134,9 @@ fn send_snap(mgr: SnapManager, addr: SocketAddr, data: ConnData) -> Result<()> {
 
     // snapshot file has been validated when created, so no need to validate again.
 
-    // Ideally, we should not collect all chunks here, and send an iterator to Grpc clint to save
-    // memory. But inside grpc client, the iterator need to be move to another thread, and we can't
-    // send the snapshot away because we need to use it later.
+    // Ideally, we should not collect all chunks here, and send an iterator to Grpc client to save
+    // memory. But inside grpc client, the iterator needs to be moved to another thread, and we
+    // can't send the snapshot away because we need to use it later.
     let chunks: Vec<result::Result<SnapshotChunk, GrpcError>> = {
         let snap_chunk = SnapChunk { snap: s.as_mut() };
         let first = iter::once({

--- a/src/server/snap.rs
+++ b/src/server/snap.rs
@@ -13,19 +13,23 @@
 
 use std::fmt::{self, Formatter, Display};
 use std::io;
-use std::net::{SocketAddr, TcpStream};
-use std::io::Read;
+use std::iter::Iterator;
+use std::net::SocketAddr;
 use std::collections::hash_map::Entry;
 use std::boxed::FnBox;
-use std::time::{Instant, Duration};
+use std::time::Instant;
+use std::iter;
+use std::result;
 
 use threadpool::ThreadPool;
 use mio::Token;
+use grpc::error::GrpcError;
+use kvproto::raft_serverpb::SnapshotChunk;
 use kvproto::raft_serverpb::RaftMessage;
+use kvproto::tikvpb_grpc::{TiKVClient, TiKV};
 
 use raftstore::store::{SnapManager, SnapKey, SnapEntry, Snapshot};
 use util::worker::Runnable;
-use util::codec::rpc;
 use util::buf::PipeBuffer;
 use util::HashMap;
 use util::transport::SendCh;
@@ -37,8 +41,6 @@ use super::transport::RaftStoreRouter;
 pub type Callback = Box<FnBox(Result<()>) + Send>;
 
 const DEFAULT_SENDER_POOL_SIZE: usize = 3;
-const DEFAULT_READ_TIMEOUT: u64 = 30;
-const DEFAULT_WRITE_TIMEOUT: u64 = 30;
 
 /// `Task` that `Runner` can handle.
 ///
@@ -73,6 +75,41 @@ impl Display for Task {
     }
 }
 
+struct SnapChunk<'a, T: Snapshot + ?Sized + 'a> {
+    snap: &'a mut T,
+}
+
+const SNAP_CHUNK_LEN: usize = 1024 * 1024;
+
+impl<'a, T: Snapshot + ?Sized + 'a> Iterator for SnapChunk<'a, T> {
+    type Item = result::Result<Vec<u8>, io::Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut buf = vec![0; SNAP_CHUNK_LEN];
+        let mut written = 0;
+        loop {
+            let len = match self.snap.read(&mut buf[written..]) {
+                Ok(0) => {
+                    return if written > 0 {
+                        Some(Ok(buf.drain(..written).collect()))
+                    } else {
+                        None
+                    }
+                }
+                Ok(len) => len,
+                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                Err(e) => {
+                    return Some(Err(e));
+                }
+            };
+            written += len;
+            if written >= SNAP_CHUNK_LEN {
+                return Some(Ok(buf));
+            }
+        }
+    }
+}
+
 /// Send the snapshot to specified address.
 ///
 /// It will first send the normal raft snapshot message and then send the snapshot file.
@@ -82,8 +119,10 @@ fn send_snap(mgr: SnapManager, addr: SocketAddr, data: ConnData) -> Result<()> {
 
     let send_timer = SEND_SNAP_HISTOGRAM.start_timer();
 
-    let snap = data.msg.get_message().get_snapshot();
-    let key = try!(SnapKey::from_snap(&snap));
+    let key = {
+        let snap = data.msg.get_message().get_snapshot();
+        try!(SnapKey::from_snap(&snap))
+    };
     mgr.register(key.clone(), SnapEntry::Sending);
     let mut s = box_try!(mgr.get_snapshot_for_sending(&key));
     defer!({
@@ -92,16 +131,33 @@ fn send_snap(mgr: SnapManager, addr: SocketAddr, data: ConnData) -> Result<()> {
     if !s.exists() {
         return Err(box_err!("missing snap file: {:?}", s.path()));
     }
+
     // snapshot file has been validated when created, so no need to validate again.
 
-    let mut conn = try!(TcpStream::connect(&addr));
-    try!(conn.set_nodelay(true));
-    try!(conn.set_read_timeout(Some(Duration::from_secs(DEFAULT_READ_TIMEOUT))));
-    try!(conn.set_write_timeout(Some(Duration::from_secs(DEFAULT_WRITE_TIMEOUT))));
+    // Ideally, we should not collect all chunks here, and send an iterator to Grpc clint to save
+    // memory. But inside grpc client, the iterator need to be move to another thread, and we can't
+    // send the snapshot away because we need to use it later.
+    let chunks: Vec<result::Result<SnapshotChunk, GrpcError>> = {
+        let snap_chunk = SnapChunk { snap: s.as_mut() };
+        let first = iter::once({
+            let mut chunk = SnapshotChunk::new();
+            chunk.set_message(data.msg);
+            Ok(chunk)
+        });
+        let rests = snap_chunk.map(|item| {
+            item.map(|buf| {
+                    let mut chunk = SnapshotChunk::new();
+                    chunk.set_data(buf);
+                    chunk
+                })
+                .map_err(GrpcError::Io)
+        });
+        first.chain(rests).collect()
+    };
 
-    let res = rpc::encode_msg(&mut conn, data.msg_id, &data.msg)
-        .and_then(|_| io::copy(&mut s, &mut conn).map_err(From::from))
-        .and_then(|_| conn.read(&mut [0]).map_err(From::from))
+    let host = format!("{}", addr.ip());
+    let res = TiKVClient::new(&*host, addr.port(), false, Default::default())
+        .and_then(|client| client.Snapshot(box chunks.into_iter()))
         .map(|_| ())
         .map_err(From::from);
     let size = try!(s.total_size());


### PR DESCRIPTION
The plan:
1. [x] update kvproto.
2. [x] remove kv/coprocessor from TCP server.
3. [x] impl  grpc server.
4. [x] impl raft grpc client.
5. [x] impl grpc snapshot.
6. [ ] replace TCP server with grpc servers.
7. [ ] add tests.