### PR TITLE
util: ignore computing size if NO_LIMIT

### DIFF
--- a/src/raft/raft_log.rs
+++ b/src/raft/raft_log.rs
@@ -33,7 +33,7 @@ use raft::errors::{Result, Error, StorageError};
 use std::cmp;
 use util;
 
-pub const NO_LIMIT: u64 = util::NO_LIMIT;
+pub use util::NO_LIMIT;
 
 /// Raft log implementation
 #[derive(Default)]

--- a/src/raft/raft_log.rs
+++ b/src/raft/raft_log.rs
@@ -30,10 +30,10 @@ use raft::storage::Storage;
 use raft::log_unstable::Unstable;
 use kvproto::eraftpb::{Entry, Snapshot};
 use raft::errors::{Result, Error, StorageError};
-use std::{cmp, u64};
+use std::cmp;
 use util;
 
-pub const NO_LIMIT: u64 = u64::MAX;
+pub const NO_LIMIT: u64 = util::NO_LIMIT;
 
 /// Raft log implementation
 #[derive(Default)]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -606,10 +606,12 @@ mod tests {
         let tbls = vec![
             (vec![], NO_LIMIT, 0),
             (vec![], size, 0),
+            (vec![e.clone(); 10], 0, 1),
             (vec![e.clone(); 10], NO_LIMIT, 10),
             (vec![e.clone(); 10], size, 1),
             (vec![e.clone(); 10], size + 1, 1),
             (vec![e.clone(); 10], 2 * size , 2),
+            (vec![e.clone(); 10], 10 * size - 1, 9),
             (vec![e.clone(); 10], 10 * size, 10),
             (vec![e.clone(); 10], 10 * size + 1, 10),
         ];

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -52,9 +52,10 @@ mod thread_metrics;
 
 pub const NO_LIMIT: u64 = u64::MAX;
 
-pub fn get_limit_at_size<'a, T: Message + Clone, I: IntoIterator<Item = &'a T>>(entries: I,
-                                                                                max: u64)
-                                                                                -> usize {
+pub fn get_limit_at_size<'a, T, I>(entries: I, max: u64) -> usize
+    where T: Message + Clone,
+          I: IntoIterator<Item = &'a T>
+{
     let mut iter = entries.into_iter();
     // If max is NO_LIMIT, we can return directly.
     if max == NO_LIMIT {


### PR DESCRIPTION
This PR tries to split #1797 and do a little improvement that ignores computing size if NO_LIMIT.

In most cases, we will use NO_LIMIT, so we can return the whole entries directly.

@BusyJay @hhkbp2 @zhangjinpeng1987 