### PR TITLE
resolver: stop thread explicitly

### DIFF
--- a/src/raftstore/coprocessor/dispatcher.rs
+++ b/src/raftstore/coprocessor/dispatcher.rs
@@ -101,12 +101,6 @@ impl CoprocessorHost {
     }
 }
 
-impl Drop for CoprocessorHost {
-    fn drop(&mut self) {
-        self.shutdown();
-    }
-}
-
 #[cfg(test)]
 mod test {
     use raftstore::coprocessor::*;

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -337,13 +337,6 @@ impl<C> Node<C>
     }
 }
 
-impl<C> Drop for Node<C>
-    where C: PdClient
-{
-    fn drop(&mut self) {
-        self.stop().unwrap();
-    }
-}
 #[cfg(test)]
 mod tests {
     use raftstore::store::keys;

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -165,6 +165,7 @@ mod tests {
     use raftstore::store::Msg as StoreMsg;
     use raftstore::store::transport::Transport;
 
+    #[derive(Clone)]
     struct MockResolver {
         addr: Arc<Mutex<Option<SocketAddr>>>,
     }

--- a/src/server/transport.rs
+++ b/src/server/transport.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::{Arc, RwLock, Mutex};
+use std::sync::{Arc, RwLock};
 use std::sync::mpsc::Sender;
 use std::net::SocketAddr;
 use kvproto::raft_serverpb::RaftMessage;
@@ -101,19 +101,19 @@ impl RaftStoreRouter for ServerRaftStoreRouter {
 
 pub struct ServerTransport<T, S>
     where T: RaftStoreRouter + 'static,
-          S: StoreAddrResolver + Send + 'static
+          S: StoreAddrResolver + 'static
 {
     raft_client: Arc<RwLock<RaftClient>>,
     snap_scheduler: Scheduler<SnapTask>,
     raft_router: T,
     snapshot_status_sender: Sender<SnapshotStatusMsg>,
     resolving: Arc<RwLock<HashSet<u64>>>,
-    resolver: Arc<Mutex<S>>,
+    resolver: S,
 }
 
 impl<T, S> Clone for ServerTransport<T, S>
     where T: RaftStoreRouter + 'static,
-          S: StoreAddrResolver + Send + 'static
+          S: StoreAddrResolver + 'static
 {
     fn clone(&self) -> Self {
         ServerTransport {
@@ -127,7 +127,7 @@ impl<T, S> Clone for ServerTransport<T, S>
     }
 }
 
-impl<T: RaftStoreRouter + 'static, S: StoreAddrResolver + Send + 'static> ServerTransport<T, S> {
+impl<T: RaftStoreRouter + 'static, S: StoreAddrResolver + 'static> ServerTransport<T, S> {
     pub fn new(raft_client: Arc<RwLock<RaftClient>>,
                snap_scheduler: Scheduler<SnapTask>,
                raft_router: T,
@@ -140,7 +140,7 @@ impl<T: RaftStoreRouter + 'static, S: StoreAddrResolver + Send + 'static> Server
             raft_router: raft_router,
             snapshot_status_sender: snapshot_status_sender,
             resolving: Arc::new(RwLock::new(Default::default())),
-            resolver: Arc::new(Mutex::new(resolver)),
+            resolver: resolver,
         }
     }
 
@@ -191,7 +191,7 @@ impl<T: RaftStoreRouter + 'static, S: StoreAddrResolver + Send + 'static> Server
             // There may be no messages in the near future, so flush it immediately.
             trans.raft_client.wl().flush();
         };
-        if let Err(e) = self.resolver.lock().unwrap().resolve(store_id, cb) {
+        if let Err(e) = self.resolver.resolve(store_id, cb) {
             error!("try to resolve err {:?}", e);
         }
     }
@@ -259,7 +259,7 @@ impl<T: RaftStoreRouter + 'static, S: StoreAddrResolver + Send + 'static> Server
 
 impl<T, S> Transport for ServerTransport<T, S>
     where T: RaftStoreRouter + 'static,
-          S: StoreAddrResolver + Send + 'static
+          S: StoreAddrResolver + 'static
 {
     fn send(&self, msg: RaftMessage) -> RaftStoreResult<()> {
         let to_store_id = msg.get_to_peer().get_store_id();

--- a/tests/raftstore/node.rs
+++ b/tests/raftstore/node.rs
@@ -214,7 +214,9 @@ impl Simulator for NodeCluster {
     }
 
     fn stop_node(&mut self, node_id: u64) {
-        self.nodes.remove(&node_id);
+        if let Some(mut node) = self.nodes.remove(&node_id) {
+            node.stop().unwrap();
+        }
         self.trans.wl().routers.remove(&node_id).unwrap();
     }
 

--- a/tests/raftstore/server.rs
+++ b/tests/raftstore/server.rs
@@ -24,11 +24,13 @@ use tempdir::TempDir;
 use super::cluster::{Simulator, Cluster};
 use tikv::server::{Server, ServerTransport};
 use tikv::server::{Node, Config, create_raft_storage, PdStoreAddrResolver, RaftClient};
+use tikv::server::resolve::{self, Task as ResolveTask};
 use tikv::server::transport::ServerRaftStoreRouter;
 use tikv::server::transport::RaftStoreRouter;
 use tikv::raftstore::{Error, Result, store};
 use tikv::raftstore::store::{Msg as StoreMsg, SnapManager};
 use tikv::util::transport::SendCh;
+use tikv::util::worker::Worker;
 use tikv::storage::{Engine, CfName, ALL_CFS};
 use kvproto::raft_serverpb::{self, RaftMessage};
 use kvproto::raft_cmdpb::*;
@@ -41,13 +43,18 @@ type SimulateServerTransport = SimulateTransport<RaftMessage,
                                                  ServerTransport<SimulateStoreTransport,
                                                                  PdStoreAddrResolver>>;
 
+struct ServerMeta {
+    node: Node<TestPdClient>,
+    server: Server<SimulateStoreTransport, PdStoreAddrResolver>,
+    router: SimulateStoreTransport,
+    sim_trans: SimulateServerTransport,
+    store_ch: SendCh<StoreMsg>,
+    worker: Worker<ResolveTask>,
+}
+
 pub struct ServerCluster {
-    routers: HashMap<u64, SimulateStoreTransport>,
-    servers: HashMap<u64, Server<SimulateStoreTransport, PdStoreAddrResolver>>,
-    nodes: HashMap<u64, Node<TestPdClient>>,
+    metas: HashMap<u64, ServerMeta>,
     addrs: HashMap<u64, SocketAddr>,
-    sim_trans: HashMap<u64, SimulateServerTransport>,
-    store_chs: HashMap<u64, SendCh<StoreMsg>>,
     pub storages: HashMap<u64, Box<Engine>>,
     snap_paths: HashMap<u64, TempDir>,
     pd_client: Arc<TestPdClient>,
@@ -57,13 +64,9 @@ pub struct ServerCluster {
 impl ServerCluster {
     pub fn new(pd_client: Arc<TestPdClient>) -> ServerCluster {
         ServerCluster {
-            routers: HashMap::new(),
-            servers: HashMap::new(),
-            nodes: HashMap::new(),
+            metas: HashMap::new(),
             addrs: HashMap::new(),
-            sim_trans: HashMap::new(),
             pd_client: pd_client,
-            store_chs: HashMap::new(),
             storages: HashMap::new(),
             snap_paths: HashMap::new(),
             raft_client: RaftClient::new(Arc::new(Environment::new(1)), Config::new()),
@@ -74,8 +77,7 @@ impl ServerCluster {
 impl Simulator for ServerCluster {
     #[allow(useless_format)]
     fn run_node(&mut self, node_id: u64, mut cfg: Config, engine: Arc<DB>) -> u64 {
-        assert!(node_id == 0 || !self.nodes.contains_key(&node_id));
-        assert!(node_id == 0 || !self.servers.contains_key(&node_id));
+        assert!(node_id == 0 || !self.metas.contains_key(&node_id));
 
         let (tmp_str, tmp) = if node_id == 0 || !self.snap_paths.contains_key(&node_id) {
             let p = TempDir::new("test_cluster").unwrap();
@@ -104,7 +106,7 @@ impl Simulator for ServerCluster {
         self.storages.insert(node_id, store.get_engine());
 
         // Create pd client, snapshot manager, server.
-        let resolver = PdStoreAddrResolver::new(self.pd_client.clone()).unwrap();
+        let (worker, resolver) = resolve::new_resolver(self.pd_client.clone()).unwrap();
         let snap_mgr = SnapManager::new(tmp_str,
                                         Some(store_sendch),
                                         cfg.raft_store.use_sst_file_snapshot);
@@ -133,14 +135,18 @@ impl Simulator for ServerCluster {
         if let Some(tmp) = tmp {
             self.snap_paths.insert(node_id, tmp);
         }
-        self.store_chs.insert(node_id, node.get_sendch());
-        self.sim_trans.insert(node_id, simulate_trans);
 
         server.start(&cfg).unwrap();
 
-        self.nodes.insert(node_id, node);
-        self.servers.insert(node_id, server);
-        self.routers.insert(node_id, sim_router);
+        self.metas.insert(node_id,
+                          ServerMeta {
+                              store_ch: node.get_sendch(),
+                              node: node,
+                              server: server,
+                              router: sim_router,
+                              sim_trans: simulate_trans,
+                              worker: worker,
+                          });
         self.addrs.insert(node_id, addr);
 
         node_id
@@ -151,15 +157,15 @@ impl Simulator for ServerCluster {
     }
 
     fn stop_node(&mut self, node_id: u64) {
-        let mut server = self.servers.remove(&node_id).unwrap();
-        server.stop().unwrap();
-        let mut node = self.nodes.remove(&node_id).unwrap();
-        node.stop().unwrap();
-        let _ = self.store_chs.remove(&node_id).unwrap();
+        if let Some(mut meta) = self.metas.remove(&node_id) {
+            meta.server.stop().unwrap();
+            meta.node.stop().unwrap();
+            meta.worker.stop().unwrap().join().unwrap();
+        }
     }
 
     fn get_node_ids(&self) -> HashSet<u64> {
-        self.nodes.keys().cloned().collect()
+        self.metas.keys().cloned().collect()
     }
 
     fn call_command_on_node(&self,
@@ -167,11 +173,10 @@ impl Simulator for ServerCluster {
                             request: RaftCmdRequest,
                             timeout: Duration)
                             -> Result<RaftCmdResponse> {
-        if !self.routers.contains_key(&node_id) {
-            return Err(box_err!("missing sender for store {}", node_id));
-        }
-
-        let router = self.routers.get(&node_id).cloned().unwrap();
+        let router = match self.metas.get(&node_id) {
+            None => return Err(box_err!("missing sender for store {}", node_id)),
+            Some(meta) => meta.router.clone(),
+        };
         wait_op!(|cb: Box<FnBox(RaftCmdResponse) + 'static + Send>| {
                      router.send_command(request, cb).unwrap()
                  },
@@ -188,23 +193,23 @@ impl Simulator for ServerCluster {
     }
 
     fn add_send_filter(&mut self, node_id: u64, filter: SendFilter) {
-        self.sim_trans.get_mut(&node_id).unwrap().add_filter(filter);
+        self.metas.get_mut(&node_id).unwrap().sim_trans.add_filter(filter);
     }
 
     fn clear_send_filters(&mut self, node_id: u64) {
-        self.sim_trans.get_mut(&node_id).unwrap().clear_filters();
+        self.metas.get_mut(&node_id).unwrap().sim_trans.clear_filters();
     }
 
     fn add_recv_filter(&mut self, node_id: u64, filter: RecvFilter) {
-        self.routers.get_mut(&node_id).unwrap().add_filter(filter);
+        self.metas.get_mut(&node_id).unwrap().router.add_filter(filter);
     }
 
     fn clear_recv_filters(&mut self, node_id: u64) {
-        self.routers.get_mut(&node_id).unwrap().clear_filters();
+        self.metas.get_mut(&node_id).unwrap().router.clear_filters();
     }
 
     fn get_store_sendch(&self, node_id: u64) -> Option<SendCh<StoreMsg>> {
-        self.store_chs.get(&node_id).cloned()
+        self.metas.get(&node_id).map(|m| m.store_ch.clone())
     }
 }
 

--- a/tests/raftstore/test_bootstrap.rs
+++ b/tests/raftstore/test_bootstrap.rs
@@ -86,6 +86,7 @@ fn test_node_bootstrap_with_prepared_data() {
         .is_none());
     assert!(engine.get_msg::<RegionLocalState>(&region_state_key).unwrap().is_none());
     assert_eq!(pd_client.get_regions_number() as u32, 1);
+    node.stop().unwrap();
 }
 
 #[test]


### PR DESCRIPTION
This pr stop the resolver thread explicitly instead of relying on drop method. When drop method is called, it's possible that the join method is called inside the resolver thread, which will lead to unexpected panic on Linux.