### PR TITLE
*: update rocksdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,7 +422,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#4d686bf9b4d083e464cfb935300830bc282f4923"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#240e5b6677367bc3db6b37294958175b59f3e8ca"
 dependencies = [
  "gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -719,7 +719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#4d686bf9b4d083e464cfb935300830bc282f4923"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#240e5b6677367bc3db6b37294958175b59f3e8ca"
 dependencies = [
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "librocksdb_sys 0.1.0 (git+https://github.com/pingcap/rust-rocksdb.git)",

--- a/src/raftstore/store/engine.rs
+++ b/src/raftstore/store/engine.rs
@@ -605,7 +605,7 @@ mod tests {
         let mut db_opt = Options::new();
         db_opt.set_target_file_size_base(1024 * 1024);
         db_opt.set_write_buffer_size(1024);
-        db_opt.compression(DBCompressionType::DBNo);
+        db_opt.compression(DBCompressionType::No);
 
         let engine =
             Arc::new(rocksdb::new_engine_opt(path.path().to_str().unwrap(), db_opt, vec![])

--- a/src/raftstore/store/engine_metrics.rs
+++ b/src/raftstore/store/engine_metrics.rs
@@ -43,7 +43,7 @@ pub const ENGINE_TICKER_TYPES: &'static [TickerType] = &[TickerType::BlockCacheM
                                                          TickerType::CompactReadBytes,
                                                          TickerType::CompactWriteBytes];
 pub const ENGINE_HIST_TYPES: &'static [HistType] =
-    &[HistType::DbGetMicros, HistType::DbWriteMicros, HistType::DbSeekMicros];
+    &[HistType::GetMicros, HistType::WriteMicros, HistType::SeekMicros];
 
 pub fn flush_engine_ticker_metrics(t: TickerType, value: u64) {
     match t {
@@ -116,7 +116,7 @@ pub fn flush_engine_ticker_metrics(t: TickerType, value: u64) {
 
 pub fn flush_engine_histogram_metrics(t: HistType, value: HistogramData) {
     match t {
-        HistType::DbGetMicros => {
+        HistType::GetMicros => {
             STORE_ENGINE_GET_MICROS_VEC.with_label_values(&["get_median"]).set(value.median);
             STORE_ENGINE_GET_MICROS_VEC.with_label_values(&["get_percentile95"])
                 .set(value.percentile95);
@@ -126,7 +126,7 @@ pub fn flush_engine_histogram_metrics(t: HistType, value: HistogramData) {
             STORE_ENGINE_GET_MICROS_VEC.with_label_values(&["get_standard_deviation"])
                 .set(value.standard_deviation);
         }
-        HistType::DbWriteMicros => {
+        HistType::WriteMicros => {
             STORE_ENGINE_WRITE_MICROS_VEC.with_label_values(&["write_median"]).set(value.median);
             STORE_ENGINE_WRITE_MICROS_VEC.with_label_values(&["write_percentile95"])
                 .set(value.percentile95);
@@ -136,7 +136,7 @@ pub fn flush_engine_histogram_metrics(t: HistType, value: HistogramData) {
             STORE_ENGINE_WRITE_MICROS_VEC.with_label_values(&["write_standard_deviation"])
                 .set(value.standard_deviation);
         }
-        HistType::DbSeekMicros => {
+        HistType::SeekMicros => {
             STORE_ENGINE_SEEK_MICROS_VEC.with_label_values(&["seek_median"]).set(value.median);
             STORE_ENGINE_SEEK_MICROS_VEC.with_label_values(&["seek_percentile95"])
                 .set(value.percentile95);

--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -1003,7 +1003,7 @@ mod v2 {
                     // compression_per_level first, so to make sure our specified compression type
                     // being used, we must set them empty or disabled.
                     io_options.compression_per_level(&[]);
-                    io_options.bottommost_compression(DBCompressionType::DBDisableCompression);
+                    io_options.bottommost_compression(DBCompressionType::Disable);
                     let mut writer = SstFileWriter::new(EnvOptions::new(), io_options);
                     box_try!(writer.open(cf_file.tmp_path.as_path().to_str().unwrap()));
                     cf_file.sst_writer = Some(writer);

--- a/src/util/config.rs
+++ b/src/util/config.rs
@@ -44,13 +44,13 @@ quick_error! {
 
 pub fn parse_rocksdb_compression(tp: &str) -> Result<DBCompressionType, ConfigError> {
     match &*tp.trim().to_lowercase() {
-        "no" => Ok(DBCompressionType::DBNo),
-        "snappy" => Ok(DBCompressionType::DBSnappy),
-        "zlib" => Ok(DBCompressionType::DBZlib),
-        "bzip2" => Ok(DBCompressionType::DBBz2),
-        "lz4" => Ok(DBCompressionType::DBLz4),
-        "lz4hc" => Ok(DBCompressionType::DBLz4hc),
-        "zstd" => Ok(DBCompressionType::DBZstd),
+        "no" => Ok(DBCompressionType::No),
+        "snappy" => Ok(DBCompressionType::Snappy),
+        "zlib" => Ok(DBCompressionType::Zlib),
+        "bzip2" => Ok(DBCompressionType::Bz2),
+        "lz4" => Ok(DBCompressionType::Lz4),
+        "lz4hc" => Ok(DBCompressionType::Lz4hc),
+        "zstd" => Ok(DBCompressionType::Zstd),
         _ => Err(ConfigError::Value(format!("invalid compression type {:?}", tp))),
     }
 }

--- a/src/util/rocksdb.rs
+++ b/src/util/rocksdb.rs
@@ -24,13 +24,13 @@ use super::cfs_diff;
 
 // Zlib and bzip2 are too slow.
 const COMPRESSION_PRIORITY: [DBCompressionType; 3] =
-    [DBCompressionType::DBLz4, DBCompressionType::DBSnappy, DBCompressionType::DBZstd];
+    [DBCompressionType::Lz4, DBCompressionType::Snappy, DBCompressionType::Zstd];
 
 pub fn get_fastest_supported_compression_type() -> DBCompressionType {
     let all_supported_compression = supported_compression();
     *COMPRESSION_PRIORITY.into_iter()
         .find(|c| all_supported_compression.contains(c))
-        .unwrap_or(&DBCompressionType::DBNo)
+        .unwrap_or(&DBCompressionType::No)
 }
 
 pub fn get_cf_handle<'a>(db: &'a DB, cf: &str) -> Result<&'a CFHandle, String> {


### PR DESCRIPTION
With latest rust-rocksdb, we will be able to build static link binary without the impact of system's jemalloc.