### PR TITLE
coprocessor/*:implement for json_remove

### DIFF
--- a/src/coprocessor/codec/mysql/json/json_remove.rs
+++ b/src/coprocessor/codec/mysql/json/json_remove.rs
@@ -44,6 +44,7 @@ impl Json {
                     return;
                 }
                 array[index].remove_path(sub_path_legs);
+                return;
             }
         }
 
@@ -70,7 +71,7 @@ mod test {
 
     #[test]
     fn test_json_remove() {
-        let mut test_cases = vec![
+        let test_cases = vec![
             (r#"{"a": [3, 4]}"#, "$.a[0]", r#"{"a": [4]}"#, true),
             (r#"{"a": [3, 4]}"#, "$.a", r#"{}"#, true),
             (r#"{"a": [3, 4], "b":1, "c":{"a":1}}"#,
@@ -87,7 +88,7 @@ mod test {
             (r#"null"#, "$**[3]", r#"null"#, false),
         ];
 
-        for (i, (json, path, expected, success)) in test_cases.drain(..).enumerate() {
+        for (i, (json, path, expected, success)) in test_cases.into_iter().enumerate() {
             let j: Result<Json> = json.parse();
             assert!(j.is_ok(), "#{} expect json parse ok but got {:?}", i, j);
             let p = parse_json_path_expr(path);

--- a/src/coprocessor/codec/mysql/json/json_remove.rs
+++ b/src/coprocessor/codec/mysql/json/json_remove.rs
@@ -1,0 +1,110 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::Json;
+use super::path_expr::{PathLeg, PathExpression};
+use super::super::Result;
+
+impl Json {
+    // Remove elements from Json,
+    // All path expressions cannot contain * or ** wildcard.
+    // If any error occurs, the input won't be changed.
+    pub fn remove(&mut self, path_expr_list: &[PathExpression]) -> Result<()> {
+        if path_expr_list.iter().any(|expr| expr.legs.is_empty() || expr.contains_any_asterisk()) {
+            return Err(box_err!("Invalid path expression"));
+        }
+
+        for expr in path_expr_list {
+            self.remove_path(&expr.legs);
+        }
+        Ok(())
+    }
+
+    fn remove_path(&mut self, path_legs: &[PathLeg]) {
+        let (current_leg, sub_path_legs) = (&path_legs[0], &path_legs[1..]);
+
+        if let PathLeg::Index(index) = *current_leg {
+            if let Json::Array(ref mut array) = *self {
+                let index = index as usize;
+                if array.len() <= index {
+                    return;
+                }
+                if sub_path_legs.is_empty() {
+                    array.remove(index);
+                    return;
+                }
+                array[index].remove_path(sub_path_legs);
+            }
+        }
+
+        if let PathLeg::Key(ref key) = *current_leg {
+            if let Json::Object(ref mut obj) = *self {
+                if !obj.contains_key(key) {
+                    return;
+                }
+                if sub_path_legs.is_empty() {
+                    obj.remove(key);
+                    return;
+                }
+                let sub_obj = obj.get_mut(key).unwrap();
+                sub_obj.remove_path(sub_path_legs);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use super::super::path_expr::parse_json_path_expr;
+
+    #[test]
+    fn test_json_remove() {
+        let mut test_cases = vec![
+            (r#"{"a": [3, 4]}"#, "$.a[0]", r#"{"a": [4]}"#, true),
+            (r#"{"a": [3, 4]}"#, "$.a", r#"{}"#, true),
+            (r#"{"a": [3, 4], "b":1, "c":{"a":1}}"#,
+             "$.c.a", r#"{"a": [3, 4],"b":1, "c":{}}"#, true),
+            // Nothing changed because the path without last leg doesn't exist.
+            (r#"{"a": [3, 4]}"#, "$.b[1]", r#"{"a": [3, 4]}"#, true),
+            // Nothing changed because the path without last leg doesn't exist.
+            (r#"{"a": [3, 4]}"#, "$.a[0].b",r#"{"a": [3, 4]}"#, true),
+
+            // Bad path expression.
+            (r#"null"#, "$.*", r#"null"#, false),
+            (r#"null"#, "$[*]", r#"null"#, false),
+            (r#"null"#, "$**.a", r#"null"#, false),
+            (r#"null"#, "$**[3]", r#"null"#, false),
+        ];
+
+        for (i, (json, path, expected, success)) in test_cases.drain(..).enumerate() {
+            let j: Result<Json> = json.parse();
+            assert!(j.is_ok(), "#{} expect json parse ok but got {:?}", i, j);
+            let p = parse_json_path_expr(path);
+            assert!(p.is_ok(), "#{} expect path parse ok but got {:?}", i, p);
+            let e: Result<Json> = expected.parse();
+            assert!(e.is_ok(),
+                    "#{} expect expected value parse ok but got {:?}",
+                    i,
+                    e);
+            let (mut j, p, e) = (j.unwrap(), p.unwrap(), e.unwrap());
+            let r = j.remove(vec![p].as_slice());
+            if success {
+                assert!(r.is_ok(), "#{} expect remove ok but got {:?}", i, r);
+            } else {
+                assert!(r.is_err(), "#{} expect remove error but got {:?}", i, r);
+            }
+            assert_eq!(e, j, "#{} expect remove json {:?} == {:?}", i, j, e);
+        }
+    }
+}

--- a/src/coprocessor/codec/mysql/json/mod.rs
+++ b/src/coprocessor/codec/mysql/json/mod.rs
@@ -24,6 +24,7 @@ mod json_merge;
 mod json_modify;
 mod json_type;
 mod json_unquote;
+mod json_remove;
 
 use std::collections::BTreeMap;
 pub use self::binary::{JsonEncoder, JsonDecoder};


### PR DESCRIPTION
Hi,
    This PR implement function `json_remove` in coprocessor, the related source code in tidb is
(https://github.com/pingcap/tidb/blob/master/expression/builtin_json.go#L207) , (https://github.com/pingcap/tidb/blob/master/util/types/json/functions.go#L329)

The related mysql document is https://dev.mysql.com/doc/refman/5.7/en/json-modification-functions.html#function_json-remove

@hicqu @andelf @BusyJay PTAL