### PR TITLE
util: fix cf disorder when creating cfs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
  "quick-error 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.70 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocksdb 0.3.0 (git+https://github.com/pingcap/rust-rocksdb.git?branch=hhkbp2/add-constructor-for-sstfilewriter)",
+ "rocksdb 0.3.0 (git+https://github.com/pingcap/rust-rocksdb.git)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sys-info 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -472,7 +472,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git?branch=hhkbp2/add-constructor-for-sstfilewriter#db205d07b0b67259a7c22043208b7973a35a0223"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#ee4c6ebb162d67fb56c74476eb369a6bdbc3957b"
 dependencies = [
  "gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -796,10 +796,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git?branch=hhkbp2/add-constructor-for-sstfilewriter#db205d07b0b67259a7c22043208b7973a35a0223"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#ee4c6ebb162d67fb56c74476eb369a6bdbc3957b"
 dependencies = [
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "librocksdb_sys 0.1.0 (git+https://github.com/pingcap/rust-rocksdb.git?branch=hhkbp2/add-constructor-for-sstfilewriter)",
+ "librocksdb_sys 0.1.0 (git+https://github.com/pingcap/rust-rocksdb.git)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1259,7 +1259,7 @@ dependencies = [
 "checksum lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce12306c4739d86ee97c23139f3a34ddf0387bbf181bc7929d287025a8c3ef6b"
 "checksum libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "e32a70cf75e5846d53a673923498228bbec6a8624708a9ea5645f075d6276122"
 "checksum libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "88ee81885f9f04bff991e306fea7c1c60a5f0f9e409e99f6b40e3311a3363135"
-"checksum librocksdb_sys 0.1.0 (git+https://github.com/pingcap/rust-rocksdb.git?branch=hhkbp2/add-constructor-for-sstfilewriter)" = "<none>"
+"checksum librocksdb_sys 0.1.0 (git+https://github.com/pingcap/rust-rocksdb.git)" = "<none>"
 "checksum log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ab83497bf8bf4ed2a74259c1c802351fcd67a65baa86394b6ba73c36f4838054"
 "checksum matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "15305656809ce5a4805b1ff2946892810992197ce1270ff79baded852187942e"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
@@ -1295,7 +1295,7 @@ dependencies = [
 "checksum regex 0.1.70 (registry+https://github.com/rust-lang/crates.io-index)" = "bd76238a728b22c47576b70f478ae13ee4f7094a83e7f11ffedcb67d77f928c4"
 "checksum regex-syntax 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "841591b1e05609a643e3b4d0045fce04f701daba7151ddcd3ad47b080693d5a9"
 "checksum regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9191b1f57603095f105d317e375d19b1c9c5c3185ea9633a99a6dcbed04457"
-"checksum rocksdb 0.3.0 (git+https://github.com/pingcap/rust-rocksdb.git?branch=hhkbp2/add-constructor-for-sstfilewriter)" = "<none>"
+"checksum rocksdb 0.3.0 (git+https://github.com/pingcap/rust-rocksdb.git)" = "<none>"
 "checksum rustc-demangle 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "662b2795f21ff17df7c4c50c1d955c8b5fa9eaddd1cf1bb32f8de2372ffd989b"
 "checksum rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "6159e4e6e559c81bd706afe9c8fd68f547d3e851ce12e76b1de7914bab61691b"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
  "quick-error 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.70 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocksdb 0.3.0 (git+https://github.com/pingcap/rust-rocksdb.git)",
+ "rocksdb 0.3.0 (git+https://github.com/pingcap/rust-rocksdb.git?branch=hhkbp2/add-constructor-for-sstfilewriter)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sys-info 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -472,7 +472,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#b3550b42fa11f04a12cc4199d95e06b27676d74b"
+source = "git+https://github.com/pingcap/rust-rocksdb.git?branch=hhkbp2/add-constructor-for-sstfilewriter#db205d07b0b67259a7c22043208b7973a35a0223"
 dependencies = [
  "gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -796,10 +796,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#b3550b42fa11f04a12cc4199d95e06b27676d74b"
+source = "git+https://github.com/pingcap/rust-rocksdb.git?branch=hhkbp2/add-constructor-for-sstfilewriter#db205d07b0b67259a7c22043208b7973a35a0223"
 dependencies = [
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "librocksdb_sys 0.1.0 (git+https://github.com/pingcap/rust-rocksdb.git)",
+ "librocksdb_sys 0.1.0 (git+https://github.com/pingcap/rust-rocksdb.git?branch=hhkbp2/add-constructor-for-sstfilewriter)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1259,7 +1259,7 @@ dependencies = [
 "checksum lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce12306c4739d86ee97c23139f3a34ddf0387bbf181bc7929d287025a8c3ef6b"
 "checksum libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "e32a70cf75e5846d53a673923498228bbec6a8624708a9ea5645f075d6276122"
 "checksum libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "88ee81885f9f04bff991e306fea7c1c60a5f0f9e409e99f6b40e3311a3363135"
-"checksum librocksdb_sys 0.1.0 (git+https://github.com/pingcap/rust-rocksdb.git)" = "<none>"
+"checksum librocksdb_sys 0.1.0 (git+https://github.com/pingcap/rust-rocksdb.git?branch=hhkbp2/add-constructor-for-sstfilewriter)" = "<none>"
 "checksum log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ab83497bf8bf4ed2a74259c1c802351fcd67a65baa86394b6ba73c36f4838054"
 "checksum matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "15305656809ce5a4805b1ff2946892810992197ce1270ff79baded852187942e"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
@@ -1295,7 +1295,7 @@ dependencies = [
 "checksum regex 0.1.70 (registry+https://github.com/rust-lang/crates.io-index)" = "bd76238a728b22c47576b70f478ae13ee4f7094a83e7f11ffedcb67d77f928c4"
 "checksum regex-syntax 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "841591b1e05609a643e3b4d0045fce04f701daba7151ddcd3ad47b080693d5a9"
 "checksum regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9191b1f57603095f105d317e375d19b1c9c5c3185ea9633a99a6dcbed04457"
-"checksum rocksdb 0.3.0 (git+https://github.com/pingcap/rust-rocksdb.git)" = "<none>"
+"checksum rocksdb 0.3.0 (git+https://github.com/pingcap/rust-rocksdb.git?branch=hhkbp2/add-constructor-for-sstfilewriter)" = "<none>"
 "checksum rustc-demangle 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "662b2795f21ff17df7c4c50c1d955c8b5fa9eaddd1cf1bb32f8de2372ffd989b"
 "checksum rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "6159e4e6e559c81bd706afe9c8fd68f547d3e851ce12e76b1de7914bab61691b"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,6 @@ signal = "0.2"
 
 [dependencies.rocksdb]
 git = "https://github.com/pingcap/rust-rocksdb.git"
-branch = "hhkbp2/add-constructor-for-sstfilewriter"
 
 [dependencies.kvproto]
 git = "https://github.com/pingcap/kvproto.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ signal = "0.2"
 
 [dependencies.rocksdb]
 git = "https://github.com/pingcap/rust-rocksdb.git"
+branch = "hhkbp2/add-constructor-for-sstfilewriter"
 
 [dependencies.kvproto]
 git = "https://github.com/pingcap/kvproto.git"

--- a/src/bin/tikv-ctl.rs
+++ b/src/bin/tikv-ctl.rs
@@ -136,7 +136,7 @@ fn main() {
     let db_path = matches.value_of("db").unwrap();
     let db = util::rocksdb::open(db_path, ALL_CFS).unwrap();
     if let Some(matches) = matches.subcommand_matches("print") {
-        let cf_name = matches.value_of("cf").unwrap_or("default");
+        let cf_name = matches.value_of("cf").unwrap_or(CF_DEFAULT);
         let key = String::from(matches.value_of("key").unwrap());
         dump_raw_value(db, cf_name, key);
     } else if let Some(matches) = matches.subcommand_matches("raft") {
@@ -165,7 +165,7 @@ fn main() {
         let from = String::from(matches.value_of("from").unwrap());
         let to = matches.value_of("to").map(String::from);
         let limit = matches.value_of("limit").map(|s| s.parse().unwrap());
-        let cf_name = matches.value_of("cf").unwrap_or("default");
+        let cf_name = matches.value_of("cf").unwrap_or(CF_DEFAULT);
         let start_ts = matches.value_of("start_ts").map(|s| s.parse().unwrap());
         let commit_ts = matches.value_of("commit_ts").map(|s| s.parse().unwrap());
         if let Some(ref to) = to {
@@ -175,7 +175,7 @@ fn main() {
         }
         dump_range(db, from, to, limit, cf_name, start_ts, commit_ts);
     } else if let Some(matches) = matches.subcommand_matches("mvcc") {
-        let cf_name = matches.value_of("cf").unwrap_or("default");
+        let cf_name = matches.value_of("cf").unwrap_or(CF_DEFAULT);
         let key = matches.value_of("key").unwrap();
         let key_encoded = matches.is_present("encoded");
         let start_ts = matches.value_of("start_ts").map(|s| s.parse().unwrap());

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -692,11 +692,12 @@ fn build_raftkv(config: &toml::Value,
     let trans = ServerTransport::new(ch);
     let path = Path::new(&cfg.storage.path).to_path_buf();
     let db_opts = get_rocksdb_db_option(config);
-    let mut cfs_opts = HashMap::default();
-    cfs_opts.insert(CF_DEFAULT, get_rocksdb_default_cf_option(config, total_mem));
-    cfs_opts.insert(CF_LOCK, get_rocksdb_lock_cf_option(config));
-    cfs_opts.insert(CF_WRITE, get_rocksdb_write_cf_option(config, total_mem));
-    cfs_opts.insert(CF_RAFT, get_rocksdb_raftlog_cf_option(config, total_mem));
+    let cfs_opts = vec![
+        rocksdb_util::CFOptions::new(CF_DEFAULT, get_rocksdb_default_cf_option(config, total_mem)),
+        rocksdb_util::CFOptions::new(CF_LOCK, get_rocksdb_lock_cf_option(config)),
+        rocksdb_util::CFOptions::new(CF_WRITE, get_rocksdb_write_cf_option(config, total_mem)),
+        rocksdb_util::CFOptions::new(CF_RAFT, get_rocksdb_raftlog_cf_option(config, total_mem)),
+    ];
     let mut db_path = path.clone();
     db_path.push("db");
     let engine = Arc::new(rocksdb_util::new_engine_opt(db_path.to_str()

--- a/src/raftstore/store/engine.rs
+++ b/src/raftstore/store/engine.rs
@@ -447,7 +447,6 @@ mod tests {
 
     use super::*;
     use kvproto::metapb::Region;
-    use util::collections::HashMap;
 
     #[test]
     fn test_base() {
@@ -602,10 +601,9 @@ mod tests {
         db_opt.set_write_buffer_size(1024);
         db_opt.compression(DBCompressionType::DBNo);
 
-        let engine = Arc::new(rocksdb::new_engine_opt(path.path().to_str().unwrap(),
-                                                      db_opt,
-                                                      HashMap::default())
-            .unwrap());
+        let engine =
+            Arc::new(rocksdb::new_engine_opt(path.path().to_str().unwrap(), db_opt, vec![])
+                .unwrap());
 
         let value = vec![0;1024];
         for i in 0..10 {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -584,4 +584,20 @@ mod tests {
             a.clone()
         }
     }
+
+    #[test]
+    fn test_cfs_diff() {
+        let a = vec!["1", "2", "3"];
+        let a_diff_a = cfs_diff(&a, &a);
+        assert!(a_diff_a.is_empty());
+        let b = vec!["4"];
+        assert_eq!(a, cfs_diff(&a, &b));
+        let c = vec!["4", "5", "3", "6"];
+        assert_eq!(vec!["1", "2"], cfs_diff(&a, &c));
+        assert_eq!(vec!["4", "5", "6"], cfs_diff(&c, &a));
+        let d = vec!["1", "2", "3", "4"];
+        let a_diff_d = cfs_diff(&a, &d);
+        assert!(a_diff_d.is_empty());
+        assert_eq!(vec!["4"], cfs_diff(&d, &a));
+    }
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -468,7 +468,7 @@ impl<T> RingQueue<T> {
 }
 
 // `cfs_diff' Returns a Vec of cf which is in `a' but not in `b'.
-pub fn cfs_diff<'a, 'b>(a: &'a [&'b str], b: &'a [&'b str]) -> Vec<&'b str> {
+pub fn cfs_diff<'a>(a: &[&'a str], b: &[&str]) -> Vec<&'a str> {
     a.iter().filter(|x| b.iter().find(|y| y == x).is_none()).map(|x| *x).collect()
 }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -468,7 +468,7 @@ impl<T> RingQueue<T> {
 }
 
 // `cfs_diff' Returns a Vec of cf which is in `a' but not in `b'.
-pub fn cfs_diff<'a, 'b>(a: &'a Vec<&'b str>, b: &'a Vec<&'b str>) -> Vec<&'b str> {
+pub fn cfs_diff<'a, 'b>(a: &'a [&'b str], b: &'a [&'b str]) -> Vec<&'b str> {
     a.iter().filter(|x| b.iter().find(|y| y == x).is_none()).map(|x| *x).collect()
 }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -467,6 +467,11 @@ impl<T> RingQueue<T> {
     }
 }
 
+// `cfs_diff' Returns a Vec of cf which is in `a' but not in `b'.
+pub fn cfs_diff<'a, 'b>(a: &'a Vec<&'b str>, b: &'a Vec<&'b str>) -> Vec<&'b str> {
+    a.iter().filter(|x| b.iter().find(|y| y == x).is_none()).map(|x| *x).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use std::net::{SocketAddr, AddrParseError};

--- a/src/util/rocksdb.rs
+++ b/src/util/rocksdb.rs
@@ -214,6 +214,7 @@ impl SliceTransform for FixedPrefixSliceTransform {
 mod tests {
     use rocksdb::{DB, Options};
     use tempdir::TempDir;
+    use storage::CF_DEFAULT;
     use super::{check_and_open, CFOptions};
 
     #[test]
@@ -222,25 +223,25 @@ mod tests {
         let path_str = path.path().to_str().unwrap();
 
         // create db when db not exist
-        let cfs_opts = vec![CFOptions::new("default", Options::new())];
+        let cfs_opts = vec![CFOptions::new(CF_DEFAULT, Options::new())];
         check_and_open(path_str, Options::new(), cfs_opts).unwrap();
-        column_families_must_eq(path_str, &["default"]);
+        column_families_must_eq(path_str, &[CF_DEFAULT]);
 
         // add cf1.
-        let cfs_opts = vec![CFOptions::new("default", Options::new()),
+        let cfs_opts = vec![CFOptions::new(CF_DEFAULT, Options::new()),
                             CFOptions::new("cf1", Options::new())];
         check_and_open(path_str, Options::new(), cfs_opts).unwrap();
-        column_families_must_eq(path_str, &["default", "cf1"]);
+        column_families_must_eq(path_str, &[CF_DEFAULT, "cf1"]);
 
         // drop cf1.
-        let cfs_opts = vec![CFOptions::new("default", Options::new())];
+        let cfs_opts = vec![CFOptions::new(CF_DEFAULT, Options::new())];
         check_and_open(path_str, Options::new(), cfs_opts).unwrap();
-        column_families_must_eq(path_str, &["default"]);
+        column_families_must_eq(path_str, &[CF_DEFAULT]);
 
         // never drop default cf
         let cfs_opts = vec![];
         check_and_open(path_str, Options::new(), cfs_opts).unwrap();
-        column_families_must_eq(path_str, &["default"]);
+        column_families_must_eq(path_str, &[CF_DEFAULT]);
     }
 
     fn column_families_must_eq(path: &str, excepted: &[&str]) {

--- a/src/util/rocksdb.rs
+++ b/src/util/rocksdb.rs
@@ -17,8 +17,6 @@ use std::path::Path;
 use storage::CF_DEFAULT;
 use rocksdb::{DB, Options, SliceTransform};
 
-use super::collections::{HashSet, HashMap};
-
 pub use rocksdb::CFHandle;
 
 pub fn get_cf_handle<'a>(db: &'a DB, cf: &str) -> Result<&'a CFHandle, String> {
@@ -45,36 +43,47 @@ pub fn open_opt(opts: Options,
     DB::open_cf(opts, path, cfs, &cfs_ref_opts)
 }
 
+pub struct CFOptions<'a> {
+    pub cf: &'a str,
+    pub options: Options,
+}
+
+impl<'a> CFOptions<'a> {
+    pub fn new(cf: &'a str, options: Options) -> CFOptions<'a> {
+        CFOptions {
+            cf: cf,
+            options: options,
+        }
+    }
+}
+
 pub fn new_engine(path: &str, cfs: &[&str]) -> Result<DB, String> {
     let mut db_opts = Options::new();
     db_opts.enable_statistics();
-    let mut cfs_opts = HashMap::default();
+    let mut cfs_opts = Vec::with_capacity(cfs.len());
     for cf in cfs {
-        cfs_opts.insert(*cf, Options::new());
+        cfs_opts.push(CFOptions::new(*cf, Options::new()));
     }
     new_engine_opt(path, db_opts, cfs_opts)
 }
 
-fn check_and_open(path: &str,
-                  mut db_opt: Options,
-                  cfs_opts: HashMap<&str, Options>)
-                  -> Result<DB, String> {
+fn check_and_open(path: &str, mut db_opt: Options, cfs_opts: Vec<CFOptions>) -> Result<DB, String> {
     // If db not exist, create it.
     if !db_exist(path) {
         db_opt.create_if_missing(true);
 
         let mut cfs = vec![];
         let mut cfs_opts_ref = vec![];
-        if let Some(opt) = cfs_opts.get(CF_DEFAULT) {
+        if let Some(cf_options) = cfs_opts.iter().find(|x| x.cf == CF_DEFAULT) {
             cfs.push(CF_DEFAULT);
-            cfs_opts_ref.push(opt);
+            cfs_opts_ref.push(&cf_options.options);
         }
         let mut db = try!(DB::open_cf(db_opt, path, cfs.as_slice(), cfs_opts_ref.as_slice()));
-        for (cf, cf_opt) in &cfs_opts {
-            if *cf == "default" {
+        for cf_options in &cfs_opts {
+            if cf_options.cf == "default" {
                 continue;
             }
-            try!(db.create_cf(*cf, cf_opt));
+            try!(db.create_cf(cf_options.cf, &cf_options.options));
         }
 
         return Ok(db);
@@ -84,16 +93,16 @@ fn check_and_open(path: &str,
 
     // List all column families in current db.
     let cfs_list = try!(DB::list_column_families(&db_opt, path));
-    let existed: HashSet<&str> = cfs_list.iter().map(|v| v.as_str()).collect();
-    let needed: HashSet<&str> = cfs_opts.keys().map(|v| *v).collect();
+    let existed: Vec<&str> = cfs_list.iter().map(|v| v.as_str()).collect();
+    let needed: Vec<&str> = cfs_opts.iter().map(|cf_options| cf_options.cf).collect();
 
     // If all column families are exist, just open db.
     if existed == needed {
         let mut cfs = vec![];
         let mut cfs_opts_ref = vec![];
-        for (cf, cf_opt) in &cfs_opts {
-            cfs.push(*cf);
-            cfs_opts_ref.push(cf_opt);
+        for cf_options in &cfs_opts {
+            cfs.push(cf_options.cf);
+            cfs_opts_ref.push(&cf_options.options);
         }
 
         return DB::open_cf(db_opt, path, cfs.as_slice(), cfs_opts_ref.as_slice());
@@ -105,9 +114,9 @@ fn check_and_open(path: &str,
     let mut cfs_opts_ref = vec![];
     for cf in &existed {
         cfs.push(*cf);
-        match cfs_opts.get(cf) {
-            Some(opt) => {
-                cfs_opts_ref.push(opt);
+        match cfs_opts.iter().find(|cf_options| cf_options.cf == *cf) {
+            Some(cf_options) => {
+                cfs_opts_ref.push(&cf_options.options);
             }
             None => {
                 cfs_opts_ref.push(&common_opt);
@@ -117,7 +126,7 @@ fn check_and_open(path: &str,
     let mut db = DB::open_cf(db_opt, path, cfs.as_slice(), cfs_opts_ref.as_slice()).unwrap();
 
     // Drop discarded column families.
-    for cf in existed.difference(&needed) {
+    for cf in existed.iter().filter(|x| needed.iter().find(|y| y == x).is_none()) {
         // Never drop default column families.
         if *cf != CF_DEFAULT {
             try!(db.drop_cf(cf));
@@ -125,17 +134,18 @@ fn check_and_open(path: &str,
     }
 
     // Create needed column families not existed yet.
-    for cf in needed.difference(&existed) {
-        try!(db.create_cf(cf, cfs_opts.get(cf).unwrap()));
+    for cf in needed.iter().filter(|x| existed.iter().find(|y| y == x).is_none()) {
+        try!(db.create_cf(cf,
+                          &cfs_opts.iter()
+                              .find(|cf_options| cf_options.cf == *cf)
+                              .unwrap()
+                              .options));
     }
 
     Ok(db)
 }
 
-pub fn new_engine_opt(path: &str,
-                      opts: Options,
-                      cfs_opts: HashMap<&str, Options>)
-                      -> Result<DB, String> {
+pub fn new_engine_opt(path: &str, opts: Options, cfs_opts: Vec<CFOptions>) -> Result<DB, String> {
     check_and_open(path, opts, cfs_opts)
 }
 
@@ -205,8 +215,7 @@ impl SliceTransform for FixedPrefixSliceTransform {
 mod tests {
     use rocksdb::{DB, Options};
     use tempdir::TempDir;
-    use util::collections::HashMap;
-    use super::check_and_open;
+    use super::{check_and_open, CFOptions};
 
     #[test]
     fn test_check_and_open() {
@@ -214,22 +223,23 @@ mod tests {
         let path_str = path.path().to_str().unwrap();
 
         // create db when db not exist
-        let cfs_opts = map!["default" => Options::new()];
+        let cfs_opts = vec![CFOptions::new("default", Options::new())];
         check_and_open(path_str, Options::new(), cfs_opts).unwrap();
         column_families_must_eq(path_str, &["default"]);
 
         // add cf1.
-        let cfs_opts = map!["default" => Options::new(), "cf1" => Options::new()];
+        let cfs_opts = vec![CFOptions::new("default", Options::new()),
+                            CFOptions::new("cf1", Options::new())];
         check_and_open(path_str, Options::new(), cfs_opts).unwrap();
         column_families_must_eq(path_str, &["default", "cf1"]);
 
         // drop cf1.
-        let cfs_opts = map!["default" => Options::new()];
+        let cfs_opts = vec![CFOptions::new("default", Options::new())];
         check_and_open(path_str, Options::new(), cfs_opts).unwrap();
         column_families_must_eq(path_str, &["default"]);
 
         // never drop default cf
-        let cfs_opts = HashMap::default();
+        let cfs_opts = vec![];
         check_and_open(path_str, Options::new(), cfs_opts).unwrap();
         column_families_must_eq(path_str, &["default"]);
     }


### PR DESCRIPTION
Hi,

This PR tries to fix the cf disorder problem, which will cause failure on applying sst format snapshot, like these logs indicate:

```
2017/04/26 12:44:01.436 region.rs:241: [ERROR] failed to apply snap: Other(StringError(“Invalid argument: External file column family id dont match”))!!!
2017/04/26 12:44:01.436 region.rs:175: [INFO] [region 885] begin apply snap data
2017/04/26 12:44:01.783 region.rs:241: [ERROR] failed to apply snap: Other(StringError(“Invalid argument: External file column family id dont match”))!!!
```

PTAL @zhangjinpeng1987 @siddontang @BusyJay 