### PR TITLE
raftstore: fix check pending apply

### DIFF
--- a/src/raft/progress.rs
+++ b/src/raft/progress.rs
@@ -84,7 +84,7 @@ pub struct Progress {
 
 
 impl Progress {
-    pub fn reset_state(&mut self, state: ProgressState) {
+    fn reset_state(&mut self, state: ProgressState) {
         self.paused = false;
         self.pending_snapshot = 0;
         self.state = state;

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -1043,9 +1043,9 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                             first_index: u64,
                             state: RaftTruncatedState) {
         let mut peer = self.region_peers.get_mut(&region_id).unwrap();
-        let total_cnt = peer.last_ready_idx - first_index;
+        let total_cnt = peer.last_applying_idx - first_index;
         // the size of current CompactLog command can be ignored.
-        let remain_cnt = peer.last_ready_idx - state.get_index() - 1;
+        let remain_cnt = peer.last_applying_idx - state.get_index() - 1;
         peer.raft_log_size_hint = peer.raft_log_size_hint * remain_cnt / total_cnt;
         let task = RaftlogGcTask {
             engine: peer.get_store().get_engine().clone(),


### PR DESCRIPTION
@siddontang @hhkbp2 @javaforfun PTAL

To add a stable test, we need to figure out a way to generate a snapshot without peer and step the store whenever we want.