### PR TITLE
reduce threads communication and batch local read

### DIFF
--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -317,7 +317,7 @@ impl BatchRunnable<Task> for Host {
 
         let req_ids1 = req_ids.clone();
         let sched = self.sched.clone();
-        let on_finish: engine::Callback<Vec<Option<engine::Result<Box<Snapshot>>>>> =
+        let on_finish: engine::BatchCallback<Box<Snapshot>> =
             box move |(_, results)| {
                 if let Ok(results) = results {
                     let batch = req_ids1.into_iter().zip(results).filter_map(|(id, res)| {

--- a/src/raftstore/store/local_metrics.rs
+++ b/src/raftstore/store/local_metrics.rs
@@ -155,6 +155,7 @@ pub struct RaftProposeMetrics {
     pub transfer_leader: u64,
     pub conf_change: u64,
     pub request_wait_time: LocalHistogram,
+    pub batch_local_read: LocalHistogram,
 }
 
 impl Default for RaftProposeMetrics {
@@ -167,6 +168,7 @@ impl Default for RaftProposeMetrics {
             transfer_leader: 0,
             conf_change: 0,
             request_wait_time: REQUEST_WAIT_TIME_HISTOGRAM.local(),
+            batch_local_read: BTACH_LOCAL_READ_HISTOGRAM.local(),
         }
     }
 }
@@ -212,6 +214,7 @@ impl RaftProposeMetrics {
             self.conf_change = 0;
         }
         self.request_wait_time.flush();
+        self.batch_local_read.flush();
     }
 }
 

--- a/src/raftstore/store/metrics.rs
+++ b/src/raftstore/store/metrics.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use prometheus::{Counter, CounterVec, GaugeVec, Histogram, HistogramVec, exponential_buckets};
+use prometheus::*;
 
 lazy_static! {
     pub static ref PEER_PROPOSAL_COUNTER_VEC: CounterVec =
@@ -184,5 +184,12 @@ lazy_static! {
             "tikv_raftstore_entry_fetches",
             "Total number of raft entry fetches",
             &["type"]
+        ).unwrap();
+
+    pub static ref BTACH_LOCAL_READ_HISTOGRAM: Histogram =
+        register_histogram!(
+            "tikv_raftstore_batch_local_read",
+            "Bucketed histogram of batch size of local read",
+            linear_buckets(0.0, 5.0, 10).unwrap()
         ).unwrap();
 }

--- a/src/raftstore/store/mod.rs
+++ b/src/raftstore/store/mod.rs
@@ -29,7 +29,7 @@ mod metrics;
 mod engine_metrics;
 mod local_metrics;
 
-pub use self::msg::{Msg, Callback, Tick, SnapshotStatusMsg};
+pub use self::msg::{Msg, Callback, BatchCallback, Tick, SnapshotStatusMsg};
 pub use self::store::{StoreChannel, Store, create_event_loop};
 pub use self::config::Config;
 pub use self::transport::Transport;

--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -56,6 +56,11 @@ pub enum Msg {
         callback: Callback,
     },
 
+    RaftCmdsBatch {
+        send_time: Instant,
+        batch: Vec<(RaftCmdRequest, Callback)>,
+    },
+
     // For split check
     SplitCheckResult {
         region_id: u64,
@@ -82,6 +87,7 @@ impl fmt::Debug for Msg {
             Msg::Quit => write!(fmt, "Quit"),
             Msg::RaftMessage(_) => write!(fmt, "Raft Message"),
             Msg::RaftCmd { .. } => write!(fmt, "Raft Command"),
+            Msg::RaftCmdsBatch { .. } => write!(fmt, "Raft Command Batch"),
             Msg::SplitCheckResult { .. } => write!(fmt, "Split Check Result"),
             Msg::ReportUnreachable { ref region_id, ref to_peer_id } => {
                 write!(fmt,
@@ -107,6 +113,13 @@ impl Msg {
             send_time: Instant::now(),
             request: request,
             callback: callback,
+        }
+    }
+
+    pub fn new_raft_cmds_batch(batch: Vec<(RaftCmdRequest, Callback)>) -> Msg {
+        Msg::RaftCmdsBatch {
+            send_time: Instant::now(),
+            batch: batch,
         }
     }
 }

--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -23,6 +23,7 @@ use raft::SnapshotStatus;
 use util::escape;
 
 pub type Callback = Box<FnBox(RaftCmdResponse) + Send>;
+pub type BatchCallback = Box<FnBox(Vec<Option<RaftCmdResponse>>) + Send>;
 
 #[derive(Debug, Clone, Copy)]
 pub enum Tick {
@@ -59,7 +60,7 @@ pub enum Msg {
     RaftCmdsBatch {
         send_time: Instant,
         batch: Vec<(RaftCmdRequest, Callback)>,
-        on_finish: Callback,
+        on_finish: BatchCallback,
     },
 
     // For split check
@@ -117,7 +118,9 @@ impl Msg {
         }
     }
 
-    pub fn new_raft_cmds_batch(batch: Vec<(RaftCmdRequest, Callback)>, on_finish: Callback) -> Msg {
+    pub fn new_raft_cmds_batch(batch: Vec<(RaftCmdRequest, Callback)>,
+                               on_finish: BatchCallback)
+                               -> Msg {
         Msg::RaftCmdsBatch {
             send_time: Instant::now(),
             batch: batch,

--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -59,6 +59,7 @@ pub enum Msg {
     RaftCmdsBatch {
         send_time: Instant,
         batch: Vec<(RaftCmdRequest, Callback)>,
+        on_finish: Callback,
     },
 
     // For split check
@@ -116,10 +117,11 @@ impl Msg {
         }
     }
 
-    pub fn new_raft_cmds_batch(batch: Vec<(RaftCmdRequest, Callback)>) -> Msg {
+    pub fn new_raft_cmds_batch(batch: Vec<(RaftCmdRequest, Callback)>, on_finish: Callback) -> Msg {
         Msg::RaftCmdsBatch {
             send_time: Instant::now(),
             batch: batch,
+            on_finish: on_finish,
         }
     }
 }

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -1049,7 +1049,6 @@ impl Peer {
             }
         }
 
-        // TODO: add metrics for collecting batch size.
         self.batch_read_local(batch_read, metrics);
     }
 
@@ -1243,6 +1242,7 @@ impl Peer {
                         batch: Vec<(RaftCmdRequest, Callback)>,
                         metrics: &mut RaftProposeMetrics) {
         metrics.local_read += batch.len() as u64;
+        metrics.batch_local_read.observe(batch.len() as f64);
         self.handle_batch_read(batch);
     }
 

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -1284,7 +1284,8 @@ impl<T: Transport, C: PdClient> Store<T, C> {
     }
 
     fn batch_propose_raft_commands(&mut self, batch: Vec<(RaftCmdRequest, Callback)>) {
-        let mut batches: HashMap<u64, Vec<(Callback,RaftCmdRequest, RaftCmdResponse)>> = HashMap::default();
+        let mut batches: HashMap<u64, Vec<(Callback, RaftCmdRequest, RaftCmdResponse)>> =
+            HashMap::default();
         for (msg, cb) in batch {
             let mut resp = RaftCmdResponse::new();
 

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -2039,7 +2039,7 @@ impl<T: Transport, C: PdClient> mio::Handler for Store<T, C> {
                     .observe(duration_to_sec(send_time.elapsed()) as f64);
                 self.propose_raft_command(request, callback)
             }
-            Msg::RaftCmdsBatch { send_time, batch } => {
+            Msg::RaftCmdsBatch { send_time, batch, on_finish } => {
                 self.raft_metrics
                     .propose
                     .request_wait_time
@@ -2047,6 +2047,7 @@ impl<T: Transport, C: PdClient> mio::Handler for Store<T, C> {
                 for (request, callback) in batch {
                     self.propose_raft_command(request, callback)
                 }
+                on_finish.call_box((RaftCmdResponse::new(),));
             }
             Msg::Quit => {
                 info!("{} receive quit message", self.tag);

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -2039,6 +2039,15 @@ impl<T: Transport, C: PdClient> mio::Handler for Store<T, C> {
                     .observe(duration_to_sec(send_time.elapsed()) as f64);
                 self.propose_raft_command(request, callback)
             }
+            Msg::RaftCmdsBatch { send_time, batch } => {
+                self.raft_metrics
+                    .propose
+                    .request_wait_time
+                    .observe(duration_to_sec(send_time.elapsed()) as f64);
+                for (request, callback) in batch {
+                    self.propose_raft_command(request, callback)
+                }
+            }
             Msg::Quit => {
                 info!("{} receive quit message", self.tag);
                 event_loop.shutdown();

--- a/src/server/transport.rs
+++ b/src/server/transport.rs
@@ -48,8 +48,11 @@ pub trait RaftStoreRouter: Send + Clone {
     }
 
     // Send a batch of RaftCmdRequest to local store.
-    fn send_commands_batch(&self, batch: Vec<(RaftCmdRequest, Callback)>) -> RaftStoreResult<()> {
-        self.try_send(StoreMsg::new_raft_cmds_batch(batch))
+    fn send_commands_batch(&self,
+                           batch: Vec<(RaftCmdRequest, Callback)>,
+                           on_finish: Callback)
+                           -> RaftStoreResult<()> {
+        self.try_send(StoreMsg::new_raft_cmds_batch(batch, on_finish))
     }
 
     fn report_unreachable(&self, region_id: u64, to_peer_id: u64, _: u64) -> RaftStoreResult<()> {
@@ -90,8 +93,11 @@ impl RaftStoreRouter for ServerRaftStoreRouter {
         self.try_send(StoreMsg::new_raft_cmd(req, cb))
     }
 
-    fn send_commands_batch(&self, batch: Vec<(RaftCmdRequest, Callback)>) -> RaftStoreResult<()> {
-        self.try_send(StoreMsg::new_raft_cmds_batch(batch))
+    fn send_commands_batch(&self,
+                           batch: Vec<(RaftCmdRequest, Callback)>,
+                           on_finish: Callback)
+                           -> RaftStoreResult<()> {
+        self.try_send(StoreMsg::new_raft_cmds_batch(batch, on_finish))
     }
 
     fn report_unreachable(&self,

--- a/src/server/transport.rs
+++ b/src/server/transport.rs
@@ -22,7 +22,7 @@ use util::HandyRwLock;
 use util::worker::{Stopped, Scheduler};
 use util::collections::HashSet;
 use raft::SnapshotStatus;
-use raftstore::store::{Msg as StoreMsg, SnapshotStatusMsg, Transport, Callback};
+use raftstore::store::{Msg as StoreMsg, SnapshotStatusMsg, Transport, Callback, BatchCallback};
 use raftstore::Result as RaftStoreResult;
 use server::raft_client::RaftClient;
 use server::Result;
@@ -50,7 +50,7 @@ pub trait RaftStoreRouter: Send + Clone {
     // Send a batch of RaftCmdRequest to local store.
     fn send_commands_batch(&self,
                            batch: Vec<(RaftCmdRequest, Callback)>,
-                           on_finish: Callback)
+                           on_finish: BatchCallback)
                            -> RaftStoreResult<()> {
         self.try_send(StoreMsg::new_raft_cmds_batch(batch, on_finish))
     }
@@ -95,7 +95,7 @@ impl RaftStoreRouter for ServerRaftStoreRouter {
 
     fn send_commands_batch(&self,
                            batch: Vec<(RaftCmdRequest, Callback)>,
-                           on_finish: Callback)
+                           on_finish: BatchCallback)
                            -> RaftStoreResult<()> {
         self.try_send(StoreMsg::new_raft_cmds_batch(batch, on_finish))
     }

--- a/src/server/transport.rs
+++ b/src/server/transport.rs
@@ -47,6 +47,11 @@ pub trait RaftStoreRouter: Send + Clone {
         self.try_send(StoreMsg::new_raft_cmd(req, cb))
     }
 
+    // Send a batch of RaftCmdRequest to local store.
+    fn send_commands_batch(&self, batch: Vec<(RaftCmdRequest, Callback)>) -> RaftStoreResult<()> {
+        self.try_send(StoreMsg::new_raft_cmds_batch(batch))
+    }
+
     fn report_unreachable(&self, region_id: u64, to_peer_id: u64, _: u64) -> RaftStoreResult<()> {
         self.try_send(StoreMsg::ReportUnreachable {
             region_id: region_id,
@@ -83,6 +88,10 @@ impl RaftStoreRouter for ServerRaftStoreRouter {
 
     fn send_command(&self, req: RaftCmdRequest, cb: Callback) -> RaftStoreResult<()> {
         self.try_send(StoreMsg::new_raft_cmd(req, cb))
+    }
+
+    fn send_commands_batch(&self, batch: Vec<(RaftCmdRequest, Callback)>) -> RaftStoreResult<()> {
+        self.try_send(StoreMsg::new_raft_cmds_batch(batch))
     }
 
     fn report_unreachable(&self,

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -44,7 +44,7 @@ const STAT_SEEK: &'static str = "seek";
 const STAT_SEEK_FOR_PREV: &'static str = "seek_for_prev";
 
 pub type Callback<T> = Box<FnBox((CbContext, Result<T>)) + Send>;
-pub type BatchCallback<T> = Box<FnBox((CbContext, Result<Option<Result<T>>>)) + Send>;
+pub type BatchCallback<T> = Box<FnBox((CbContext, Result<Vec<Option<Result<T>>>>)) + Send>;
 
 pub struct CbContext {
     pub term: Option<u64>,
@@ -68,7 +68,7 @@ pub trait Engine: Send + Debug {
     // batch and on_finish should be called in the same thread and in order.
     fn async_snapshots_batch(&self,
                              batch: Vec<(Context, Callback<Box<Snapshot>>)>,
-                             on_finish: Callback<Vec<Option<Result<Box<Snapshot>>>>>)
+                             on_finish: BatchCallback<Box<Snapshot>>)
                              -> Result<()>;
 
     fn write(&self, ctx: &Context, batch: Vec<Modify>) -> Result<()> {

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -64,13 +64,11 @@ pub enum Modify {
 pub trait Engine: Send + Debug {
     fn async_write(&self, ctx: &Context, batch: Vec<Modify>, callback: Callback<()>) -> Result<()>;
     fn async_snapshot(&self, ctx: &Context, callback: Callback<Box<Snapshot>>) -> Result<()>;
-
+    // batch and on_finish should be called in the same thread and in order.
     fn async_snapshots_batch(&self,
-                             _: Vec<(Context, Callback<Box<Snapshot>>)>,
-                             _: Callback<()>)
-                             -> Result<()> {
-        unimplemented!()
-    }
+                             batch: Vec<(Context, Callback<Box<Snapshot>>)>,
+                             on_finish: Callback<()>)
+                             -> Result<()>;
 
     fn write(&self, ctx: &Context, batch: Vec<Modify>) -> Result<()> {
         let timeout = Duration::from_secs(DEFAULT_TIMEOUT_SECS);

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -65,7 +65,7 @@ pub trait Engine: Send + Debug {
     fn async_write(&self, ctx: &Context, batch: Vec<Modify>, callback: Callback<()>) -> Result<()>;
     fn async_snapshot(&self, ctx: &Context, callback: Callback<Box<Snapshot>>) -> Result<()>;
 
-    fn async_snapshots_batch(&self, _: Vec<(&Context, Callback<Box<Snapshot>>)>) -> Result<()> {
+    fn async_snapshots_batch(&self, _: Vec<(Context, Callback<Box<Snapshot>>)>) -> Result<()> {
         unimplemented!()
     }
 

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -65,7 +65,10 @@ pub trait Engine: Send + Debug {
     fn async_write(&self, ctx: &Context, batch: Vec<Modify>, callback: Callback<()>) -> Result<()>;
     fn async_snapshot(&self, ctx: &Context, callback: Callback<Box<Snapshot>>) -> Result<()>;
 
-    fn async_snapshots_batch(&self, _: Vec<(Context, Callback<Box<Snapshot>>)>) -> Result<()> {
+    fn async_snapshots_batch(&self,
+                             _: Vec<(Context, Callback<Box<Snapshot>>)>,
+                             _: Callback<()>)
+                             -> Result<()> {
         unimplemented!()
     }
 

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -65,6 +65,10 @@ pub trait Engine: Send + Debug {
     fn async_write(&self, ctx: &Context, batch: Vec<Modify>, callback: Callback<()>) -> Result<()>;
     fn async_snapshot(&self, ctx: &Context, callback: Callback<Box<Snapshot>>) -> Result<()>;
 
+    fn async_snapshots_batch(&self, _: Vec<(&Context, Callback<Box<Snapshot>>)>) -> Result<()> {
+        unimplemented!()
+    }
+
     fn write(&self, ctx: &Context, batch: Vec<Modify>) -> Result<()> {
         let timeout = Duration::from_secs(DEFAULT_TIMEOUT_SECS);
         match wait_op!(|cb| self.async_write(ctx, batch, cb).unwrap(), timeout) {

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -44,6 +44,7 @@ const STAT_SEEK: &'static str = "seek";
 const STAT_SEEK_FOR_PREV: &'static str = "seek_for_prev";
 
 pub type Callback<T> = Box<FnBox((CbContext, Result<T>)) + Send>;
+pub type BatchCallback<T> = Box<FnBox((CbContext, Result<Option<Result<T>>>)) + Send>;
 
 pub struct CbContext {
     pub term: Option<u64>,
@@ -67,7 +68,7 @@ pub trait Engine: Send + Debug {
     // batch and on_finish should be called in the same thread and in order.
     fn async_snapshots_batch(&self,
                              batch: Vec<(Context, Callback<Box<Snapshot>>)>,
-                             on_finish: Callback<()>)
+                             on_finish: Callback<Vec<Option<Result<Box<Snapshot>>>>>)
                              -> Result<()>;
 
     fn write(&self, ctx: &Context, batch: Vec<Modify>) -> Result<()> {

--- a/src/storage/engine/raftkv.rs
+++ b/src/storage/engine/raftkv.rs
@@ -201,7 +201,7 @@ impl<S: RaftStoreRouter> RaftKv<S> {
                 }
             }
 
-            on_finish((ctx.unwrap(), Ok(batch)));
+            on_finish((ctx.unwrap_or_else(CbContext::new), Ok(batch)));
         };
         try!(self.router.send_commands_batch(batch1, on_finish));
         Ok(())

--- a/src/storage/engine/raftkv.rs
+++ b/src/storage/engine/raftkv.rs
@@ -193,6 +193,10 @@ impl<S: RaftStoreRouter> RaftKv<S> {
         header
     }
 
+    fn new_request_header1(&self, ctx: Context) -> RaftRequestHeader {
+        self.new_request_header(&ctx)
+    }
+
     fn exec_requests(&self, ctx: &Context, reqs: Vec<Request>, cb: Callback<CmdRes>) -> Result<()> {
         let header = self.new_request_header(ctx);
         let mut cmd = RaftCmdRequest::new();
@@ -202,10 +206,10 @@ impl<S: RaftStoreRouter> RaftKv<S> {
     }
 
     fn exec_requests_batch(&self,
-                           batch: Vec<(&Context, Vec<Request>, Callback<CmdRes>)>)
+                           batch: Vec<(Context, Vec<Request>, Callback<CmdRes>)>)
                            -> Result<()> {
         let batch = batch.into_iter().map(|(ctx, reqs, cb)| {
-            let header = self.new_request_header(ctx);
+            let header = self.new_request_header1(ctx);
             let mut cmd = RaftCmdRequest::new();
             cmd.set_header(header);
             cmd.set_requests(RepeatedField::from_vec(reqs));
@@ -327,7 +331,7 @@ impl<S: RaftStoreRouter> Engine for RaftKv<S> {
     }
 
     fn async_snapshots_batch(&self,
-                             batch: Vec<(&Context, Callback<Box<Snapshot>>)>)
+                             batch: Vec<(Context, Callback<Box<Snapshot>>)>)
                              -> engine::Result<()> {
         let batch = batch.into_iter().map(|(ctx, cb)| {
             let mut req = Request::new();

--- a/src/storage/engine/raftkv.rs
+++ b/src/storage/engine/raftkv.rs
@@ -33,7 +33,7 @@ use rocksdb::DB;
 use protobuf::RepeatedField;
 
 use storage::engine;
-use super::{CbContext, Engine, Modify, Cursor, Snapshot, ScanMode, Callback,
+use super::{CbContext, Engine, Modify, Cursor, Snapshot, ScanMode, Callback, BatchCallback,
             Iterator as EngineIterator};
 use storage::{Key, Value, CfName, CF_DEFAULT};
 use super::metrics::*;
@@ -354,7 +354,7 @@ impl<S: RaftStoreRouter> Engine for RaftKv<S> {
 
     fn async_snapshots_batch(&self,
                              batch: Vec<(Context, Callback<Box<Snapshot>>)>,
-                             on_finish: Callback<Vec<Option<super::Result<Box<Snapshot>>>>>)
+                             on_finish: BatchCallback<Box<Snapshot>>)
                              -> engine::Result<()> {
         let batch = batch.into_iter().map(|(ctx, cb)| {
             let mut req = Request::new();

--- a/tests/storage/util.rs
+++ b/tests/storage/util.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use std::sync::mpsc::Sender;
 use std::sync::Mutex;
 use tikv::storage::{Engine, Snapshot, Modify, ALL_CFS};
-use tikv::storage::engine::{Callback, Result};
+use tikv::storage::engine::{Callback, Result, BatchCallback};
 use tikv::storage::config::Config;
 use kvproto::kvrpcpb::Context;
 use raftstore::cluster::Cluster;
@@ -118,7 +118,7 @@ impl Engine for BlockEngine {
 
     fn async_snapshots_batch(&self,
                              batch: Vec<(Context, Callback<Box<Snapshot>>)>,
-                             on_finish: Callback<Vec<Option<Result<Box<Snapshot>>>>>)
+                             on_finish: BatchCallback<Box<Snapshot>>)
                              -> Result<()> {
         let block_snapshot = self.block_snapshot.clone();
         let sender = self.sender.clone();

--- a/tests/storage/util.rs
+++ b/tests/storage/util.rs
@@ -118,7 +118,7 @@ impl Engine for BlockEngine {
 
     fn async_snapshots_batch(&self,
                              batch: Vec<(Context, Callback<Box<Snapshot>>)>,
-                             on_finish: Callback<()>)
+                             on_finish: Callback<Vec<Option<Result<Box<Snapshot>>>>>)
                              -> Result<()> {
         let block_snapshot = self.block_snapshot.clone();
         let sender = self.sender.clone();


### PR DESCRIPTION
This PR reducing threads communication by batching `RaftCmd`s, it also batches local read for `RaftCmd`s in the same batch. 