### PR TITLE
coprocessor/metircs:init exponential buckets for duration

### DIFF
--- a/src/coprocessor/metrics.rs
+++ b/src/coprocessor/metrics.rs
@@ -18,28 +18,32 @@ lazy_static! {
         register_histogram_vec!(
             "tikv_coprocessor_request_duration_seconds",
             "Bucketed histogram of coprocessor request duration",
-            &["req"]
+            &["req"],
+            exponential_buckets(0.0005, 2.0, 20).unwrap()
         ).unwrap();
 
     pub static ref OUTDATED_REQ_WAIT_TIME: HistogramVec =
         register_histogram_vec!(
             "tikv_coprocessor_outdated_request_wait_seconds",
             "Bucketed histogram of outdated coprocessor request wait duration",
-            &["req"]
+            &["req"],
+            exponential_buckets(0.0005, 2.0, 20).unwrap()
         ).unwrap();
 
     pub static ref COPR_REQ_HANDLE_TIME: HistogramVec =
         register_histogram_vec!(
             "tikv_coprocessor_request_handle_seconds",
             "Bucketed histogram of coprocessor handle request duration",
-            &["req"]
+            &["req"],
+            exponential_buckets(0.0005, 2.0, 20).unwrap()
         ).unwrap();
 
     pub static ref COPR_REQ_WAIT_TIME: HistogramVec =
         register_histogram_vec!(
             "tikv_coprocessor_request_wait_seconds",
             "Bucketed histogram of coprocessor request wait duration",
-            &["req"]
+            &["req"],
+            exponential_buckets(0.0005, 2.0, 20).unwrap()
         ).unwrap();
 
     pub static ref COPR_REQ_ERROR: CounterVec =


### PR DESCRIPTION
HI, 
     This PR initialize exponential buckets for duration metrics.
@siddontang @andelf @BusyJay PTAL