### PR TITLE
coprocessor/xeval: add handling for datum null

### DIFF
--- a/src/coprocessor/xeval/builtin_math.rs
+++ b/src/coprocessor/xeval/builtin_math.rs
@@ -34,7 +34,7 @@ impl Evaluator {
                     Ok(Datum::I64(-i))
                 }
             }
-            Datum::U64(_) => Ok(d),
+            Datum::U64(_) | Datum::Null => Ok(d),
             _ => invalid_type_error(&d, TYPE_INT),
         }
     }
@@ -109,5 +109,9 @@ mod test {
                     (build_expr_with_sig(vec![Datum::U64(1)],
                                          ExprType::ScalarFunc,
                                          ScalarFuncSig::AbsInt),
-                     Datum::U64(1))]);
+                     Datum::U64(1)),
+                    (build_expr_with_sig(vec![Datum::Null],
+                                         ExprType::ScalarFunc,
+                                         ScalarFuncSig::AbsInt),
+                     Datum::Null)]);
 }


### PR DESCRIPTION
Hi,

This PR fixes an issue when the input datum is null. It address

```
select abs(null);
+-----------+
| abs(null) |
+-----------+
|      NULL |
+-----------+
1 row in set (0.00 sec)
```

PTAL @XuHuaiyu @AndreMouche @andelf @BusyJay 