### PR TITLE
server: change MAX_GRPC_SEND_MSG_LEN

### DIFF
--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -22,6 +22,7 @@ use kvproto::tikvpb_grpc::*;
 use util::worker::Worker;
 use storage::Storage;
 use raftstore::store::{SnapshotStatusMsg, SnapManager};
+use raftstore::store::config::REGION_SPLIT_SIZE;
 
 use super::{Result, Config};
 use coprocessor::{EndPointHost, EndPointTask};
@@ -33,7 +34,7 @@ use super::raft_client::RaftClient;
 
 const DEFAULT_COPROCESSOR_BATCH: usize = 50;
 const MAX_GRPC_RECV_MSG_LEN: usize = 10 * 1024 * 1024;
-const MAX_GRPC_SEND_MSG_LEN: usize = 8 * 1024 * 1024 * 1024;
+const MAX_GRPC_SEND_MSG_LEN: usize = REGION_SPLIT_SIZE as usize * 1024 * 1024;
 
 pub struct Server<T: RaftStoreRouter + 'static, S: StoreAddrResolver + 'static> {
     env: Arc<Environment>,

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -33,7 +33,7 @@ use super::raft_client::RaftClient;
 
 const DEFAULT_COPROCESSOR_BATCH: usize = 50;
 const MAX_GRPC_RECV_MSG_LEN: usize = 10 * 1024 * 1024;
-const MAX_GRPC_SEND_MSG_LEN: usize = 128 * 1024 * 1024;
+const MAX_GRPC_SEND_MSG_LEN: usize = 8 * 1024 * 1024 * 1024;
 
 pub struct Server<T: RaftStoreRouter + 'static, S: StoreAddrResolver + 'static> {
     env: Arc<Environment>,

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -34,7 +34,7 @@ use super::raft_client::RaftClient;
 
 const DEFAULT_COPROCESSOR_BATCH: usize = 50;
 const MAX_GRPC_RECV_MSG_LEN: usize = 10 * 1024 * 1024;
-const MAX_GRPC_SEND_MSG_LEN: usize = REGION_SPLIT_SIZE as usize * 1024 * 1024;
+const MAX_GRPC_SEND_MSG_LEN: usize = 128 * REGION_SPLIT_SIZE as usize;
 
 pub struct Server<T: RaftStoreRouter + 'static, S: StoreAddrResolver + 'static> {
     env: Arc<Environment>,

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -34,7 +34,7 @@ use super::raft_client::RaftClient;
 
 const DEFAULT_COPROCESSOR_BATCH: usize = 50;
 const MAX_GRPC_RECV_MSG_LEN: usize = 10 * 1024 * 1024;
-const MAX_GRPC_SEND_MSG_LEN: usize = 128 * REGION_SPLIT_SIZE as usize;
+const MAX_GRPC_SEND_MSG_LEN: usize = 4 * REGION_SPLIT_SIZE as usize;
 
 pub struct Server<T: RaftStoreRouter + 'static, S: StoreAddrResolver + 'static> {
     env: Arc<Environment>,


### PR DESCRIPTION
Set region size to 256MB may cause grpc msg length bigger than 128M.

@zhangjinpeng1987 @disksing PTAL

Signed-off-by: Cholerae Hu <huyingqian@pingcap.com>