### PR TITLE
disable mem-profiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ time = "0.1"
 
 [features]
 default = []
-dev = ["clippy", "mem-profiling"]
+dev = ["clippy"]
 static-link = ["rocksdb/static-link"]
 portable = ["rocksdb/portable"]
 sse = ["rocksdb/sse"]

--- a/src/coprocessor/xeval/builtin_math.rs
+++ b/src/coprocessor/xeval/builtin_math.rs
@@ -174,11 +174,11 @@ mod test {
                vec![(build_expr_with_sig(vec![Datum::F64(-1.5)],
                                          ExprType::ScalarFunc,
                                          ScalarFuncSig::CeilReal),
-                    Datum::F64(-1.0)),
+                     Datum::F64(-1.0)),
                     (build_expr_with_sig(vec![Datum::F64(1.1)],
                                          ExprType::ScalarFunc,
                                          ScalarFuncSig::CeilReal),
-                    Datum::F64(2.0)),
+                     Datum::F64(2.0)),
                     (build_expr_with_sig(vec![Datum::F64(2.0)],
                                          ExprType::ScalarFunc,
                                          ScalarFuncSig::CeilReal),
@@ -186,5 +186,5 @@ mod test {
                     (build_expr_with_sig(vec![Datum::Null],
                                          ExprType::ScalarFunc,
                                          ScalarFuncSig::CeilReal),
-                    Datum::Null)]);
+                     Datum::Null)]);
 }


### PR DESCRIPTION
`jemallocator` depends on libc with default features disabled. But `TiKV` also have several dependencies depend on libc with default features enabled. In this case, cargo will enable default features for all libc dependencies. We were able to get around this by using the built in libc crate. But in the recent nightly release of rustc, there will be two libc crates that will lead to conflict.

So let's disable mem-profiling by default until we find a better solution.