### PR TITLE
coprocessor/metrics: remove type from labels

### DIFF
--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -158,7 +158,7 @@ impl RequestTask {
             return;
         }
         let wait_time = duration_to_sec(self.timer.elapsed());
-        COPR_REQ_WAIT_TIME.with_label_values(&["select", get_req_type_str(self.req.get_tp())])
+        COPR_REQ_WAIT_TIME.with_label_values(&[get_req_type_str(self.req.get_tp())])
             .observe(wait_time);
         self.wait_time = Some(wait_time);
     }
@@ -168,15 +168,16 @@ impl RequestTask {
 
         let handle_time = duration_to_sec(self.timer.elapsed());
         let type_str = get_req_type_str(self.req.get_tp());
-        COPR_REQ_HISTOGRAM_VEC.with_label_values(&["select", type_str]).observe(handle_time);
+        COPR_REQ_HISTOGRAM_VEC.with_label_values(&[type_str]).observe(handle_time);
         let wait_time = self.wait_time.unwrap();
-        COPR_REQ_HANDLE_TIME.with_label_values(&["select", type_str])
+        COPR_REQ_HANDLE_TIME.with_label_values(&[type_str])
             .observe(handle_time - wait_time);
 
+
         let scanned_keys = self.statistics.total_op_count() as f64;
-        COPR_SCAN_KEYS.with_label_values(&["select", type_str]).observe(scanned_keys);
+        COPR_SCAN_KEYS.with_label_values(&[type_str]).observe(scanned_keys);
         let inefficiency = self.statistics.inefficiency();
-        COPR_SCAN_INEFFICIENCY.with_label_values(&["select", type_str]).observe(inefficiency);
+        COPR_SCAN_INEFFICIENCY.with_label_values(&[type_str]).observe(inefficiency);
 
         if handle_time > SLOW_QUERY_LOWER_BOUND {
             info!("[region {}] handle {:?} [{}] takes {:?} [waiting: {:?}, keys: {}, hit: {}, \
@@ -237,19 +238,21 @@ impl BatchRunnable<Task> for Host {
                             continue;
                         }
                     };
-                    let len = reqs.len() as f64;
 
                     if self.pool.get_task_count() >= self.max_running_task_count {
                         notify_batch_failed(Error::Full(self.max_running_task_count), reqs);
                         continue;
                     }
-                    COPR_PENDING_REQS.with_label_values(&["select"]).add(len);
+
                     for req in reqs {
+                        let type_str = get_req_type_str(req.req.get_tp());
+                        let labels = vec![type_str];
+                        COPR_PENDING_REQS.with_label_values(&labels).add(1.0);
                         let end_point = TiDbEndPoint::new(snap.clone());
                         let txn_id = req.start_ts.unwrap_or_default();
                         self.pool.execute(txn_id, move || {
                             end_point.handle_request(req);
-                            COPR_PENDING_REQS.with_label_values(&["select"]).sub(1.0);
+                            COPR_PENDING_REQS.with_label_values(&labels).sub(1.0);
                         });
                     }
                 }
