### PR TITLE
xeval/evaluator: implement json_type

### DIFF
--- a/src/util/codec/datum.rs
+++ b/src/util/codec/datum.rs
@@ -460,7 +460,7 @@ impl Datum {
         };
         parse_json_path_expr(v)
     }
-  
+
     /// Try its best effort to convert into a decimal datum.
     /// source function name is `ConvertDatumToDecimal`.
     fn coerce_to_dec(self) -> Result<Datum> {

--- a/src/util/codec/datum.rs
+++ b/src/util/codec/datum.rs
@@ -273,7 +273,7 @@ impl Datum {
                 Json::String(String::from(data)).cmp(json)
             }
             _ => {
-                let data = format!("{:?}", *self);
+                let data = self.as_string().unwrap_or_default();
                 Json::String(data).cmp(json)
             }
         };
@@ -299,21 +299,30 @@ impl Datum {
         Ok(b)
     }
 
-    /// into_string convert self into a string.
-    /// source function name is `ToString`.
-    pub fn into_string(self) -> Result<String> {
-        let s = match self {
+    pub fn as_string(&self) -> Result<String> {
+        let s = match *self {
             Datum::I64(i) => format!("{}", i),
             Datum::U64(u) => format!("{}", u),
             Datum::F64(f) => format!("{}", f),
-            Datum::Bytes(bs) => try!(String::from_utf8(bs)),
-            Datum::Time(t) => format!("{}", t),
-            Datum::Dur(d) => format!("{}", d),
-            Datum::Dec(d) => format!("{}", d),
-            Datum::Json(d) => d.to_string(),
-            d => return Err(invalid_type!("can't convert {:?} to string", d)),
+            Datum::Bytes(ref bs) => try!(String::from_utf8(bs.to_vec())),
+            Datum::Time(ref t) => format!("{}", t),
+            Datum::Dur(ref d) => format!("{}", d),
+            Datum::Dec(ref d) => format!("{}", d),
+            Datum::Json(ref d) => d.to_string(),
+            ref d => return Err(invalid_type!("can't convert {:?} to string", d)),
         };
         Ok(s)
+    }
+
+    /// into_string convert self into a string.
+    /// source function name is `ToString`.
+    pub fn into_string(self) -> Result<String> {
+        if let Datum::Bytes(bs) = self {
+            let data = try!(String::from_utf8(bs));
+            Ok(data)
+        } else {
+            self.as_string()
+        }
     }
 
     /// `into_f64` converts self into f64.
@@ -396,6 +405,51 @@ impl Datum {
                     d => Err(box_err!("failed to conver {} to decimal", d)),
                 }
             }
+        }
+    }
+
+    /// cast_as_json converts Datum::Bytes(bs) into Json::from_str(bs)
+    /// and Datum::Null would be illegal. It would be used in cast,
+    /// json_merge,json_extract,json_type
+    /// mysql> SELECT CAST('null' AS JSON);
+    /// +----------------------+
+    /// | CAST('null' AS JSON) |
+    /// +----------------------+
+    /// | null                 |
+    /// +----------------------+
+    pub fn cast_as_json(self) -> Result<Json> {
+        match self {
+            Datum::Bytes(ref bs) => {
+                let s = box_try!(str::from_utf8(bs));
+                let json: Json = try!(s.parse());
+                Ok(json)
+            }
+            Datum::I64(d) => Ok(Json::I64(d)),
+            Datum::U64(d) => Ok(Json::I64(d as i64)),
+            Datum::F64(d) => Ok(Json::Double(d)),
+            Datum::Dec(d) => {
+                let ff = try!(d.as_f64());
+                Ok(Json::Double(ff))
+            }
+            Datum::Json(d) => Ok(d),
+            _ => {
+                let s = try!(self.into_string());
+                Ok(Json::String(s))
+            }
+        }
+    }
+
+    /// into_json would convert Datum::Bytes(bs) into Json::String(bs)
+    /// and convert Datum::Null into Json::None.
+    /// This func would be used in json_unquote and json_modify
+    pub fn into_json(self) -> Result<Json> {
+        match self {
+            Datum::Null => Ok(Json::None),
+            Datum::Bytes(bs) => {
+                let s = try!(String::from_utf8(bs));
+                Ok(Json::String(s))
+            }
+            _ => self.cast_as_json(),
         }
     }
 
