### PR TITLE
tests: remove redundant cases

### DIFF
--- a/tests/raftstore/test_compact_after_delete.rs
+++ b/tests/raftstore/test_compact_after_delete.rs
@@ -19,7 +19,6 @@ use rocksdb::Range;
 use super::util::*;
 use super::cluster::{Cluster, Simulator};
 use super::node::new_node_cluster;
-use super::server::new_server_cluster;
 
 fn test_compact_after_delete<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.cfg.raft_store.region_compact_check_interval = 500_000;

--- a/tests/raftstore/test_compact_after_delete.rs
+++ b/tests/raftstore/test_compact_after_delete.rs
@@ -51,13 +51,6 @@ fn test_compact_after_delete<T: Simulator>(cluster: &mut Cluster<T>) {
 }
 
 #[test]
-fn test_server_compact_after_delete() {
-    let count = 1;
-    let mut cluster = new_server_cluster(0, count);
-    test_compact_after_delete(&mut cluster);
-}
-
-#[test]
 fn test_node_compact_after_delete() {
     let count = 1;
     let mut cluster = new_node_cluster(0, count);

--- a/tests/raftstore/test_compact_log.rs
+++ b/tests/raftstore/test_compact_log.rs
@@ -198,13 +198,6 @@ fn test_node_compact_log() {
 }
 
 #[test]
-fn test_server_compact_log() {
-    let count = 5;
-    let mut cluster = new_server_cluster(0, count);
-    test_compact_log(&mut cluster);
-}
-
-#[test]
 fn test_node_compact_count_limit() {
     let count = 5;
     let mut cluster = new_node_cluster(0, count);
@@ -212,23 +205,9 @@ fn test_node_compact_count_limit() {
 }
 
 #[test]
-fn test_server_compact_count_limit() {
-    let count = 5;
-    let mut cluster = new_server_cluster(0, count);
-    test_compact_count_limit(&mut cluster);
-}
-
-#[test]
 fn test_node_compact_many_times() {
     let count = 5;
     let mut cluster = new_node_cluster(0, count);
-    test_compact_many_times(&mut cluster);
-}
-
-#[test]
-fn test_server_compact_many_times() {
-    let count = 5;
-    let mut cluster = new_server_cluster(0, count);
     test_compact_many_times(&mut cluster);
 }
 
@@ -318,12 +297,5 @@ fn test_compact_size_limit<T: Simulator>(cluster: &mut Cluster<T>) {
 fn test_node_compact_size_limit() {
     let count = 5;
     let mut cluster = new_node_cluster(0, count);
-    test_compact_size_limit(&mut cluster);
-}
-
-#[test]
-fn test_server_compact_size_limit() {
-    let count = 5;
-    let mut cluster = new_server_cluster(0, count);
     test_compact_size_limit(&mut cluster);
 }

--- a/tests/raftstore/test_compact_log.rs
+++ b/tests/raftstore/test_compact_log.rs
@@ -24,7 +24,6 @@ use kvproto::raft_serverpb::{RaftApplyState, RaftTruncatedState};
 use super::util::*;
 use super::cluster::{Cluster, Simulator};
 use super::node::new_node_cluster;
-use super::server::new_server_cluster;
 
 fn get_msg_cf_or_default<M>(engine: &DB, cf: &str, key: &[u8]) -> M
     where M: protobuf::Message + protobuf::MessageStatic

--- a/tests/raftstore/test_lease_read.rs
+++ b/tests/raftstore/test_lease_read.rs
@@ -33,7 +33,6 @@ use tikv::util::{escape, HandyRwLock};
 
 use super::cluster::{Cluster, Simulator};
 use super::node::new_node_cluster;
-use super::server::new_server_cluster;
 use super::transport_simulate::*;
 use super::util::*;
 

--- a/tests/raftstore/test_lease_read.rs
+++ b/tests/raftstore/test_lease_read.rs
@@ -206,23 +206,9 @@ fn test_one_node_renew_lease() {
 }
 
 #[test]
-fn test_one_server_renew_lease() {
-    let count = 1;
-    let mut cluster = new_server_cluster(0, count);
-    test_renew_lease(&mut cluster);
-}
-
-#[test]
 fn test_node_renew_lease() {
     let count = 3;
     let mut cluster = new_node_cluster(0, count);
-    test_renew_lease(&mut cluster);
-}
-
-#[test]
-fn test_server_renew_lease() {
-    let count = 3;
-    let mut cluster = new_server_cluster(0, count);
     test_renew_lease(&mut cluster);
 }
 
@@ -272,13 +258,6 @@ fn test_lease_expired<T: Simulator>(cluster: &mut Cluster<T>) {
 fn test_node_lease_expired() {
     let count = 3;
     let mut cluster = new_node_cluster(0, count);
-    test_lease_expired(&mut cluster);
-}
-
-#[test]
-fn test_server_lease_expired() {
-    let count = 3;
-    let mut cluster = new_server_cluster(0, count);
     test_lease_expired(&mut cluster);
 }
 
@@ -374,13 +353,6 @@ fn test_lease_unsafe_during_leader_transfers<T: Simulator>(cluster: &mut Cluster
 
 #[test]
 fn test_node_lease_unsafe_during_leader_transfers() {
-    let count = 3;
-    let mut cluster = new_node_cluster(0, count);
-    test_lease_unsafe_during_leader_transfers(&mut cluster);
-}
-
-#[test]
-fn test_server_lease_unsafe_during_leader_transfers() {
     let count = 3;
     let mut cluster = new_node_cluster(0, count);
     test_lease_unsafe_during_leader_transfers(&mut cluster);

--- a/tests/raftstore/test_multi.rs
+++ b/tests/raftstore/test_multi.rs
@@ -690,12 +690,6 @@ fn test_node_consistency_check() {
     test_consistency_check(&mut cluster);
 }
 
-#[test]
-fn test_server_consistency_check() {
-    let mut cluster = new_server_cluster(0, 2);
-    test_consistency_check(&mut cluster);
-}
-
 fn test_batch_write<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.run();
     let r = cluster.get_region(b"");
@@ -720,12 +714,6 @@ fn test_batch_write<T: Simulator>(cluster: &mut Cluster<T>) {
     assert!(resp.get_header().has_error());
     assert_eq!(cluster.must_get(b"k1"), Some(b"v1".to_vec()));
     assert_eq!(cluster.must_get(b"k3"), None);
-}
-
-#[test]
-fn test_node_batch_write() {
-    let mut cluster = new_node_cluster(0, 3);
-    test_batch_write(&mut cluster);
 }
 
 #[test]

--- a/tests/raftstore/test_stats.rs
+++ b/tests/raftstore/test_stats.rs
@@ -96,12 +96,6 @@ fn test_node_simple_store_stats() {
 }
 
 #[test]
-fn test_server_simple_store_stats() {
-    let mut cluster = new_server_cluster(0, 1);
-    test_simple_store_stats(&mut cluster);
-}
-
-#[test]
 fn test_server_store_snap_stats() {
     let mut cluster = new_server_cluster(0, 2);
     cluster.cfg.raft_store.pd_store_heartbeat_tick_interval = 600000;


### PR DESCRIPTION
Some cases don't have to be run with both node cluster and server cluster.