### PR TITLE
raftstore: clean up metadata on start

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -376,8 +376,8 @@ impl Peer {
         info!("{} begin to destroy", self.tag);
 
         // Set Tombstone state explicitly
-        let wb = WriteBatch::new();
-        try!(self.mut_store().clear_meta(&wb));
+        let mut wb = WriteBatch::new();
+        try!(self.mut_store().clear_meta(&mut wb));
         try!(write_peer_state(&wb, &region, PeerState::Tombstone));
         try!(self.engine.write(wb));
 

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -22,7 +22,7 @@ use std::time::{Duration, Instant};
 use std::thread;
 use std::u64;
 
-use rocksdb::{DB, DBStatisticsTickerType as TickerType};
+use rocksdb::{DB, DBStatisticsTickerType as TickerType, WriteBatch};
 use rocksdb::rocksdb_options::WriteOptions;
 use mio::{self, EventLoop, EventLoopConfig, Sender};
 use protobuf;
@@ -45,7 +45,7 @@ use util::worker::{Worker, Scheduler, FutureWorker};
 use util::transport::SendCh;
 use util::{rocksdb, RingQueue};
 use util::collections::{HashMap, HashSet};
-use storage::{CF_DEFAULT, CF_LOCK, CF_WRITE};
+use storage::{CF_DEFAULT, CF_LOCK, CF_WRITE, CF_RAFT};
 use raftstore::coprocessor::CoprocessorHost;
 use raftstore::coprocessor::split_observer::SplitObserver;
 use super::worker::{SplitCheckRunner, SplitCheckTask, RegionTask, RegionRunner, CompactTask,
@@ -58,7 +58,7 @@ use super::keys::{self, enc_start_key, enc_end_key, data_end_key, data_key};
 use super::engine::{Iterable, Peekable, Snapshot as EngineSnapshot};
 use super::config::Config;
 use super::peer::{self, Peer, StaleState, ConsistencyState, ReadyContext};
-use super::peer_storage::{ApplySnapResult, CacheQueryStats};
+use super::peer_storage::{self, ApplySnapResult, CacheQueryStats};
 use super::msg::Callback;
 use super::cmd_resp::{bind_term, bind_error};
 use super::transport::Transport;
@@ -237,6 +237,7 @@ impl<T, C> Store<T, C> {
         let mut applying_count = 0;
 
         let t = Instant::now();
+        let mut wb = WriteBatch::new();
         try!(engine.scan(start_key,
                          end_key,
                          false,
@@ -255,6 +256,7 @@ impl<T, C> Store<T, C> {
                 debug!("region {:?} is tombstone in store {}",
                        region,
                        self.store_id());
+                self.clean_up_meta(&mut wb, region);
                 return Ok(true);
             }
             let mut peer = try!(Peer::create(self, region));
@@ -274,6 +276,10 @@ impl<T, C> Store<T, C> {
             Ok(true)
         }));
 
+        if !wb.is_empty() {
+            self.engine.write(wb).unwrap();
+        }
+
         info!("{} starts with {} regions, including {} tombstones and {} applying \
                regions, takes {:?}",
               self.tag,
@@ -285,6 +291,18 @@ impl<T, C> Store<T, C> {
         try!(self.clean_up());
 
         Ok(())
+    }
+
+    fn clean_up_meta(&mut self, wb: &mut WriteBatch, region: &metapb::Region) {
+        let raft_key = keys::raft_state_key(region.get_id());
+        let handle = rocksdb::get_cf_handle(&self.engine, CF_RAFT).unwrap();
+        if self.engine.get_cf(handle, &raft_key).unwrap().is_none() {
+            // it has been cleaned up.
+            return;
+        }
+
+        peer_storage::clear_meta(&self.engine, wb, region.get_id()).unwrap();
+        peer_storage::write_peer_state(wb, region, PeerState::Tombstone).unwrap();
     }
 
     /// `clean_up` clean up all possible garbage data.

--- a/tests/raftstore/test_tombstone.rs
+++ b/tests/raftstore/test_tombstone.rs
@@ -249,10 +249,12 @@ fn test_server_stale_meta() {
     cluster.shutdown();
 
     let engine_3 = cluster.get_engine(3);
-    let mut state: RegionLocalState = engine_3.get_msg(&keys::region_state_key(1)).unwrap().unwrap();
+    let mut state: RegionLocalState =
+        engine_3.get_msg(&keys::region_state_key(1)).unwrap().unwrap();
     state.set_state(PeerState::Tombstone);
     engine_3.put_msg(&keys::region_state_key(1), &state).unwrap();
     cluster.clear_send_filters();
+
     // avoid TIMEWAIT
     sleep_ms(500);
     cluster.start();

--- a/tests/raftstore/test_tombstone.rs
+++ b/tests/raftstore/test_tombstone.rs
@@ -22,7 +22,7 @@ use super::node::new_node_cluster;
 use super::transport_simulate::*;
 use super::server::new_server_cluster;
 use super::util::*;
-use tikv::raftstore::store::{keys, Peekable, Iterable};
+use tikv::raftstore::store::{keys, Peekable, Iterable, Mutable};
 
 fn test_tombstone<T: Simulator>(cluster: &mut Cluster<T>) {
     let pd_client = cluster.pd_client.clone();
@@ -231,4 +231,32 @@ fn test_server_readd_peer() {
     let count = 5;
     let mut cluster = new_server_cluster(0, count);
     test_readd_peer(&mut cluster);
+}
+
+// Simulate a case that tikv exit before a removed peer clean up its stale meta.
+#[test]
+fn test_server_stale_meta() {
+    let count = 3;
+    let mut cluster = new_server_cluster(0, count);
+    let pd_client = cluster.pd_client.clone();
+    // Disable default max peer number check.
+    pd_client.disable_default_rule();
+
+    cluster.run();
+    cluster.add_send_filter(IsolationFilterFactory::new(3));
+    pd_client.must_remove_peer(1, new_peer(3, 3));
+    pd_client.must_add_peer(1, new_peer(3, 4));
+    cluster.shutdown();
+
+    let engine_3 = cluster.get_engine(3);
+    let mut state: RegionLocalState = engine_3.get_msg(&keys::region_state_key(1)).unwrap().unwrap();
+    state.set_state(PeerState::Tombstone);
+    engine_3.put_msg(&keys::region_state_key(1), &state).unwrap();
+    cluster.clear_send_filters();
+    // avoid TIMEWAIT
+    sleep_ms(500);
+    cluster.start();
+
+    cluster.must_put(b"k1", b"v1");
+    must_get_equal(&engine_3, b"k1", b"v1");
 }


### PR DESCRIPTION
If a region removes a peer on a store, it usually puts a tombstone mark then deletes all meta and data. In some condition, TiKV may exit before clearing meta and data (like killed, core or system shutdown). When it's restarted, data will be cleaned up thanks to our current mechanism, but the meta will remain on disk. If the same region schedules a new peer on it again, the old meta will be picked up, hence we get a corrupted region peer.

This pr tries to resolve it by clearing meta too on start.