### PR TITLE
travis: let gcc decide which compiler to use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
             packages: ['g++-4.8', 'zlib1g-dev', 'libbz2-dev', 'libsnappy-dev', 'curl', 'libdw-dev', 'libelf-dev', 'elfutils', 'binutils-dev', 'libcurl4-openssl-dev', 'libiberty-dev']
     - os: osx
       rust: nightly-2017-05-29
-      env: COMPILER=clang++ SKIP_FORMAT_CHECK=true CXX=clang++
+      env: SKIP_FORMAT_CHECK=true
 
 install:
   - export LOCAL_DIR=$HOME/.cache/


### PR DESCRIPTION
Looks like clang++ in OSX sometimes doesn't work as expected. So let gcc-rs decide which compiler to use to build cpp wrapper.