### PR TITLE
storage: make error cloneable when possible

### DIFF
--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -432,6 +432,17 @@ quick_error! {
     }
 }
 
+impl Error {
+    pub fn maybe_clone(&self) -> Option<Error> {
+        match *self {
+            Error::Request(ref e) => Some(Error::Request(e.clone())),
+            Error::RocksDb(ref msg) => Some(Error::RocksDb(msg.clone())),
+            Error::Timeout(d) => Some(Error::Timeout(d)),
+            Error::Other(_) => None,
+        }
+    }
+}
+
 pub type Result<T> = result::Result<T, Error>;
 
 #[cfg(test)]

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -62,4 +62,28 @@ quick_error! {
     }
 }
 
+impl Error {
+    pub fn maybe_clone(&self) -> Option<Error> {
+        match *self {
+            Error::Engine(ref e) => e.maybe_clone().map(Error::Engine),
+            Error::Codec(ref e) => e.maybe_clone().map(Error::Codec),
+            Error::KeyIsLocked { ref key, ref primary, ts, ttl } => {
+                Some(Error::KeyIsLocked {
+                    key: key.clone(),
+                    primary: primary.clone(),
+                    ts: ts,
+                    ttl: ttl,
+                })
+            }
+            Error::BadFormatLock => Some(Error::BadFormatLock),
+            Error::BadFormatWrite => Some(Error::BadFormatWrite),
+            Error::TxnLockNotFound => Some(Error::TxnLockNotFound),
+            Error::WriteConflict => Some(Error::WriteConflict),
+            Error::KeyVersion => Some(Error::KeyVersion),
+            Error::Committed { commit_ts } => Some(Error::Committed { commit_ts: commit_ts }),
+            Error::Io(_) => None,
+        }
+    }
+}
+
 pub type Result<T> = ::std::result::Result<T, Error>;

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -64,4 +64,23 @@ quick_error! {
     }
 }
 
+impl Error {
+    pub fn maybe_clone(&self) -> Option<Error> {
+        match *self {
+            Error::Engine(ref e) => e.maybe_clone().map(Error::Engine),
+            Error::Codec(ref e) => e.maybe_clone().map(Error::Codec),
+            Error::Mvcc(ref e) => e.maybe_clone().map(Error::Mvcc),
+            Error::InvalidTxnTso { start_ts, commit_ts } => {
+                Some(Error::InvalidTxnTso {
+                    start_ts: start_ts,
+                    commit_ts: commit_ts,
+                })
+            }
+            Error::Other(_) |
+            Error::ProtoBuf(_) |
+            Error::Io(_) => None,
+        }
+    }
+}
+
 pub type Result<T> = ::std::result::Result<T, Error>;

--- a/src/util/codec/mod.rs
+++ b/src/util/codec/mod.rs
@@ -55,6 +55,20 @@ quick_error! {
     }
 }
 
+impl Error {
+    pub fn maybe_clone(&self) -> Option<Error> {
+        match *self {
+            Error::KeyLength => Some(Error::KeyLength),
+            Error::KeyPadding => Some(Error::KeyPadding),
+            Error::InvalidDataType(ref r) => Some(Error::InvalidDataType(r.clone())),
+            Error::Encoding(e) => Some(Error::Encoding(e)),
+            Error::Protobuf(_) |
+            Error::Io(_) |
+            Error::Other(_) => None,
+        }
+    }
+}
+
 impl From<FromUtf8Error> for Error {
     fn from(err: FromUtf8Error) -> Error {
         err.utf8_error().into()


### PR DESCRIPTION
This is useful if we want to introduce batch processing to scheduler later.