### PR TITLE
tikv-server: check TZ setting

### DIFF
--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -271,7 +271,7 @@ fn check_system_config(config: &toml::Value) {
         warn!("{:?}", e);
     }
 
-    if cfg!(windows) {
+    if !cfg!(windows) {
         if env::var("TZ").is_err() {
             env::set_var("TZ", "/etc/localtime");
             error!("environment variable `TZ` is missing, use `/etc/localtime`");

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -51,6 +51,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::io::Read;
 use std::time::Duration;
+use std::env;
 
 use clap::{Arg, App, ArgMatches};
 use rocksdb::{DB, Options as RocksdbOptions, BlockBasedOptions};
@@ -268,6 +269,13 @@ fn check_system_config(config: &toml::Value) {
 
     for e in util::config::check_kernel() {
         warn!("{:?}", e);
+    }
+
+    if cfg!(windows) {
+        if env::var("TZ").is_err() {
+            env::set_var("TZ", "/etc/localtime");
+            error!("environment variable `TZ` is missing, use `/etc/localtime`");
+        }
     }
 }
 

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -271,11 +271,9 @@ fn check_system_config(config: &toml::Value) {
         warn!("{:?}", e);
     }
 
-    if !cfg!(windows) {
-        if env::var("TZ").is_err() {
-            env::set_var("TZ", "/etc/localtime");
-            error!("environment variable `TZ` is missing, use `/etc/localtime`");
-        }
+    if !cfg!(windows) && env::var("TZ").is_err() {
+        env::set_var("TZ", "/etc/localtime");
+        error!("environment variable `TZ` is missing, use `/etc/localtime`");
     }
 }
 

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -273,7 +273,7 @@ fn check_system_config(config: &toml::Value) {
 
     if !cfg!(windows) && env::var("TZ").is_err() {
         env::set_var("TZ", "/etc/localtime");
-        error!("environment variable `TZ` is missing, use `/etc/localtime`");
+        warn!("environment variable `TZ` is missing, use `/etc/localtime`");
     }
 }
 


### PR DESCRIPTION
related: https://github.com/pingcap/tidb-ansible/pull/20

If TZ is not set, tikv will stat(/etc/localtime) twice every logging operation.

ref: https://stackoverflow.com/questions/4554271/how-to-avoid-excessive-stat-etc-localtime-calls-in-strftime-on-linux