### PR TITLE
optimize seek write-cf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "grpc"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/grpc-rs.git#1aeb34fac8e728f7484cd7aa9ac1c533cb4e9899"
+source = "git+https://github.com/pingcap/grpc-rs.git#867fe48b18c6fb494f4b7e57e8a45f45a13a7ed5"
 dependencies = [
  "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpc-sys 0.1.0 (git+https://github.com/pingcap/grpc-rs.git)",
@@ -269,7 +269,7 @@ dependencies = [
 [[package]]
 name = "grpc-sys"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/grpc-rs.git#1aeb34fac8e728f7484cd7aa9ac1c533cb4e9899"
+source = "git+https://github.com/pingcap/grpc-rs.git#867fe48b18c6fb494f4b7e57e8a45f45a13a7ed5"
 dependencies = [
  "cmake 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#76b3a4b78dde5333156aacb5d128257487bdd20d"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#62741f9e6e5a8bef365245847b09e600eb848ee6"
 dependencies = [
  "gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -700,7 +700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#76b3a4b78dde5333156aacb5d128257487bdd20d"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#62741f9e6e5a8bef365245847b09e600eb848ee6"
 dependencies = [
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "librocksdb_sys 0.1.0 (git+https://github.com/pingcap/rust-rocksdb.git)",

--- a/src/raftstore/store/engine.rs
+++ b/src/raftstore/store/engine.rs
@@ -181,6 +181,10 @@ impl IterOption {
         self
     }
 
+    pub fn prefix_seek_used(&self) -> bool {
+        self.seek_mode == SeekMode::Prefix
+    }
+
     pub fn total_order_seek_used(&self) -> bool {
         self.seek_mode == SeekMode::TotalOrder
     }
@@ -280,7 +284,11 @@ impl Iterable for DB {
     fn new_iterator(&self, iter_opt: IterOption) -> DBIterator {
         let mut readopts = ReadOptions::new();
         readopts.fill_cache(iter_opt.fill_cache);
-        readopts.set_total_order_seek(iter_opt.total_order_seek_used());
+        if iter_opt.prefix_seek_used() {
+            readopts.set_prefix_same_as_start(true);
+        } else {
+            readopts.set_total_order_seek(iter_opt.total_order_seek_used());
+        }
         if let Some(key) = iter_opt.upper_bound {
             readopts.set_iterate_upper_bound(&key);
         }
@@ -290,7 +298,11 @@ impl Iterable for DB {
     fn new_iterator_cf(&self, cf: &str, iter_opt: IterOption) -> Result<DBIterator> {
         let mut readopts = ReadOptions::new();
         readopts.fill_cache(iter_opt.fill_cache);
-        readopts.set_total_order_seek(iter_opt.total_order_seek_used());
+        if iter_opt.prefix_seek_used() {
+            readopts.set_prefix_same_as_start(true);
+        } else {
+            readopts.set_total_order_seek(iter_opt.total_order_seek_used());
+        }
         if let Some(key) = iter_opt.upper_bound {
             readopts.set_iterate_upper_bound(&key);
         }
@@ -324,7 +336,11 @@ impl Iterable for Snapshot {
     fn new_iterator(&self, iter_opt: IterOption) -> DBIterator {
         let mut opt = ReadOptions::new();
         opt.fill_cache(iter_opt.fill_cache);
-        opt.set_total_order_seek(iter_opt.total_order_seek_used());
+        if iter_opt.prefix_seek_used() {
+            opt.set_prefix_same_as_start(true);
+        } else {
+            opt.set_total_order_seek(iter_opt.total_order_seek_used());
+        }
         if let Some(key) = iter_opt.upper_bound {
             opt.set_iterate_upper_bound(&key);
         }
@@ -338,7 +354,11 @@ impl Iterable for Snapshot {
         let handle = try!(rocksdb::get_cf_handle(&self.db, cf));
         let mut opt = ReadOptions::new();
         opt.fill_cache(iter_opt.fill_cache);
-        opt.set_total_order_seek(iter_opt.total_order_seek_used());
+        if iter_opt.prefix_seek_used() {
+            opt.set_prefix_same_as_start(true);
+        } else {
+            opt.set_total_order_seek(iter_opt.total_order_seek_used());
+        }
         if let Some(key) = iter_opt.upper_bound {
             opt.set_iterate_upper_bound(&key);
         }

--- a/src/raftstore/store/engine.rs
+++ b/src/raftstore/store/engine.rs
@@ -178,24 +178,29 @@ impl IterOption {
         }
     }
 
+    #[inline]
     pub fn use_prefix_seek(mut self) -> IterOption {
         self.seek_mode = SeekMode::Prefix;
         self
     }
 
+    #[inline]
     pub fn total_order_seek_used(&self) -> bool {
         self.seek_mode == SeekMode::TotalOrder
     }
 
+    #[inline]
     pub fn upper_bound(&self) -> Option<&[u8]> {
         self.upper_bound.as_ref().map(|v| v.as_slice())
     }
 
+    #[inline]
     pub fn set_upper_bound(mut self, bound: Vec<u8>) -> IterOption {
         self.upper_bound = Some(bound);
         self
     }
 
+    #[inline]
     pub fn set_prefix_same_as_start(mut self) -> IterOption {
         self.prefix_same_as_start = true;
         self

--- a/src/raftstore/store/engine.rs
+++ b/src/raftstore/store/engine.rs
@@ -290,10 +290,8 @@ impl Iterable for DB {
         readopts.fill_cache(iter_opt.fill_cache);
         if iter_opt.total_order_seek_used() {
             readopts.set_total_order_seek(true);
-        } else {
-            if iter_opt.prefix_bound {
-                readopts.set_prefix_same_as_start(true);
-            }
+        } else if iter_opt.prefix_bound {
+            readopts.set_prefix_same_as_start(true);
         }
         if let Some(key) = iter_opt.upper_bound {
             readopts.set_iterate_upper_bound(&key);
@@ -306,10 +304,8 @@ impl Iterable for DB {
         readopts.fill_cache(iter_opt.fill_cache);
         if iter_opt.total_order_seek_used() {
             readopts.set_total_order_seek(true);
-        } else {
-            if iter_opt.prefix_bound {
-                readopts.set_prefix_same_as_start(true);
-            }
+        } else if iter_opt.prefix_bound {
+            readopts.set_prefix_same_as_start(true);
         }
         if let Some(key) = iter_opt.upper_bound {
             readopts.set_iterate_upper_bound(&key);
@@ -346,10 +342,8 @@ impl Iterable for Snapshot {
         opt.fill_cache(iter_opt.fill_cache);
         if iter_opt.total_order_seek_used() {
             opt.set_total_order_seek(true);
-        } else {
-            if iter_opt.prefix_bound {
-                opt.set_prefix_same_as_start(true);
-            }
+        } else if iter_opt.prefix_bound {
+            opt.set_prefix_same_as_start(true);
         }
         if let Some(key) = iter_opt.upper_bound {
             opt.set_iterate_upper_bound(&key);
@@ -366,10 +360,8 @@ impl Iterable for Snapshot {
         opt.fill_cache(iter_opt.fill_cache);
         if iter_opt.total_order_seek_used() {
             opt.set_total_order_seek(true);
-        } else {
-            if iter_opt.prefix_bound {
-                opt.set_prefix_same_as_start(true);
-            }
+        } else if iter_opt.prefix_bound {
+            opt.set_prefix_same_as_start(true);
         }
         if let Some(key) = iter_opt.upper_bound {
             opt.set_iterate_upper_bound(&key);

--- a/src/raftstore/store/engine.rs
+++ b/src/raftstore/store/engine.rs
@@ -163,7 +163,7 @@ enum SeekMode {
 
 pub struct IterOption {
     upper_bound: Option<Vec<u8>>,
-    prefix_bound: bool,
+    prefix_same_as_start: bool,
     fill_cache: bool,
     seek_mode: SeekMode,
 }
@@ -172,7 +172,7 @@ impl IterOption {
     pub fn new(upper_bound: Option<Vec<u8>>, fill_cache: bool) -> IterOption {
         IterOption {
             upper_bound: upper_bound,
-            prefix_bound: false,
+            prefix_same_as_start: false,
             fill_cache: fill_cache,
             seek_mode: SeekMode::TotalOrder,
         }
@@ -196,8 +196,8 @@ impl IterOption {
         self
     }
 
-    pub fn enable_prefix_bound(mut self) -> IterOption {
-        self.prefix_bound = true;
+    pub fn set_prefix_same_as_start(mut self) -> IterOption {
+        self.prefix_same_as_start = true;
         self
     }
 }
@@ -206,7 +206,7 @@ impl Default for IterOption {
     fn default() -> IterOption {
         IterOption {
             upper_bound: None,
-            prefix_bound: false,
+            prefix_same_as_start: false,
             fill_cache: true,
             seek_mode: SeekMode::TotalOrder,
         }
@@ -290,7 +290,7 @@ impl Iterable for DB {
         readopts.fill_cache(iter_opt.fill_cache);
         if iter_opt.total_order_seek_used() {
             readopts.set_total_order_seek(true);
-        } else if iter_opt.prefix_bound {
+        } else if iter_opt.prefix_same_as_start {
             readopts.set_prefix_same_as_start(true);
         }
         if let Some(key) = iter_opt.upper_bound {
@@ -304,7 +304,7 @@ impl Iterable for DB {
         readopts.fill_cache(iter_opt.fill_cache);
         if iter_opt.total_order_seek_used() {
             readopts.set_total_order_seek(true);
-        } else if iter_opt.prefix_bound {
+        } else if iter_opt.prefix_same_as_start {
             readopts.set_prefix_same_as_start(true);
         }
         if let Some(key) = iter_opt.upper_bound {
@@ -342,7 +342,7 @@ impl Iterable for Snapshot {
         opt.fill_cache(iter_opt.fill_cache);
         if iter_opt.total_order_seek_used() {
             opt.set_total_order_seek(true);
-        } else if iter_opt.prefix_bound {
+        } else if iter_opt.prefix_same_as_start {
             opt.set_prefix_same_as_start(true);
         }
         if let Some(key) = iter_opt.upper_bound {
@@ -360,7 +360,7 @@ impl Iterable for Snapshot {
         opt.fill_cache(iter_opt.fill_cache);
         if iter_opt.total_order_seek_used() {
             opt.set_total_order_seek(true);
-        } else if iter_opt.prefix_bound {
+        } else if iter_opt.prefix_same_as_start {
             opt.set_prefix_same_as_start(true);
         }
         if let Some(key) = iter_opt.upper_bound {

--- a/src/raftstore/store/engine.rs
+++ b/src/raftstore/store/engine.rs
@@ -201,12 +201,12 @@ impl IterOption {
     }
 
     #[inline]
-    pub fn set_prefix_same_as_start(mut self) -> IterOption {
-        self.prefix_same_as_start = true;
+    pub fn set_prefix_same_as_start(mut self, enable: bool) -> IterOption {
+        self.prefix_same_as_start = enable;
         self
     }
 
-    pub fn to_read_opts(&self) -> ReadOptions {
+    pub fn build_read_opts(&self) -> ReadOptions {
         let mut opts = ReadOptions::new();
         opts.fill_cache(self.fill_cache);
         if self.total_order_seek_used() {
@@ -305,12 +305,12 @@ impl Peekable for DB {
 
 impl Iterable for DB {
     fn new_iterator(&self, iter_opt: IterOption) -> DBIterator {
-        self.iter_opt(iter_opt.to_read_opts())
+        self.iter_opt(iter_opt.build_read_opts())
     }
 
     fn new_iterator_cf(&self, cf: &str, iter_opt: IterOption) -> Result<DBIterator> {
         let handle = try!(rocksdb::get_cf_handle(self, cf));
-        let readopts = iter_opt.to_read_opts();
+        let readopts = iter_opt.build_read_opts();
         Ok(DBIterator::new_cf(self, handle, readopts))
     }
 }
@@ -338,7 +338,7 @@ impl Peekable for Snapshot {
 
 impl Iterable for Snapshot {
     fn new_iterator(&self, iter_opt: IterOption) -> DBIterator {
-        let mut opt = iter_opt.to_read_opts();
+        let mut opt = iter_opt.build_read_opts();
         unsafe {
             opt.set_snapshot(&self.snap);
         }
@@ -347,7 +347,7 @@ impl Iterable for Snapshot {
 
     fn new_iterator_cf(&self, cf: &str, iter_opt: IterOption) -> Result<DBIterator> {
         let handle = try!(rocksdb::get_cf_handle(&self.db, cf));
-        let mut opt = iter_opt.to_read_opts();
+        let mut opt = iter_opt.build_read_opts();
         unsafe {
             opt.set_snapshot(&self.snap);
         }

--- a/src/server/errors.rs
+++ b/src/server/errors.rs
@@ -43,6 +43,7 @@ quick_error!{
         Io(err: IoError) {
             from()
             cause(err)
+            display("{:?}", err)
             description(err.description())
         }
         Protobuf(err: ProtobufError) {
@@ -53,43 +54,52 @@ quick_error!{
         Grpc(err: GrpcError) {
             from()
             cause(err)
+            display("{:?}", err)
             description(err.description())
         }
         Codec(err: CodecError) {
             from()
             cause(err)
+            display("{:?}", err)
             description(err.description())
         }
         AddrParse(err: AddrParseError) {
             from()
             cause(err)
+            display("{:?}", err)
             description(err.description())
         }
         RaftServer(err: RaftServerError) {
             from()
             cause(err)
+            display("{:?}", err)
             description(err.description())
         }
         Engine(err: EngineError) {
             from()
             cause(err)
+            display("{:?}", err)
             description(err.description())
         }
         Storage(err: StorageError) {
             from()
             cause(err)
+            display("{:?}", err)
             description(err.description())
         }
         Pd(err: PdError) {
             from()
             cause(err)
+            display("{:?}", err)
             description(err.description())
         }
         SnapWorkerStopped(err: Stopped<SnapTask>) {
             from()
+            display("{:?}", err)
         }
         EndPointStopped(err: Stopped<EndPointTask>) {
             from()
+            display("{:?}", err)
         }
         Sink {
             description("failed to poll from mpsc receiver")
@@ -97,6 +107,7 @@ quick_error!{
         Canceled(err: Canceled) {
             from()
             cause(err)
+            display("{:?}", err)
             description(err.description())
         }
     }

--- a/src/storage/mvcc/reader.rs
+++ b/src/storage/mvcc/reader.rs
@@ -150,7 +150,7 @@ impl<'a> MvccReader<'a> {
             }
         } else {
             // use prefix bloom filter
-            let iter_opt = IterOption::new(None, true).use_prefix_seek().enable_prefix_bound();
+            let iter_opt = IterOption::default().use_prefix_seek().set_prefix_same_as_start();
             let iter = try!(self.snapshot.iter_cf(CF_WRITE, iter_opt, ScanMode::Mixed));
             self.write_cursor = Some(iter);
         }

--- a/src/storage/mvcc/reader.rs
+++ b/src/storage/mvcc/reader.rs
@@ -149,10 +149,8 @@ impl<'a> MvccReader<'a> {
                 self.write_cursor = Some(iter);
             }
         } else {
-            let upper_bound_key = key.append_ts(0u64);
-            let upper_bound = upper_bound_key.encoded().clone();
             // use prefix bloom filter
-            let iter_opt = IterOption::new(Some(upper_bound), true).use_prefix_seek();
+            let iter_opt = IterOption::new(None, true).use_prefix_seek();
             let iter = try!(self.snapshot.iter_cf(CF_WRITE, iter_opt, ScanMode::Mixed));
             self.write_cursor = Some(iter);
         }

--- a/src/storage/mvcc/reader.rs
+++ b/src/storage/mvcc/reader.rs
@@ -150,7 +150,7 @@ impl<'a> MvccReader<'a> {
             }
         } else {
             // use prefix bloom filter
-            let iter_opt = IterOption::default().use_prefix_seek().set_prefix_same_as_start();
+            let iter_opt = IterOption::default().use_prefix_seek().set_prefix_same_as_start(true);
             let iter = try!(self.snapshot.iter_cf(CF_WRITE, iter_opt, ScanMode::Mixed));
             self.write_cursor = Some(iter);
         }

--- a/src/storage/mvcc/reader.rs
+++ b/src/storage/mvcc/reader.rs
@@ -150,7 +150,7 @@ impl<'a> MvccReader<'a> {
             }
         } else {
             // use prefix bloom filter
-            let iter_opt = IterOption::new(None, true).use_prefix_seek();
+            let iter_opt = IterOption::new(None, true).use_prefix_seek().enable_prefix_bound();
             let iter = try!(self.snapshot.iter_cf(CF_WRITE, iter_opt, ScanMode::Mixed));
             self.write_cursor = Some(iter);
         }


### PR DESCRIPTION
the main optimization is using prefix seek instead of total order seek which is already enabled before this pull.
BUT replacing upper bound with prefix bound still can reduce some iterate ops like much del key exist before the bound.
eg. you del a big range of data, and you just want to get the bound value of the deleted range which is not exist.