### PR TITLE
remove bloom for raft cf

### DIFF
--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -565,8 +565,6 @@ fn get_rocksdb_raftlog_cf_option(config: &toml::Value, total_mem: u64) -> Rocksd
     }
     let mut default_values = CfOptValues::default();
     default_values.block_cache_size = block_cache_size as i64;
-    default_values.use_bloom_filter = true;
-    default_values.whole_key_filtering = true;
 
     let mut opts = get_rocksdb_cf_option(config, "raftcf", default_values);
     opts.set_memtable_insert_hint_prefix_extractor("RaftPrefixSliceTransform",

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -596,7 +596,7 @@ fn adjust_end_points_by_cpu_num(total_cpu_num: usize) -> usize {
         (total_cpu_num as f32 * 0.8) as usize
     } else {
         4
-    }
+     }
 }
 
 fn adjust_sched_workers_by_cpu_num(total_cpu_num: usize) -> usize {

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -596,7 +596,7 @@ fn adjust_end_points_by_cpu_num(total_cpu_num: usize) -> usize {
         (total_cpu_num as f32 * 0.8) as usize
     } else {
         4
-     }
+    }
 }
 
 fn adjust_sched_workers_by_cpu_num(total_cpu_num: usize) -> usize {


### PR DESCRIPTION
In most cases raft entries can get from memtable, in another special case that raft log lag is large, scan will used. So bloom filter for raft cf is redundant.