@@ -1205,12 +1259,12 @@ mod test {
              Ordering::Equal),
             (Datum::I64(18), Datum::Json(Json::I64(18)), Ordering::Equal),
             (Datum::U64(18), Datum::Json(Json::I64(20)), Ordering::Less),
-            (Datum::F64(1.2),Datum::Json(Json::Double(1.0)), Ordering::Greater),
+            (Datum::F64(1.2), Datum::Json(Json::Double(1.0)), Ordering::Greater),
             (Datum::Dec(i32::MIN.into()),
              Datum::Json(Json::Double(i32::MIN as f64)), Ordering::Equal),
             (b"hi".as_ref().into(), Datum::Json(Json::from_str(r#""hi""#).unwrap()),
              Ordering::Equal),
-            (Datum::Max,Datum::Json(Json::from_str(r#""MAX""#).unwrap()),Ordering::Equal),
+            (Datum::Max, Datum::Json(Json::from_str(r#""MAX""#).unwrap()),Ordering::Less),
         ];
 
         for (lhs, rhs, ret) in tests {
@@ -1339,6 +1393,57 @@ mod test {
             let (res_x, res_y) = Datum::coerce(x, y).unwrap();
             assert_eq!(res_x, exp_x);
             assert_eq!(res_y, exp_y);
+        }
+    }
+
+    #[test]
+    fn test_cast_as_json() {
+        let tests = vec![
+            (Datum::I64(1), "1.0"),
+            (Datum::F64(3.3),"3.3"),
+            (Datum::Bytes(br#""Hello,world""#.to_vec()), r#""Hello,world""#),
+            (Datum::Bytes(b"[1, 2, 3]".to_vec()), "[1, 2, 3]"),
+            (Datum::Bytes(b"{}".to_vec()), "{}"),
+            (Datum::I64(1), "true"),
+        ];
+
+        for (d, json) in tests {
+            assert_eq!(d.cast_as_json().unwrap(), json.parse().unwrap());
+        }
+
+        let illegal_cases = vec![
+            Datum::Bytes(b"hello,world".to_vec()),
+            Datum::Null,
+            Datum::Max,
+            Datum::Min,
+        ];
+
+        for d in illegal_cases {
+            assert!(d.cast_as_json().is_err());
+        }
+    }
+
+    #[test]
+    fn test_datum_into_json() {
+        let tests = vec![
+            (Datum::I64(1), "1.0"),
+            (Datum::F64(3.3),"3.3"),
+            (Datum::Bytes(b"Hello,world".to_vec()), r#""Hello,world""#),
+            (Datum::Bytes(b"[1, 2, 3]".to_vec()), r#""[1, 2, 3]""#),
+            (Datum::Null, "null"),
+        ];
+
+        for (d, json) in tests {
+            assert_eq!(d.into_json().unwrap(), json.parse().unwrap());
+        }
+
+        let illegal_cases = vec![
+            Datum::Max,
+            Datum::Min,
+        ];
+
+        for d in illegal_cases {
+            assert!(d.into_json().is_err());
         }
     }
 }

--- a/src/util/xeval/evaluator.rs
+++ b/src/util/xeval/evaluator.rs
@@ -13,6 +13,7 @@
 
 use std::cmp::Ordering;
 use std::ascii::AsciiExt;
+use std::str;
 
 use chrono::FixedOffset;
 use tipb::expression::{Expr, ExprType};
@@ -20,8 +21,7 @@ use tipb::select::SelectRequest;
 
 use util::codec::number::NumberDecoder;
 use util::codec::datum::{Datum, DatumDecoder};
-use util::codec::mysql::DecimalDecoder;
-use util::codec::mysql::{MAX_FSP, Duration};
+use util::codec::mysql::{DecimalDecoder, MAX_FSP, Duration};
 use util::codec;
 use util::collections::{HashMap, HashMapEntry};
 
@@ -137,6 +137,7 @@ impl Evaluator {
             ExprType::IfNull => self.eval_if_null(ctx, expr),
             ExprType::IsNull => self.eval_is_null(ctx, expr),
             ExprType::NullIf => self.eval_null_if(ctx, expr),
+            ExprType::JsonType => self.eval_json_type(ctx, expr),
             _ => Ok(Datum::Null),
         }
     }
@@ -223,6 +224,17 @@ impl Evaluator {
         }
         let children = expr.get_children();
         Ok((&children[0], &children[1]))
+    }
+
+    fn eval_one_child(&mut self, ctx: &EvalContext, expr: &Expr) -> Result<Datum> {
+        let children = expr.get_children();
+        if children.len() != 1 {
+            return Err(Error::Expr(format!("{:?} need 1 operands but got {}",
+                                           expr.get_tp(),
+                                           children.len())));
+        }
+        let child = try!(self.eval(ctx, &children[0]));
+        Ok(child)
     }
 
     fn eval_two_children(&mut self, ctx: &EvalContext, expr: &Expr) -> Result<(Datum, Datum)> {
@@ -384,6 +396,16 @@ impl Evaluator {
         } else {
             Ok(left)
         }
+    }
+
+    fn eval_json_type(&mut self, ctx: &EvalContext, expr: &Expr) -> Result<Datum> {
+        let child = try!(self.eval_one_child(ctx, expr));
+        if Datum::Null == child {
+            return Ok(Datum::Null);
+        }
+        let json = try!(child.cast_as_json());
+        let json_type = json.json_type().to_vec();
+        Ok(Datum::Bytes(json_type))
     }
 
     fn eval_logic<F>(&mut self,
@@ -588,6 +610,23 @@ mod test {
             }
         };
     }
+
+    macro_rules! test_eval_err {
+        ($tag:ident, $cases:expr) => {
+            #[test]
+            fn $tag() {
+                let cases = $cases;
+
+                let mut xevaluator = Evaluator::default();
+                xevaluator.row.insert(1, Datum::I64(100));
+                for expr in cases {
+                    let res = xevaluator.eval(&Default::default(), &expr);
+                    assert!(res.is_err());
+                }
+            }
+        };
+    }
+
 
     test_eval!(test_eval_datum_col,
                vec![
@@ -999,4 +1038,34 @@ mod test {
             }
         }
     }
+
+    fn build_byte_datums_expr(data: &[&[u8]], tp: ExprType) -> Expr {
+        let datums = data.into_iter().map(|item| Datum::Bytes(item.to_vec())).collect();
+        build_expr(datums, tp)
+    }
+
+    test_eval!(test_eval_json_type,
+               vec![
+            (build_expr(vec![Datum::Null], ExprType::JsonType),
+                        Datum::Null),
+            (build_byte_datums_expr(&[br#"true"#], ExprType::JsonType),
+                        Datum::Bytes(b"BOOLEAN".to_vec())),
+            (build_byte_datums_expr(&[br#"null"#], ExprType::JsonType),
+                        Datum::Bytes(b"NULL".to_vec())),
+            (build_byte_datums_expr(&[br#"3"#], ExprType::JsonType),
+                        Datum::Bytes(b"INTEGER".to_vec())),
+            (build_byte_datums_expr(&[br#"3.14"#], ExprType::JsonType),
+                        Datum::Bytes(b"DOUBLE".to_vec())),
+            (build_byte_datums_expr(&[br#"{"name":"shirly","age":18}"#], ExprType::JsonType),
+                        Datum::Bytes(b"OBJECT".to_vec())),
+            (build_byte_datums_expr(&[br#"[1,2,3]"#], ExprType::JsonType),
+                        Datum::Bytes(b"ARRAY".to_vec())),
+    ]);
+
+    test_eval_err!(test_eval_json_err,
+                   vec![
+          build_expr(vec![], ExprType::JsonType),
+          build_byte_datums_expr(&[br#"true"#, br#"444"#], ExprType::JsonType),
+     ]);
+
 }


### PR DESCRIPTION
Hi,
    This PR implement function `json_type` in evaluator, the related PR in `tidb` is https://github.com/pingcap/tidb/pull/3492,
and the related source files in `tidb` are

- https://github.com/pingcap/tidb/blob/master/expression/builtin_json.go
- https://github.com/pingcap/tidb/blob/master/distsql/xeval/eval_json.go
- https://github.com/pingcap/tidb/blob/master/distsql/xeval/eval.go

And the file datum.rs is the same with https://github.com/pingcap/tikv/pull/1996. we should do review after it has been merged.

- [x] https://github.com/pingcap/tikv/pull/1996

@hhkbp2 @hicqu @lishihai9017 @andelf PTAL