### PR TITLE
threadpool:use channel to reduce lock in push new task && adjust test

### DIFF
--- a/src/util/threadpool.rs
+++ b/src/util/threadpool.rs
@@ -252,7 +252,10 @@ struct TaskPool<Q, T> {
     jobs: Receiver<Task<T>>,
 }
 
-impl<Q: ScheduleQueue<T>, T: Debug> TaskPool<Q, T> {
+impl<Q, T> TaskPool<Q, T>
+    where Q: ScheduleQueue<T>,
+          T: Debug
+{
     fn new(queue: Q, jobs: Receiver<Task<T>>) -> TaskPool<Q, T> {
         TaskPool {
             next_task_id: 0,

--- a/src/util/threadpool.rs
+++ b/src/util/threadpool.rs
@@ -511,8 +511,8 @@ mod test {
 
         for gid in 0..group_num {
             tx.send(gid).unwrap();
-            let left_num = task_pool.get_task_count();
             frx.recv_timeout(recv_timeout_duration).unwrap();
+            let left_num = task_pool.get_task_count();
             // current task may not finished
             assert!(left_num == task_num || left_num == task_num - 1,
                     format!("left_num {},task_num {}", left_num, task_num));

--- a/src/util/threadpool.rs
+++ b/src/util/threadpool.rs
@@ -272,13 +272,12 @@ impl<Q: ScheduleQueue<T>, T: Debug> TaskPool<Q, T> {
     }
 
     fn pop_task(&mut self) -> Option<Task<T>> {
-        let task = self.task_queue.pop();
-        if task.is_none() {
-            // try fill queue when queue is empty.
-            self.try_fill_queue();
-            return self.task_queue.pop();
+        if let Some(task) = self.task_queue.pop() {
+            return Some(task);
         }
-        task
+        // try fill queue when queue is empty.
+        self.try_fill_queue();
+        self.task_queue.pop()
     }
 
     fn try_fill_queue(&mut self) {


### PR DESCRIPTION
Hi,all,
      This PR use channel to reduce lock when a tasks comes. Also it adjust the test to fix https://github.com/pingcap/tikv/issues/1796.

@zhangjinpeng1987 @hhkbp2 PTAL.