### PR TITLE
mvcc:fix bug in get_txn_commit_info

### DIFF
--- a/src/storage/mvcc/reader.rs
+++ b/src/storage/mvcc/reader.rs
@@ -222,10 +222,12 @@ impl<'a> MvccReader<'a> {
                                key: &Key,
                                start_ts: u64)
                                -> Result<Option<(u64, WriteType)>> {
-        if let Some((commit_ts, write)) = try!(self.reverse_seek_write(key, start_ts)) {
+        let mut seek_ts = start_ts;
+        while let Some((commit_ts, write)) = try!(self.reverse_seek_write(key, seek_ts)) {
             if write.start_ts == start_ts {
                 return Ok(Some((commit_ts, write.write_type)));
             }
+            seek_ts = commit_ts + 1;
         }
         Ok(None)
     }

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -477,6 +477,30 @@ mod tests {
     }
 
     #[test]
+    fn test_mvcc_txn_rollback_after_commit() {
+        let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
+
+        let k = b"k";
+        let v = b"v";
+        let t1 = 1;
+        let t2 = 10;
+        let t3 = 20;
+        let t4 = 30;
+
+        must_prewrite_put(engine.as_ref(), k, v, k, t1);
+
+        must_rollback(engine.as_ref(), k, t2);
+        must_rollback(engine.as_ref(), k, t2);
+        must_rollback(engine.as_ref(), k, t4);
+
+        must_commit(engine.as_ref(), k, t1, t3);
+
+        must_rollback_err(engine.as_ref(), k, t1);
+        must_rollback_err(engine.as_ref(), k, t1);
+        must_get(engine.as_ref(), k, t4, v);
+    }
+
+    #[test]
     fn test_mvcc_txn_rollback() {
         test_mvcc_txn_rollback_imp(b"k", b"v");
 

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -494,8 +494,8 @@ mod tests {
         must_rollback(engine.as_ref(), k, t4);
 
         must_commit(engine.as_ref(), k, t1, t3);
-
-        must_rollback_err(engine.as_ref(), k, t1);
+        // The rollback should be failed since the transaction
+        // was committed before.
         must_rollback_err(engine.as_ref(), k, t1);
         must_get(engine.as_ref(), k, t4, v);
     }


### PR DESCRIPTION
Hi,
     This PR fix bug in func `get_txn_commit_info`.  Since `tidb` would do `prewrite`  concurrently, a `rollback` record may do between a `prewrite` and `commit`.  That is when we try to `get_txn_commit_info` with a `start_ts`, the first one from `reverse_seek_write` may not the record with `start_ts`, so we need to go on seek the next util meet the commit with `start_ts` .

Here is the log detail:
 ```
[pingcap@ip-172-16-10-12 ~]$ ./tikv-ctl -d "/data1/new_deploy1/data/db" mvcc -c write -k "t\\200\\000\\000\\000\\000\\000\\000\\041_r\\200\\000\\000\\000\\002'6\\232"
You are searching Key t\200\000\000\000\000\000\000\041_r\200\000\000\000\002'6\232:
Key: "t\\200\\000\\000\\000\\000\\000\\000\\377!_r\\200\\000\\000\\000\\002\\377\'6\\232\\000\\000\\000\\000\\000\\372"
Type: Put
Start_ts: 392413040540123221
Commit_ts: 392413041968808188
Short value: Some([8, 2, 8, 180, 218, 185, 34, 8, 4, 8, 218, 21])

Key: "t\\200\\000\\000\\000\\000\\000\\000\\377!_r\\200\\000\\000\\000\\002\\377\'6\\232\\000\\000\\000\\000\\000\\372"
Type: Rollback
Start_ts: 392413040579444737
Commit_ts: 392413040579444737
Short value: None

Key: "t\\200\\000\\000\\000\\000\\000\\000\\377!_r\\200\\000\\000\\000\\002\\377\'6\\232\\000\\000\\000\\000\\000\\372"
Type: Rollback
Start_ts: 392413040540123221
Commit_ts: 392413040540123221
Short value: None
```

@disksing @zhangjinpeng1987 @hhkbp2 PTAL