### PR TITLE
upgrade rocksdb to 5.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#a67bce5405bff5aa3b3b511c82a712fc10b39255"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#b95e696fd28b1c3e1df4ba8798a802e4256f3092"
 dependencies = [
  "gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -760,7 +760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#a67bce5405bff5aa3b3b511c82a712fc10b39255"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#b95e696fd28b1c3e1df4ba8798a802e4256f3092"
 dependencies = [
  "crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/circle.yml
+++ b/circle.yml
@@ -53,12 +53,12 @@ dependencies:
         make install;
       fi
     - |
-      if [[ ! -e $HOME/.local/lib/librocksdb.so.5.6.1 ]]; then
+      if [[ ! -e $HOME/.local/lib/librocksdb.so.5.6.2 ]]; then
         export CPLUS_INCLUDE_PATH="${LOCAL_PREFIX}/include" && \
         cd /tmp && \
-        curl -L https://github.com/facebook/rocksdb/archive/v5.6.1.tar.gz -o rocksdb.tar.gz && \
+        curl -L https://github.com/facebook/rocksdb/archive/v5.6.2.tar.gz -o rocksdb.tar.gz && \
         tar xf rocksdb.tar.gz && \
-        cd rocksdb-5.6.1 && \
+        cd rocksdb-5.6.2 && \
         INSTALL_PATH=${LOCAL_PREFIX} make -j 1 install-shared;
       fi
   post:

--- a/docker/rust_dockerfile
+++ b/docker/rust_dockerfile
@@ -21,11 +21,11 @@ RUN curl -L https://github.com/gflags/gflags/archive/v2.1.2.tar.gz -o gflags.tar
 	&& make install \
 	&& rm -rf /gflags.tar.gz /gflags-2.1.2
 
-RUN curl -L https://github.com/facebook/rocksdb/archive/v5.6.1.tar.gz -o rocksdb.tar.gz \
+RUN curl -L https://github.com/facebook/rocksdb/archive/v5.6.2.tar.gz -o rocksdb.tar.gz \
 	&& tar xf rocksdb.tar.gz \
-	&& cd rocksdb-5.6.1 \
+	&& cd rocksdb-5.6.2 \
 	&& make -j install-shared \
-	&& rm -rf /rocksdb.tar.gz /rocksdb-5.6.1
+	&& rm -rf /rocksdb.tar.gz /rocksdb-5.6.2
 
 ENV GOLANG_VERSION 1.8
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz


### PR DESCRIPTION
RocksDB 5.6.2 has fixed [deletion dropping](https://github.com/facebook/rocksdb/commit/acf935e40f9d6f4c3d13c7d310def7064c1f1c95) in intra-L0.