### PR TITLE
coprocessor/xeval: add function signatures mapping

### DIFF
--- a/src/coprocessor/xeval/evaluator.rs
+++ b/src/coprocessor/xeval/evaluator.rs
@@ -521,6 +521,11 @@ impl Evaluator {
     fn eval_scalar_function(&mut self, ctx: &EvalContext, expr: &Expr) -> Result<Datum> {
         match expr.get_sig() {
             ScalarFuncSig::AbsInt => self.abs_int(ctx, expr),
+            ScalarFuncSig::AbsReal => self.abs_real(ctx, expr),
+            ScalarFuncSig::CeilInt => self.ceil_int(ctx, expr),
+            ScalarFuncSig::CeilReal => self.ceil_real(ctx, expr),
+            ScalarFuncSig::FloorInt => self.floor_int(ctx, expr),
+            ScalarFuncSig::FloorReal => self.floor_real(ctx, expr),
             _ => Err(Error::Expr(format!("unsupported scalar function: {:?}", expr.get_sig()))),
         }
     }


### PR DESCRIPTION
Hi,

This PR adds the mapping fro function signatures to implementation function for evaluator.

PTAL @XuHuaiyu @AndreMouche @lishihai9017 @andelf 