### PR TITLE
coprocessor/endpoint:remove metrics for scan_details

### DIFF
--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -205,12 +205,12 @@ impl RequestTask {
         COPR_SCAN_KEYS.with_label_values(&[type_str])
             .observe(self.statistics.total_op_count() as f64);
 
-        for (cf, details) in self.statistics.details() {
-            for (tag, count) in details {
-                COPR_SCAN_DETAILS.with_label_values(&[type_str, cf, tag])
-                    .observe(count as f64);
-            }
-        }
+        // for (cf, details) in self.statistics.details() {
+        //     for (tag, count) in details {
+        //         COPR_SCAN_DETAILS.with_label_values(&[type_str, cf, tag])
+        //             .observe(count as f64);
+        //     }
+        // }
 
         if handle_time > SLOW_QUERY_LOWER_BOUND {
             info!("[region {}] handle {:?} [{}] takes {:?} [waiting: {:?}, keys: {}, hit: {}, \

--- a/src/coprocessor/metrics.rs
+++ b/src/coprocessor/metrics.rs
@@ -68,13 +68,13 @@ lazy_static! {
             exponential_buckets(1.0, 2.0, 20).unwrap()
         ).unwrap();
 
-    pub static ref COPR_SCAN_DETAILS: HistogramVec =
-        register_histogram_vec!(
-            "tikv_coprocessor_scan_details",
-            "Bucketed histogram of coprocessor scan details for each CF",
-            &["req", "cf", "tag"],
-             exponential_buckets(1.0, 2.0, 20).unwrap()
-        ).unwrap();
+    // pub static ref COPR_SCAN_DETAILS: HistogramVec =
+    //     register_histogram_vec!(
+    //         "tikv_coprocessor_scan_details",
+    //         "Bucketed histogram of coprocessor scan details for each CF",
+    //         &["req", "cf", "tag"],
+    //          exponential_buckets(1.0, 2.0, 20).unwrap()
+    //     ).unwrap();
 
     pub static ref COPR_EXECUTOR_COUNT: CounterVec =
         register_counter_vec!(


### PR DESCRIPTION
Hi,
      This PR removes metrics `tikv_coprocessor_scan_details` to reduce lock conflicts.

@siddontang @BusyJay PTAL