### PR TITLE
update rocksdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#73a86f7136904b2d93c4264caafa66ef3abce0a6"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#3d49265a12b1b7371b35ad142f34debd99090aef"
 dependencies = [
  "gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -795,7 +795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#73a86f7136904b2d93c4264caafa66ef3abce0a6"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#3d49265a12b1b7371b35ad142f34debd99090aef"
 dependencies = [
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "librocksdb_sys 0.1.0 (git+https://github.com/pingcap/rust-rocksdb.git)",


### PR DESCRIPTION
To support o2 optimization, we need to use latest rust-rocksdb.