### PR TITLE
pd: put store before start store thread

### DIFF
--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -140,14 +140,14 @@ impl<C> Node<C>
         }
 
         // inform pd.
+        try!(self.pd_client
+            .put_store(self.store.clone()));
         try!(self.start_store(event_loop,
                               store_id,
                               engine,
                               trans,
                               snap_mgr,
                               snap_status_receiver));
-        try!(self.pd_client
-            .put_store(self.store.clone()));
         Ok(())
     }
 

--- a/tests/raftstore/pd.rs
+++ b/tests/raftstore/pd.rs
@@ -483,6 +483,10 @@ impl TestPdClient {
 
     pub fn add_peer(&self, region_id: u64, peer: metapb::Peer) {
         self.set_rule(box move |region: &metapb::Region, _: &metapb::Peer| {
+            debug!("[region {}] trying add {:?} to {:?}",
+                   region_id,
+                   peer,
+                   region);
             if region.get_id() != region_id {
                 return None;
             }


### PR DESCRIPTION
Test pd client need to be informed before it can handle region heartbeat response callback, so here invoke put store before store thread is actually started.

@disksing is it OK for pd?

close #1982 