### PR TITLE
apply: batch register proposal callbacks

### DIFF
--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -890,7 +890,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             let mut ctx = ReadyContext::new(&mut self.raft_metrics, &self.trans, pending_count);
             for region_id in self.pending_raft_groups.drain() {
                 if let Some(peer) = self.region_peers.get_mut(&region_id) {
-                    peer.schedule_apply_proposals(&mut self.apply_worker);
+                    peer.schedule_apply_proposals(&self.apply_worker);
                     peer.handle_raft_ready_append(&mut ctx, &self.pd_worker);
                 }
             }

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -890,6 +890,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             let mut ctx = ReadyContext::new(&mut self.raft_metrics, &self.trans, pending_count);
             for region_id in self.pending_raft_groups.drain() {
                 if let Some(peer) = self.region_peers.get_mut(&region_id) {
+                    peer.schedule_apply_proposals(&mut self.apply_worker);
                     peer.handle_raft_ready_append(&mut ctx, &self.pd_worker);
                 }
             }

--- a/src/raftstore/store/worker/apply.rs
+++ b/src/raftstore/store/worker/apply.rs
@@ -39,6 +39,8 @@ use raftstore::store::peer_storage::{self, write_initial_state, write_peer_state
 use raftstore::store::peer::{parse_data_at, check_epoch, Peer};
 use raftstore::store::metrics::*;
 
+use super::metrics::*;
+
 const WRITE_BATCH_MAX_KEYS: usize = 128;
 const DEFAULT_APPLY_WB_SIZE: usize = 4 * 1024;
 
@@ -1269,6 +1271,7 @@ impl Runner {
     }
 
     fn handle_proposals(&mut self, proposals: Proposals) {
+        APPLY_PROPOSAL.observe(proposals.props.len() as f64);
         let delegate = match self.delegates.get_mut(&proposals.region_id) {
             Some(d) => d,
             None => {

--- a/src/raftstore/store/worker/metrics.rs
+++ b/src/raftstore/store/worker/metrics.rs
@@ -74,4 +74,10 @@ lazy_static! {
             "tikv_raftstore_hash_duration_seconds",
             "Bucketed histogram of raftstore hash compution duration"
         ).unwrap();
+
+    pub static ref APPLY_PROPOSAL: Histogram =
+        register_histogram!(
+            "tikv_raftstore_apply_proposal",
+            "Proposal count of every region in a mio tick"
+        ).unwrap();
 }

--- a/src/raftstore/store/worker/mod.rs
+++ b/src/raftstore/store/worker/mod.rs
@@ -61,4 +61,4 @@ pub use self::raftlog_gc::{Task as RaftlogGcTask, Runner as RaftlogGcRunner};
 pub use self::pd::{Task as PdTask, Runner as PdRunner};
 pub use self::consistency_check::{Task as ConsistencyCheckTask, Runner as ConsistencyCheckRunner};
 pub use self::apply::{Task as ApplyTask, Runner as ApplyRunner, TaskRes as ApplyTaskRes, ApplyRes,
-                      ApplyMetrics, Registration, Apply};
+                      ApplyMetrics, Registration, Apply, Proposal};


### PR DESCRIPTION
Send proposal callbacks in batch can reduce the invocation of channel send and HashMap queries.

@siddontang @javaforfun PTAL