### PR TITLE
endpoint: avoid allocating a lot of memory at first in topn

### DIFF
--- a/src/server/coprocessor/endpoint.rs
+++ b/src/server/coprocessor/endpoint.rs
@@ -567,13 +567,19 @@ struct TopNHeap {
     err: Rc<RefCell<Option<String>>>,
 }
 
+const HEAP_DEFAULT_CAPACITY: usize = 1024;
+
 impl TopNHeap {
     fn new(limit: usize) -> Result<TopNHeap> {
         if limit == usize::MAX {
             return Err(box_err!("invalid limit"));
         }
+        let mut heap_capacity = HEAP_DEFAULT_CAPACITY;
+        if limit < heap_capacity {
+            heap_capacity = limit
+        }
         Ok(TopNHeap {
-            rows: BinaryHeap::with_capacity(limit),
+            rows: BinaryHeap::with_capacity(heap_capacity),
             limit: limit,
             err: Rc::new(RefCell::new(None)),
         })

--- a/src/server/coprocessor/endpoint.rs
+++ b/src/server/coprocessor/endpoint.rs
@@ -16,7 +16,7 @@ use std::collections::BinaryHeap;
 use std::time::{Instant, Duration};
 use std::rc::Rc;
 use std::fmt::{self, Display, Formatter, Debug};
-use std::cmp::Ordering as CmpOrdering;
+use std::cmp::{self, Ordering as CmpOrdering};
 use std::cell::RefCell;
 use tipb::select::{self, SelectRequest, SelectResponse, Chunk, RowMeta};
 use tipb::schema::ColumnInfo;
@@ -574,10 +574,7 @@ impl TopNHeap {
         if limit == usize::MAX {
             return Err(box_err!("invalid limit"));
         }
-        let mut cap = limit;
-        if limit > HEAP_MAX_CAPACITY {
-            cap = HEAP_MAX_CAPACITY
-        }
+        let cap = cmp::min(limit, HEAP_MAX_CAPACITY);
         Ok(TopNHeap {
             rows: BinaryHeap::with_capacity(cap),
             limit: limit,
@@ -1373,7 +1370,7 @@ mod tests {
 
     #[test]
     fn test_topn_limit_oom() {
-        let topn_heap = TopNHeap::new(HEAP_MAX_CAPACITY + 100);
+        let topn_heap = TopNHeap::new(usize::MAX - 1);
         assert!(topn_heap.is_ok());
         let topn_heap = TopNHeap::new(usize::MAX);
         assert!(topn_heap.is_err());


### PR DESCRIPTION
hi,
      If we order by c1 limit int.max, topn will alloc a lot of memory for heap, which leads to oom. This pr fix it.
       The related PR in tidb is https://github.com/pingcap/tidb/pull/3392

@BusyJay @andelf PTAL

