### PR TITLE
storage: rename configuration field

### DIFF
--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -661,10 +661,6 @@ fn adjust_end_points_by_cpu_num(total_cpu_num: usize) -> usize {
     }
 }
 
-fn adjust_sched_workers_by_cpu_num(total_cpu_num: usize) -> usize {
-    if total_cpu_num >= 16 { 8 } else { 4 }
-}
-
 // TODO: merge this function with Config::new
 // Currently, to add a new option, we will define three default value
 // in config.rs, this file and config-template.toml respectively. It may be more
@@ -798,21 +794,19 @@ fn build_cfg(matches: &ArgMatches,
     cfg_f64(&mut cfg.storage.gc_ratio_threshold,
             config,
             "storage.gc-ratio-threshold");
-    cfg_usize(&mut cfg.storage.sched_notify_capacity,
+    cfg_usize(&mut cfg.storage.scheduler_notify_capacity,
               config,
               "storage.scheduler-notify-capacity");
-    cfg_usize(&mut cfg.storage.sched_msg_per_tick,
+    cfg_usize(&mut cfg.storage.scheduler_message_per_tick,
               config,
               "storage.scheduler-messages-per-tick");
-    cfg_usize(&mut cfg.storage.sched_concurrency,
+    cfg_usize(&mut cfg.storage.scheduler_concurrency,
               config,
               "storage.scheduler-concurrency");
-    if !cfg_usize(&mut cfg.storage.sched_worker_pool_size,
-                  config,
-                  "storage.scheduler-worker-pool-size") {
-        cfg.storage.sched_worker_pool_size = adjust_sched_workers_by_cpu_num(total_cpu_num);
-    }
-    cfg_usize(&mut cfg.storage.sched_too_busy_threshold,
+    cfg_usize(&mut cfg.storage.scheduler_worker_pool_size,
+              config,
+              "storage.scheduler-worker-pool-size");
+    cfg_usize(&mut cfg.storage.scheduler_too_busy_threshold,
               config,
               "storage.scheduler-too-busy-threshold");
 
@@ -878,7 +872,7 @@ fn run_raft_server(pd_client: RpcClient,
                    total_mem: u64) {
     info!("tikv server config: {:?}", cfg);
 
-    let store_path = Path::new(&cfg.storage.path);
+    let store_path = Path::new(&cfg.storage.data_dir);
     let lock_path = store_path.join(Path::new("LOCK"));
     let db_path = store_path.join(Path::new("db"));
     let snap_path = store_path.join(Path::new("snap"));
@@ -1104,7 +1098,7 @@ fn main() {
     let mut cfg = build_cfg(&matches, &config, cluster_id, addr, total_cpu_num as usize);
     cfg.labels = get_store_labels(&matches, &config);
     let (store_path, backup_path) = get_data_and_backup_dirs(&matches, &config);
-    cfg.storage.path = store_path;
+    cfg.storage.data_dir = store_path;
 
     if cluster_id == DEFAULT_CLUSTER_ID {
         panic!("in raftkv, cluster_id must greater than 0");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate toml;
+extern crate sys_info;
 
 #[macro_use]
 pub mod util;

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -11,41 +11,39 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const DEFAULT_STORE_PATH: &'static str = "";
+use sys_info;
+
+pub const DEFAULT_DATA_DIR: &'static str = "";
 const DEFAULT_GC_RATIO_THRESHOLD: f64 = 1.1;
 const DEFAULT_SCHED_CAPACITY: usize = 10240;
 const DEFAULT_SCHED_MSG_PER_TICK: usize = 1024;
 const DEFAULT_SCHED_CONCURRENCY: usize = 102400;
-const DEFAULT_SCHED_WORKER_POOL_SIZE: usize = 4;
 const DEFAULT_SCHED_TOO_BUSY_THRESHOLD: usize = 1000;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(default)]
+#[serde(rename_all = "kebab-case")]
 pub struct Config {
-    pub path: String,
+    pub data_dir: String,
     pub gc_ratio_threshold: f64,
-    pub sched_notify_capacity: usize,
-    pub sched_msg_per_tick: usize,
-    pub sched_concurrency: usize,
-    pub sched_worker_pool_size: usize,
-    pub sched_too_busy_threshold: usize,
+    pub scheduler_notify_capacity: usize,
+    pub scheduler_message_per_tick: usize,
+    pub scheduler_concurrency: usize,
+    pub scheduler_worker_pool_size: usize,
+    pub scheduler_too_busy_threshold: usize,
 }
 
 impl Default for Config {
     fn default() -> Config {
+        let total_cpu = sys_info::cpu_num().unwrap();
         Config {
-            path: DEFAULT_STORE_PATH.to_owned(),
+            data_dir: DEFAULT_DATA_DIR.to_owned(),
             gc_ratio_threshold: DEFAULT_GC_RATIO_THRESHOLD,
-            sched_notify_capacity: DEFAULT_SCHED_CAPACITY,
-            sched_msg_per_tick: DEFAULT_SCHED_MSG_PER_TICK,
-            sched_concurrency: DEFAULT_SCHED_CONCURRENCY,
-            sched_worker_pool_size: DEFAULT_SCHED_WORKER_POOL_SIZE,
-            sched_too_busy_threshold: DEFAULT_SCHED_TOO_BUSY_THRESHOLD,
+            scheduler_notify_capacity: DEFAULT_SCHED_CAPACITY,
+            scheduler_message_per_tick: DEFAULT_SCHED_MSG_PER_TICK,
+            scheduler_concurrency: DEFAULT_SCHED_CONCURRENCY,
+            scheduler_worker_pool_size: if total_cpu >= 16 { 8 } else { 4 },
+            scheduler_too_busy_threshold: DEFAULT_SCHED_TOO_BUSY_THRESHOLD,
         }
-    }
-}
-
-impl Config {
-    pub fn new() -> Config {
-        Config::default()
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -29,7 +29,7 @@ pub mod config;
 pub mod types;
 mod metrics;
 
-pub use self::config::Config;
+pub use self::config::{Config, DEFAULT_DATA_DIR};
 pub use self::engine::{Engine, Snapshot, TEMP_DIR, new_local_engine, Modify, Cursor,
                        Error as EngineError, ScanMode, Statistics, CFStatistics};
 pub use self::engine::raftkv::RaftKv;
@@ -395,7 +395,7 @@ pub struct Storage {
 
 impl Storage {
     pub fn from_engine(engine: Box<Engine>, config: &Config) -> Result<Storage> {
-        let (tx, rx) = mpsc::sync_channel(config.sched_notify_capacity);
+        let (tx, rx) = mpsc::sync_channel(config.scheduler_notify_capacity);
         let sendch = SyncSendCh::new(tx, "kv-storage");
 
         info!("storage {:?} started.", engine);
@@ -411,7 +411,7 @@ impl Storage {
     }
 
     pub fn new(config: &Config) -> Result<Storage> {
-        let engine = try!(engine::new_local_engine(&config.path, ALL_CFS));
+        let engine = try!(engine::new_local_engine(&config.data_dir, ALL_CFS));
         Storage::from_engine(engine, config)
     }
 
@@ -424,9 +424,9 @@ impl Storage {
         let engine = self.engine.clone();
         let builder = thread::Builder::new().name(thd_name!("storage-scheduler"));
         let rx = handle.receiver.take().unwrap();
-        let sched_concurrency = config.sched_concurrency;
-        let sched_worker_pool_size = config.sched_worker_pool_size;
-        let sched_too_busy_threshold = config.sched_too_busy_threshold;
+        let sched_concurrency = config.scheduler_concurrency;
+        let sched_worker_pool_size = config.scheduler_worker_pool_size;
+        let sched_too_busy_threshold = config.scheduler_too_busy_threshold;
         let ch = self.sendch.clone();
         let h = try!(builder.spawn(move || {
             let mut sched = Scheduler::new(engine,
@@ -892,7 +892,7 @@ mod tests {
 
     #[test]
     fn test_get_put() {
-        let config = Config::new();
+        let config = Config::default();
         let mut storage = Storage::new(&config).unwrap();
         storage.start(&config).unwrap();
         let (tx, rx) = channel();
@@ -934,9 +934,9 @@ mod tests {
 
     #[test]
     fn test_put_with_err() {
-        let config = Config::new();
+        let config = Config::default();
         // New engine lack of some column families.
-        let engine = engine::new_local_engine(&config.path, &["default"]).unwrap();
+        let engine = engine::new_local_engine(&config.data_dir, &["default"]).unwrap();
         let mut storage = Storage::from_engine(engine, &config).unwrap();
         storage.start(&config).unwrap();
         let (tx, rx) = channel();
@@ -957,7 +957,7 @@ mod tests {
 
     #[test]
     fn test_scan() {
-        let config = Config::new();
+        let config = Config::default();
         let mut storage = Storage::new(&config).unwrap();
         storage.start(&config).unwrap();
         let (tx, rx) = channel();
@@ -999,7 +999,7 @@ mod tests {
 
     #[test]
     fn test_batch_get() {
-        let config = Config::new();
+        let config = Config::default();
         let mut storage = Storage::new(&config).unwrap();
         storage.start(&config).unwrap();
         let (tx, rx) = channel();
@@ -1039,7 +1039,7 @@ mod tests {
 
     #[test]
     fn test_txn() {
-        let config = Config::new();
+        let config = Config::default();
         let mut storage = Storage::new(&config).unwrap();
         storage.start(&config).unwrap();
         let (tx, rx) = channel();
@@ -1098,8 +1098,8 @@ mod tests {
 
     #[test]
     fn test_sched_too_busy() {
-        let mut config = Config::new();
-        config.sched_too_busy_threshold = 1;
+        let mut config = Config::default();
+        config.scheduler_too_busy_threshold = 1;
         let mut storage = Storage::new(&config).unwrap();
         storage.start(&config).unwrap();
         let (tx, rx) = channel();
@@ -1138,7 +1138,7 @@ mod tests {
 
     #[test]
     fn test_cleanup() {
-        let config = Config::new();
+        let config = Config::default();
         let mut storage = Storage::new(&config).unwrap();
         storage.start(&config).unwrap();
         let (tx, rx) = channel();
@@ -1167,7 +1167,7 @@ mod tests {
 
     #[test]
     fn test_high_priority_get_put() {
-        let config = Config::new();
+        let config = Config::default();
         let mut storage = Storage::new(&config).unwrap();
         storage.start(&config).unwrap();
         let (tx, rx) = channel();
@@ -1213,8 +1213,8 @@ mod tests {
 
     #[test]
     fn test_high_priority_no_block() {
-        let mut config = Config::new();
-        config.sched_worker_pool_size = 1;
+        let mut config = Config::default();
+        config.scheduler_worker_pool_size = 1;
         let mut storage = Storage::new(&config).unwrap();
         storage.start(&config).unwrap();
         let (tx, rx) = channel();

--- a/tests/raftstore/util.rs
+++ b/tests/raftstore/util.rs
@@ -101,7 +101,7 @@ pub fn new_server_config(cluster_id: u64) -> ServerConfig {
         cluster_id: cluster_id,
         addr: "127.0.0.1:0".to_owned(),
         raft_store: store_cfg,
-        storage: StorageConfig { sched_worker_pool_size: 1, ..StorageConfig::default() },
+        storage: StorageConfig { scheduler_worker_pool_size: 1, ..StorageConfig::default() },
         grpc_concurrency: 1,
         // Considering connection selection algo is involved, maybe
         // use 2 or larger value here?


### PR DESCRIPTION
This pr tries to make the storage's configuration field names be consistent with toml.