### PR TITLE
pd: better sleep mechanism on retry

### DIFF
--- a/src/pd/async/util.rs
+++ b/src/pd/async/util.rs
@@ -93,10 +93,12 @@ impl LeaderClient {
             (try!(try_connect_leader(&inner.members)), start)
         };
 
-        let mut inner = self.inner.wl();
-        inner.client = client;
-        inner.members = members;
-        inner.last_update = Instant::now();
+        {
+            let mut inner = self.inner.wl();
+            inner.client = client;
+            inner.members = members;
+            inner.last_update = Instant::now();
+        }
         warn!("updating PD client done, spent {:?}", start.elapsed());
         Ok(())
     }

--- a/src/pd/async/util.rs
+++ b/src/pd/async/util.rs
@@ -88,10 +88,10 @@ impl LeaderClient {
         let ret = {
             let inner = self.inner.rl();
             sleep = inner.timer
-                .sleep(Duration::from_secs(RECON_INTERVAL))
+                .sleep(Duration::from_secs(RECONNECT_INTERVAL_SEC))
                 .map_err(|e| box_err!(e))
                 .boxed();
-            if inner.last_update.elapsed() < Duration::from_secs(RECON_INTERVAL) {
+            if inner.last_update.elapsed() < Duration::from_secs(RECONNECT_INTERVAL_SEC) {
                 // Avoid unnecessary updating.
                 return sleep;
             }
@@ -120,8 +120,8 @@ impl LeaderClient {
     }
 }
 
-const RECON_INTERVAL: u64 = 1; // 1s
-const RETRY_INTERVAL: u64 = 500; // 500ms
+const RECONNECT_INTERVAL_SEC: u64 = 1; // 1s
+const RETRY_INTERVAL_MS: u64 = 500; // 500ms
 
 /// The context of sending requets.
 pub struct Request<Req, Resp, F> {
@@ -153,7 +153,7 @@ impl<Req, Resp, F> Request<Req, Resp, F>
         if self.request_sent < MAX_REQUEST_COUNT {
             debug!("retry on the same client");
             let sleep =
-                self.timer.sleep(Duration::from_millis(RETRY_INTERVAL)).map_err(|e| box_err!(e));
+                self.timer.sleep(Duration::from_millis(RETRY_INTERVAL_MS)).map_err(|e| box_err!(e));
             return sleep.map(|_| self).boxed();
         }
 

--- a/src/pd/async/util.rs
+++ b/src/pd/async/util.rs
@@ -102,7 +102,7 @@ impl LeaderClient {
     }
 }
 
-const RECONNECT_INTERVAL_SEC: u64 = 2; // 2s
+const RECONNECT_INTERVAL_SEC: u64 = 1; // 1s
 
 /// The context of sending requets.
 pub struct Request<Req, Resp, F> {
@@ -143,7 +143,7 @@ impl<Req, Resp, F> Request<Req, Resp, F>
             }
             Err(_) => {
                 self.timer
-                    .sleep(Duration::from_secs(RECONNECT_INTERVAL_SEC / 2))
+                    .sleep(Duration::from_secs(RECONNECT_INTERVAL_SEC))
                     .then(|_| Err(self))
                     .boxed()
             }

--- a/tests/pd/test_rpc_client.rs
+++ b/tests/pd/test_rpc_client.rs
@@ -163,7 +163,7 @@ fn test_restart_leader() {
     let _server_b = MockServer::run("127.0.0.1:52978", se.clone(), Some(se.clone()));
     let _server_c = MockServer::run("127.0.0.1:62978", se.clone(), Some(se.clone()));
 
-    thread::sleep(Duration::from_secs(1));
+    thread::sleep(Duration::from_secs(2));
 
     let client = RpcClient::new(&eps[0]).unwrap();
     // Put a region.
@@ -193,7 +193,9 @@ fn test_restart_leader() {
     let _server_a = MockServer::run("127.0.0.1:42978", se.clone(), Some(se.clone()));
     let _server_b = MockServer::run("127.0.0.1:52978", se.clone(), Some(se.clone()));
     let _server_c = MockServer::run("127.0.0.1:62978", se.clone(), Some(se.clone()));
-    thread::sleep(Duration::from_secs(1));
+
+    // RECONNECT_INTERVAL_SEC is 2s.
+    thread::sleep(Duration::from_secs(2));
 
     let region = client.get_region_by_id(1);
     region.wait().unwrap();

--- a/tests/pd/test_rpc_client.rs
+++ b/tests/pd/test_rpc_client.rs
@@ -194,8 +194,8 @@ fn test_restart_leader() {
     let _server_b = MockServer::run("127.0.0.1:52978", se.clone(), Some(se.clone()));
     let _server_c = MockServer::run("127.0.0.1:62978", se.clone(), Some(se.clone()));
 
-    // RECONNECT_INTERVAL_SEC is 2s.
-    thread::sleep(Duration::from_secs(2));
+    // RECONNECT_INTERVAL_SEC is 1s.
+    thread::sleep(Duration::from_secs(1));
 
     let region = client.get_region_by_id(1);
     region.wait().unwrap();


### PR DESCRIPTION
If a request fails, it will retry after 500ms (will not block core). If it fails 5 times, it tries to update client (will block core).

PTAL @siddontang @BusyJay @disksing 