@@ -283,29 +286,29 @@ fn err_resp(e: Error) -> Response {
     match e {
         Error::Region(e) => {
             let tag = storage::get_tag_from_header(&e);
-            COPR_REQ_ERROR.with_label_values(&["select", tag]).inc();
+            COPR_REQ_ERROR.with_label_values(&[tag]).inc();
             resp.set_region_error(e);
         }
         Error::Locked(info) => {
             resp.set_locked(info);
-            COPR_REQ_ERROR.with_label_values(&["select", "lock"]).inc();
+            COPR_REQ_ERROR.with_label_values(&["lock"]).inc();
         }
         Error::Other(_) => {
             resp.set_other_error(format!("{}", e));
-            COPR_REQ_ERROR.with_label_values(&["select", "other"]).inc();
+            COPR_REQ_ERROR.with_label_values(&["other"]).inc();
         }
         Error::Outdated(deadline, now, tp) => {
             let t = get_req_type_str(tp);
             let elapsed = now.duration_since(deadline) +
                           Duration::from_secs(REQUEST_MAX_HANDLE_SECS);
-            COPR_REQ_ERROR.with_label_values(&["select", "outdated"]).inc();
-            OUTDATED_REQ_WAIT_TIME.with_label_values(&["select", t])
+            COPR_REQ_ERROR.with_label_values(&["outdated"]).inc();
+            OUTDATED_REQ_WAIT_TIME.with_label_values(&[t])
                 .observe(elapsed.as_secs() as f64);
 
             resp.set_other_error(OUTDATED_ERROR_MSG.to_owned());
         }
         Error::Full(allow) => {
-            COPR_REQ_ERROR.with_label_values(&["select", "full"]).inc();
+            COPR_REQ_ERROR.with_label_values(&["full"]).inc();
             let mut errorpb = errorpb::Error::new();
             errorpb.set_message(format!("running batches reach limit {}", allow));
             let mut server_is_busy_err = ServerIsBusy::new();

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -246,13 +246,12 @@ impl BatchRunnable<Task> for Host {
 
                     for req in reqs {
                         let type_str = get_req_type_str(req.req.get_tp());
-                        let labels = vec![type_str];
-                        COPR_PENDING_REQS.with_label_values(&labels).add(1.0);
+                        COPR_PENDING_REQS.with_label_values(&[type_str]).add(1.0);
                         let end_point = TiDbEndPoint::new(snap.clone());
                         let txn_id = req.start_ts.unwrap_or_default();
                         self.pool.execute(txn_id, move || {
                             end_point.handle_request(req);
-                            COPR_PENDING_REQS.with_label_values(&labels).sub(1.0);
+                            COPR_PENDING_REQS.with_label_values(&[type_str]).sub(1.0);
                         });
                     }
                 }

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -173,7 +173,6 @@ impl RequestTask {
         COPR_REQ_HANDLE_TIME.with_label_values(&[type_str])
             .observe(handle_time - wait_time);
 
-
         let scanned_keys = self.statistics.total_op_count() as f64;
         COPR_SCAN_KEYS.with_label_values(&[type_str]).observe(scanned_keys);
         let inefficiency = self.statistics.inefficiency();

--- a/src/coprocessor/metrics.rs
+++ b/src/coprocessor/metrics.rs
@@ -18,49 +18,49 @@ lazy_static! {
         register_histogram_vec!(
             "tikv_coprocessor_request_duration_seconds",
             "Bucketed histogram of coprocessor request duration",
-            &["type", "req"]
+            &["req"]
         ).unwrap();
 
     pub static ref OUTDATED_REQ_WAIT_TIME: HistogramVec =
         register_histogram_vec!(
             "tikv_coprocessor_outdated_request_wait_seconds",
             "Bucketed histogram of outdated coprocessor request wait duration",
-            &["type", "req"]
+            &["req"]
         ).unwrap();
 
     pub static ref COPR_REQ_HANDLE_TIME: HistogramVec =
         register_histogram_vec!(
             "tikv_coprocessor_request_handle_seconds",
             "Bucketed histogram of coprocessor handle request duration",
-            &["type", "req"]
+            &["req"]
         ).unwrap();
 
     pub static ref COPR_REQ_WAIT_TIME: HistogramVec =
         register_histogram_vec!(
             "tikv_coprocessor_request_wait_seconds",
             "Bucketed histogram of coprocessor request wait duration",
-            &["type", "req"]
+            &["req"]
         ).unwrap();
 
     pub static ref COPR_REQ_ERROR: CounterVec =
         register_counter_vec!(
             "tikv_coprocessor_request_error",
             "Total number of push down request error.",
-            &["type", "reason"]
+            &["reason"]
         ).unwrap();
 
     pub static ref COPR_PENDING_REQS: GaugeVec =
         register_gauge_vec!(
             "tikv_coprocessor_pending_request",
             "Total number of pending push down request.",
-            &["type"]
+            &["req"]
         ).unwrap();
 
     pub static ref COPR_SCAN_KEYS: HistogramVec =
         register_histogram_vec!(
             "tikv_coprocessor_scan_keys",
             "Bucketed histogram of coprocessor per request scan keys",
-            &["type", "req"],
+            &["req"],
             exponential_buckets(1.0, 2.0, 20).unwrap()
         ).unwrap();
 
@@ -68,7 +68,7 @@ lazy_static! {
         register_histogram_vec!(
             "tikv_coprocessor_scan_inefficiency",
             "Bucketed histogram of coprocessor scan inefficiency",
-            &["type", "req"],
+            &["req"],
             vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
         ).unwrap();
 


### PR DESCRIPTION
Hi, 
    This PR remove `type` from labels in metrics for coprocessor.
@BusyJay @lishihai9017 @hhkbp2 @andelf PTAL.