### PR TITLE
add bloom filter for lock cf memtable

### DIFF
--- a/src/util/rocksdb.rs
+++ b/src/util/rocksdb.rs
@@ -210,6 +210,22 @@ impl SliceTransform for FixedPrefixSliceTransform {
     }
 }
 
+pub struct NoopSliceTransform;
+
+impl SliceTransform for NoopSliceTransform {
+    fn transform<'a>(&mut self, key: &'a [u8]) -> &'a [u8] {
+        key
+    }
+
+    fn in_domain(&mut self, _: &[u8]) -> bool {
+        true
+    }
+
+    fn in_range(&mut self, _: &[u8]) -> bool {
+        true
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use rocksdb::{DB, Options};


### PR DESCRIPTION
As I have tested, if a key is not existed, memtable get with bloom filter is much more faster than memtable get without bloom filter.
`MVCC get` always call `load_lock` first, in most cases the lock is not exist, so add bloom filter for memtable of lock cf will benefit a lot.
I have tested that in insert case, this pr also reduce about 5%-10% cpu for `scheduler worker`, since every `prewrite` comand will call `load_lock` that in most cases the lock is not exist.
```
test memtable::bench_memtable::bench_memtable_get_exist_32mb                ... bench:         923 ns/iter (+/- 165)
test memtable::bench_memtable::bench_memtable_get_exist_64mb                ... bench:         899 ns/iter (+/- 250)
test memtable::bench_memtable::bench_memtable_get_exist_with_bloom_32mb     ... bench:       1,028 ns/iter (+/- 525)
test memtable::bench_memtable::bench_memtable_get_exist_with_bloom_64mb     ... bench:         974 ns/iter (+/- 405)
test memtable::bench_memtable::bench_memtable_get_not_exist_32mb            ... bench:         822 ns/iter (+/- 129)
test memtable::bench_memtable::bench_memtable_get_not_exist_64mb            ... bench:       1,069 ns/iter (+/- 460)
test memtable::bench_memtable::bench_memtable_get_not_exist_with_bloom_32mb ... bench:         259 ns/iter (+/- 76)
test memtable::bench_memtable::bench_memtable_get_not_exist_with_bloom_64mb ... bench:         247 ns/iter (+/- 88)
```