### PR TITLE
raftstore: enable sst format snapshot by default

### DIFF
--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -728,7 +728,7 @@ fn build_cfg(matches: &ArgMatches,
             config,
             "raftstore.consistency-check-interval");
     cfg.raft_store.use_sst_file_snapshot =
-        get_toml_boolean(config, "raftstore.use-sst-file-snapshot", Some(false));
+        get_toml_boolean(config, "raftstore.use-sst-file-snapshot", Some(true));
     cfg_usize(&mut cfg.storage.sched_notify_capacity,
               config,
               "storage.scheduler-notify-capacity");

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -59,7 +59,7 @@ const DEFAULT_REPORT_REGION_FLOW_INTERVAL: u64 = 60000; // 60 seconds
 
 const DEFAULT_RAFT_STORE_LEASE_SEC: i64 = 9; // 9 seconds
 
-const DEFAULT_USE_SST_FILE_SNAPSHOT: bool = false;
+const DEFAULT_USE_SST_FILE_SNAPSHOT: bool = true;
 
 #[derive(Debug, Clone)]
 pub struct Config {


### PR DESCRIPTION
Hi,

This PR enables the sst format snapshot by default.

PTAL @siddontang @BusyJay @zhangjinpeng1987 @javaforfun @lishihai9017 