### PR TITLE
raftstore: add entry cache

### DIFF
--- a/src/raftstore/store/metrics.rs
+++ b/src/raftstore/store/metrics.rs
@@ -115,8 +115,6 @@ lazy_static! {
                     512.0, 1024.0, 5120.0, 10240.0]
         ).unwrap();
 
-
-
     pub static ref REGION_WRITTEN_BYTES_HISTOGRAM: Histogram =
         register_histogram!(
             "tikv_region_written_bytes",
@@ -179,5 +177,12 @@ lazy_static! {
             "tikv_snapshot_size",
             "Size of snapshot",
              exponential_buckets(1024.0, 2.0, 22).unwrap() // 1024,1024*2^1,..,4G
+        ).unwrap();
+
+    pub static ref RAFT_ENTRY_FETCHES: CounterVec =
+        register_counter_vec!(
+            "tikv_raftstore_entry_fetches",
+            "Total number of raft entry fetches",
+            &["type"]
         ).unwrap();
 }

--- a/src/raftstore/store/mod.rs
+++ b/src/raftstore/store/mod.rs
@@ -38,6 +38,6 @@ pub use self::bootstrap::{bootstrap_store, prepare_bootstrap, write_prepare_boot
                           clear_prepare_bootstrap, clear_prepare_bootstrap_state};
 pub use self::engine::{Peekable, Iterable, Mutable};
 pub use self::peer_storage::{PeerStorage, do_snapshot, SnapState, RAFT_INIT_LOG_TERM,
-                             RAFT_INIT_LOG_INDEX};
+                             RAFT_INIT_LOG_INDEX, CacheQueryStats};
 pub use self::snap::{SnapKey, Snapshot, SnapshotDeleter, SnapshotStatistics, ApplyOptions,
                      SnapEntry, SnapManager, check_abort, copy_snapshot};

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -292,7 +292,11 @@ impl Peer {
         let peer_cache = FlatMap::default();
         let tag = format!("[region {}] {}", region.get_id(), peer_id);
 
-        let ps = try!(PeerStorage::new(store.engine(), region, sched, tag.clone()));
+        let ps = try!(PeerStorage::new(store.engine(),
+                                       region,
+                                       sched,
+                                       tag.clone(),
+                                       store.entry_cache_metries.clone()));
 
         let applied_index = ps.applied_index();
 

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -370,7 +370,7 @@ impl Peer {
 
         // Set Tombstone state explicitly
         let wb = WriteBatch::new();
-        try!(self.get_store().clear_meta(&wb));
+        try!(self.mut_store().clear_meta(&wb));
         try!(write_peer_state(&wb, &region, PeerState::Tombstone));
         try!(self.engine.write(wb));
 

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -1586,7 +1586,7 @@ mod test {
         validate_cache(&store, &exp_res);
 
         // compact shrink
-        assert!(store.cache.cache.capacity() > cap as usize);
+        assert!(store.cache.cache.capacity() >= cap as usize);
         store.compact_to(cap * 2);
         exp_res = (cap * 2..cap * 2 + 7).map(|i| new_entry(i, 8)).collect();
         validate_cache(&store, &exp_res);
@@ -1595,7 +1595,7 @@ mod test {
         // append shrink
         entries = (0..cap + 1).map(|i| new_entry(i, 8)).collect();
         append_ents(&mut store, &entries);
-        assert!(store.cache.cache.capacity() > cap as usize);
+        assert!(store.cache.cache.capacity() >= cap as usize);
         append_ents(&mut store, &[new_entry(6, 8)]);
         exp_res = (1..7).map(|i| new_entry(i, 8)).collect();
         validate_cache(&store, &exp_res);

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -47,7 +47,7 @@ const MAX_SNAP_TRY_CNT: usize = 5;
 const RAFT_LOG_MULTI_GET_CNT: u64 = 8;
 
 // One extra slot for VecDeque internal usage.
-const MAX_CACHE_CAPACITY: usize = 1024 * 3 - 1;
+const MAX_CACHE_CAPACITY: usize = 1024 - 1;
 const SHRINK_CACHE_CAPACITY: usize = 64;
 
 pub const JOB_STATUS_PENDING: usize = 0;

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -1058,6 +1058,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             end_idx: state.get_index() + 1,
         };
         peer.last_compacted_idx = task.end_idx;
+        peer.mut_store().compact_to(task.end_idx);
         if let Err(e) = self.raftlog_gc_worker.schedule(task) {
             error!("[region {}] failed to schedule compact task: {}",
                    region_id,

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -81,6 +81,22 @@ pub fn limit_size<T: Message + Clone>(entries: &mut Vec<T>, max: u64) {
     entries.truncate(limit);
 }
 
+/// Take slices in the range.
+///
+/// ### Panic
+///
+/// if [low, high) is out of bound.
+pub fn slices_in_range<'a, T>(entry: &'a VecDeque<T>, low: usize, high: usize) -> (&'a [T], &'a [T]) {
+    let (first, second) = entry.as_slices();
+    if low >= first.len() {
+        (&second[low - first.len()..high - first.len()], &[])
+    } else if high <= first.len() {
+        (&first[low..high], &[])
+    } else {
+        (&first[low..], &second[..high - first.len()])
+    }
+}
+
 pub struct DefaultRng {
     rng: ThreadRng,
 }
@@ -487,6 +503,7 @@ pub fn cfs_diff<'a>(a: &[&'a str], b: &[&str]) -> Vec<&'a str> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::*;
     use std::net::{SocketAddr, AddrParseError};
     use std::time::Duration;
     use std::rc::Rc;
@@ -611,6 +628,35 @@ mod tests {
         for (mut entries, max, len) in tbls {
             limit_size(&mut entries, max);
             assert_eq!(entries.len(), len);
+        }
+    }
+
+    #[test]
+    fn test_slices_vec_deque() {
+        for first in 0..10 {
+            let mut v = VecDeque::with_capacity(10);
+            for i in 0..first {
+                v.push_back(i);
+            }
+            for i in first..10 {
+                v.push_back(i - first);
+            }
+            v.drain(..first);
+            for i in 0..first {
+                v.push_back(10 + i - first);
+            }
+            for len in 0..10 {
+                for low in 0..len + 1 {
+                    for high in low..len + 1 {
+                        let (p1, p2) = super::slices_in_range(&v, low, high);
+                        let mut res = vec![];
+                        res.extend_from_slice(p1);
+                        res.extend_from_slice(p2);
+                        let exp: Vec<_> = (low..high).collect();
+                        assert_eq!(res, exp, "[{}, {}) in {:?} with first: {}", low, high, v, first);
+                    }
+                }
+            }
         }
     }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -86,7 +86,7 @@ pub fn limit_size<T: Message + Clone>(entries: &mut Vec<T>, max: u64) {
 /// ### Panic
 ///
 /// if [low, high) is out of bound.
-pub fn slices_in_range<'a, T>(entry: &'a VecDeque<T>, low: usize, high: usize) -> (&'a [T], &'a [T]) {
+pub fn slices_in_range<T>(entry: &VecDeque<T>, low: usize, high: usize) -> (&[T], &[T]) {
     let (first, second) = entry.as_slices();
     if low >= first.len() {
         (&second[low - first.len()..high - first.len()], &[])
@@ -653,7 +653,13 @@ mod tests {
                         res.extend_from_slice(p1);
                         res.extend_from_slice(p2);
                         let exp: Vec<_> = (low..high).collect();
-                        assert_eq!(res, exp, "[{}, {}) in {:?} with first: {}", low, high, v, first);
+                        assert_eq!(res,
+                                   exp,
+                                   "[{}, {}) in {:?} with first: {}",
+                                   low,
+                                   high,
+                                   v,
+                                   first);
                     }
                 }
             }


### PR DESCRIPTION
Add cache for fetching log entries, this can reduce the time visiting rocksdb.