### PR TITLE
raftstore: get snapshot lazily

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -1517,14 +1517,19 @@ impl Peer {
 
     fn exec_read(&mut self, req: &RaftCmdRequest) -> Result<RaftCmdResponse> {
         try!(check_epoch(self.region(), req));
-        let snap = Snapshot::new(self.engine.clone());
+        let mut snap = None;
         let requests = req.get_requests();
         let mut responses = Vec::with_capacity(requests.len());
 
         for req in requests {
             let cmd_type = req.get_cmd_type();
             let mut resp = match cmd_type {
-                CmdType::Get => try!(apply::do_get(&self.tag, self.region(), &snap, req)),
+                CmdType::Get => {
+                    if snap.is_none() {
+                        snap = Some(Snapshot::new(self.engine.clone()));
+                    }
+                    try!(apply::do_get(&self.tag, self.region(), snap.as_ref().unwrap(), req))
+                },
                 CmdType::Snap => try!(apply::do_snap(self.region().to_owned())),
                 CmdType::Prewrite => unreachable!(),
                 CmdType::Put | CmdType::Delete | CmdType::Invalid => unreachable!(),

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -1529,7 +1529,7 @@ impl Peer {
                         snap = Some(Snapshot::new(self.engine.clone()));
                     }
                     try!(apply::do_get(&self.tag, self.region(), snap.as_ref().unwrap(), req))
-                },
+                }
                 CmdType::Snap => try!(apply::do_snap(self.region().to_owned())),
                 CmdType::Prewrite => unreachable!(),
                 CmdType::Put | CmdType::Delete | CmdType::Invalid => unreachable!(),


### PR DESCRIPTION
When dealing with snap command, we will generating a region snapshot instead. Hence generate a snapshot early is a waste.