### PR TITLE
enlarge default write-buffer-size for lock cf

### DIFF
--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -497,7 +497,7 @@ fn get_rocksdb_lock_cf_option(config: &toml::Value) -> RocksdbOptions {
 
     let block_cache_size = get_toml_int(config,
                                         "rocksdb.lockcf.block-cache-size",
-                                        Some(64 * 1024 * 1024));
+                                        Some(256 * 1024 * 1024));
     block_base_opts.set_lru_cache(block_cache_size as usize);
 
     block_base_opts.set_bloom_filter(10, false);
@@ -510,7 +510,7 @@ fn get_rocksdb_lock_cf_option(config: &toml::Value) -> RocksdbOptions {
 
     let write_buffer_size = get_toml_int(config,
                                          "rocksdb.lockcf.write-buffer-size",
-                                         Some(64 * 1024 * 1024));
+                                         Some(128 * 1024 * 1024));
     opts.set_write_buffer_size(write_buffer_size as u64);
 
     let max_write_buffer_number =
@@ -519,7 +519,7 @@ fn get_rocksdb_lock_cf_option(config: &toml::Value) -> RocksdbOptions {
 
     let max_bytes_for_level_base = get_toml_int(config,
                                                 "rocksdb.lockcf.max-bytes-for-level-base",
-                                                Some(64 * 1024 * 1024));
+                                                Some(128 * 1024 * 1024));
     opts.set_max_bytes_for_level_base(max_bytes_for_level_base as u64);
     opts.set_target_file_size_base(32 * 1024 * 1024);
 


### PR DESCRIPTION
Enlarge default write-buffer-size and block-cache-size for lock cf.
@siddontang @lishihai9017 PTAL