### PR TITLE
support sub compactions

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -113,6 +113,11 @@ max-background-compactions = 6
 # Maximum number of concurrent background flush jobs
 max-background-flushes = 2
 
+# This value represents the maximum number of threads that will concurrently perform a
+# compaction job by breaking it into multiple, smaller ones that are run simultaneously.
+# Default: 1 (i.e. no subcompactions)
+# max-sub-compactions = 1
+
 # Number of open files that can be used by the DB.  You may need to
 # increase this if your database has a large working set. Value -1 means
 # files opened are always kept open. You can estimate number of files based

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -365,7 +365,7 @@ fn get_rocksdb_db_option(config: &toml::Value) -> RocksdbOptions {
     }
 
     let max_sub_compactions = get_toml_int(config, "rocksdb.max-sub-compactions", Some(1));
-    opts.set_max_subcompactions(max_sub_compactions as i64);
+    opts.set_max_subcompactions(max_sub_compactions as usize);
 
     opts
 }

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -364,6 +364,9 @@ fn get_rocksdb_db_option(config: &toml::Value) -> RocksdbOptions {
         opts.set_ratelimiter(rate_bytes_per_sec as i64);
     }
 
+    let max_sub_compactions = get_toml_int(config, "rocksdb.max-sub-compactions", Some(1));
+    opts.set_max_subcompactions(max_sub_compactions as i64);
+
     opts
 }
 


### PR DESCRIPTION
If set max-sub-compactions, RocksDB will break a big compaction job into multiple, smaller ones that are run simultaneously.
@siddontang @lishihai9017 PTAL