### PR TITLE
bin: remove toggle profiling

### DIFF
--- a/src/bin/profiling.rs
+++ b/src/bin/profiling.rs
@@ -38,21 +38,6 @@ mod imp {
         }
     }
 
-    /// Toggle the prof.active option, return the final value.
-    pub fn toggle_prof() -> Result<bool, i32> {
-        let mut enabled = false;
-        unsafe {
-            try!(jemallocator::mallctl_fetch(PROFILE_ACTIVE, &mut enabled)
-                .and_then(|_| jemallocator::mallctl_set(PROFILE_ACTIVE, !enabled)));
-        }
-        if enabled {
-            info!("memory profiling is disabled");
-        } else {
-            info!("memory profiling is enabled");
-        }
-        Ok(!enabled)
-    }
-
     /// Dump the profile to the `path`.
     ///
     /// If `path` is `None`, will dump it in the working directory with a auto-generated name.
@@ -91,12 +76,10 @@ mod imp {
             let dir = TempDir::new("test_profiling").unwrap();
             let os_path = dir.path().to_path_buf().join("test1.dump").into_os_string();
             let path = os_path.into_string().unwrap();
-            assert_eq!(super::toggle_prof(), Ok(true));
             super::dump_prof(Some(&path));
 
             let os_path = dir.path().to_path_buf().join("test2.dump").into_os_string();
             let path = os_path.into_string().unwrap();
-            assert_eq!(super::toggle_prof(), Ok(false));
             super::dump_prof(Some(&path));
 
             let files = fs::read_dir(dir.path()).unwrap().count();
@@ -107,10 +90,6 @@ mod imp {
 
 #[cfg(not(feature = "mem-profiling"))]
 mod imp {
-    pub fn toggle_prof() -> Result<bool, i32> {
-        Ok(false)
-    }
-
     pub fn dump_prof(_: Option<&str>) {}
 }
 

--- a/src/bin/signal_handler.rs
+++ b/src/bin/signal_handler.rs
@@ -17,14 +17,10 @@ mod imp {
     use std::sync::Arc;
 
     use rocksdb::DB;
-    use libc;
 
     use tikv::server::Msg;
     use tikv::util::transport::SendCh;
     use prometheus::{self, Encoder, TextEncoder};
-
-    // Real-time signals
-    const TOGGLE_PROF_SIG: libc::c_int = 41;
 
     use profiling;
 
@@ -35,7 +31,7 @@ mod imp {
     pub fn handle_signal(ch: SendCh<Msg>, engine: Arc<DB>, _: &str) {
         use signal::trap::Trap;
         use nix::sys::signal::{SIGTERM, SIGINT, SIGUSR1, SIGUSR2};
-        let trap = Trap::trap(&[SIGTERM, SIGINT, SIGUSR1, SIGUSR2, TOGGLE_PROF_SIG]);
+        let trap = Trap::trap(&[SIGTERM, SIGINT, SIGUSR1, SIGUSR2]);
         for sig in trap {
             match sig {
                 SIGTERM | SIGINT => {
@@ -70,11 +66,6 @@ mod imp {
                     }
                 }
                 SIGUSR2 => profiling::dump_prof(None),
-                TOGGLE_PROF_SIG => {
-                    if let Err(e) = profiling::toggle_prof() {
-                        error!("failed to toggle memory profiling: {}", e);
-                    }
-                }
                 // TODO: handle more signal
                 _ => unreachable!(),
             }


### PR DESCRIPTION
Due to lacking support of libc, current usage of realtime signal is not portable (may not work in some architecture and operating system). Hence let's remove it for now.

After merging this pr, profiling can't be disabled during runtime. I think it's acceptable.