### PR TITLE
util/time: use millisecond resolution for coarse Instant

### DIFF
--- a/src/util/time.rs
+++ b/src/util/time.rs
@@ -270,6 +270,10 @@ impl Instant {
         }
     }
 
+    // It is different from `elapsed_duration`, the resolution here is millisecond.
+    // The processors in an SMP system do not start all at exactly the same time
+    // and therefore the timer registers are typically running at an offset.
+    // Use millisecond resolution for ignoring the error.
     fn elapsed_duration_coarse(later: Timespec, earlier: Timespec) -> Duration {
         let later_ms = later.sec * MILLISECOND_PER_SECOND +
                        (later.nsec / NANOSECONDS_PER_MILLISECOND) as i64;
@@ -443,5 +447,16 @@ mod tests {
         // Add Duration.
         assert_eq!(late_raw + zero, late_raw);
         assert_eq!(late_coarse + zero, late_coarse);
+    }
+
+    #[test]
+    fn test_coarse_instant_on_smp() {
+        for i in 0..100000 {
+            let now = Instant::now_coarse();
+            if i % 100 == 0 {
+                thread::yield_now();
+            }
+            now.elapsed();
+        }
     }
 }

--- a/src/util/time.rs
+++ b/src/util/time.rs
@@ -447,6 +447,13 @@ mod tests {
         // Add Duration.
         assert_eq!(late_raw + zero, late_raw);
         assert_eq!(late_coarse + zero, late_coarse);
+
+        // PartialEq and PartialOrd
+        let ts = Timespec::new(1, 1);
+        let now1 = Instant::Monotonic(ts);
+        let now2 = Instant::MonotonicCoarse(ts);
+        assert_ne!(now1, now2);
+        assert_eq!(now1.partial_cmp(&now2), None);
     }
 
     #[test]

--- a/src/util/time.rs
+++ b/src/util/time.rs
@@ -443,12 +443,4 @@ mod tests {
         assert_eq!(late_raw + zero, late_raw);
         assert_eq!(late_coarse + zero, late_coarse);
     }
-
-    #[test]
-    #[should_panic]
-    fn test_instant_panic() {
-        let earlier = Instant::now();
-        thread::sleep(Duration::from_millis(10));
-        Instant::now_coarse().duration_since(earlier);
-    }
 }


### PR DESCRIPTION
It's a quick fix for #2158. `SlowTimer` should not panic again by using millisecond resolution for coarse Instant. 

Fix #2158 