### PR TITLE
consistency check: prevent duplicated consistency check

### DIFF
--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -1877,8 +1877,13 @@ fn verify_and_store_hash(region_id: u64,
     }
 
     if state.index == expected_index {
+        if state.hash.is_empty() {
+            warn!("[region {}] duplicated consistency check detected, skip.",
+                  region_id);
+            return false;
+        }
         if state.hash != expected_hash {
-            panic!("[region {}] hash at {} not correct, want {}, got {}!!!",
+            panic!("[region {}] hash at {} not correct, want \"{}\", got \"{}\"!!!",
                    region_id,
                    state.index,
                    escape(&expected_hash),


### PR DESCRIPTION
In some rare cases like election or slow hash computation, there may be duplicated consistency verification. We need to skip consistency check in this case, because it's going to fail no matter if the data is consistent with other peers.