### PR TITLE
raftstore/peer: revise leader lease time log

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -39,7 +39,7 @@ use raftstore::store::worker::apply::ExecResult;
 
 use util::worker::{FutureWorker as Worker, Scheduler};
 use raftstore::store::worker::{ApplyTask, ApplyRes, Apply};
-use util::{clocktime, Either, strftimespec};
+use util::{clocktime, Either};
 use util::collections::{HashSet, FlatMap, FlatMapValues as Values};
 
 use pd::INVALID_ID;
@@ -601,7 +601,7 @@ impl Peer {
                     self.leader_lease_expired_time = Some(Either::Left(next_expired_time));
                     debug!("{} becomes leader and lease expired time is {:?}",
                            self.tag,
-                           strftimespec(next_expired_time));
+                           next_expired_time);
                     self.heartbeat_pd(worker)
                 }
                 StateRole::Follower => {
@@ -858,8 +858,8 @@ impl Peer {
             if current_expired_time < next_expired_time {
                 debug!("{} update leader lease expired time from {:?} to {:?}",
                        self.tag,
-                       strftimespec(current_expired_time),
-                       strftimespec(next_expired_time));
+                       current_expired_time,
+                       next_expired_time);
                 self.leader_lease_expired_time = Some(Either::Left(next_expired_time));
             }
         } else if self.is_leader() {
@@ -869,7 +869,7 @@ impl Peer {
             let next_expired_time = self.next_lease_expired_time(propose_time);
             debug!("{} update leader lease expired time from None to {:?}",
                    self.tag,
-                   strftimespec(next_expired_time));
+                   next_expired_time);
             self.leader_lease_expired_time = Some(Either::Left(next_expired_time));
         }
     }
@@ -1046,7 +1046,7 @@ impl Peer {
 
             debug!("{} leader lease expired time {:?} is outdated",
                    self.tag,
-                   strftimespec(safe_expired_time));
+                   safe_expired_time);
             // Reset leader lease expiring time.
             self.leader_lease_expired_time = None;
         }

--- a/src/util/clocktime.rs
+++ b/src/util/clocktime.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// `now_monotonic_raw` returns the monotonic raw clocktime corresponding to "now".
+// `raw_now` returns the monotonic time since some unspecified starting point.
 pub use self::inner::raw_now;
 
 #[cfg(not(target_os = "linux"))]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -17,7 +17,6 @@ use std::io;
 use std::{slice, thread};
 use std::net::{ToSocketAddrs, TcpStream, SocketAddr};
 use std::time::{Duration, Instant};
-use time::{self, Timespec};
 use std::collections::hash_map::Entry;
 use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::collections::vec_deque::{Iter, VecDeque};
@@ -325,14 +324,6 @@ pub fn duration_to_nanos(d: Duration) -> u64 {
     d.as_secs() * 1_000_000_000 + nanos
 }
 
-// Returns the formatted string for a specified time in local timezone.
-pub fn strftimespec(t: Timespec) -> String {
-    let tm = time::at(t);
-    let mut s = time::strftime("%Y/%m/%d %H:%M:%S", &tm).unwrap();
-    s += &format!(".{:03}", t.nsec / 1_000_000);
-    s
-}
-
 pub fn get_tag_from_thread_name() -> Option<String> {
     thread::current().name().and_then(|name| name.split("::").skip(1).last()).map(From::from)
 }
@@ -501,7 +492,6 @@ mod tests {
     use std::rc::Rc;
     use std::{f64, cmp};
     use std::sync::atomic::{AtomicBool, Ordering};
-    use time;
     use kvproto::eraftpb::Entry;
     use protobuf::Message;
     use super::*;
@@ -563,17 +553,6 @@ mod tests {
             assert!((act_sec - exp_sec).abs() < f64::EPSILON);
             assert_eq!(ms * 1_000_000, duration_to_nanos(d));
         }
-    }
-
-    #[test]
-    fn test_strftimespec() {
-        let s = "2016/08/30 15:40:07".to_owned();
-        let mut tm = time::strptime(&s, "%Y/%m/%d %H:%M:%S").unwrap();
-        // `tm` is of UTC timezone. Set the timezone of `tm` to be local timezone,
-        // so that we get a `tm` of local timezone.
-        let ltm = tm.to_local();
-        tm.tm_utcoff = ltm.tm_utcoff;
-        assert_eq!(strftimespec(tm.to_timespec()), s + ".000");
     }
 
     #[test]


### PR DESCRIPTION
Hi,

This PR revises the format of leader lease in log messages. It reverts the PR #1722. Because the leader lease is a monotonic time since startup time. It's confusing to output it in absolute time format. This PR changes the leader lease format from `"1970/01/01 00:17:01.272"` to `Timespec { sec: 51988, nsec: 392739700 }` for better description.

PTAL @javaforfun @BusyJay @siddontang