### PR TITLE
*: remove all unnecessary mut

### DIFF
--- a/src/coprocessor/codec/mysql/json/json_modify.rs
+++ b/src/coprocessor/codec/mysql/json/json_modify.rs
@@ -93,7 +93,7 @@ impl Json {
             if let Json::Object(ref mut map) = *self {
                 if map.contains_key(key) {
                     // e.g. json_replace('{"a": 1}', '$.a', 2) => '{"a": 2}'
-                    let mut v = map.get_mut(key).unwrap();
+                    let v = map.get_mut(key).unwrap();
                     v.set_json(sub_path_legs, value, mt);
                 } else if sub_path_legs.is_empty() && mt != ModifyType::Replace {
                     // e.g. json_insert('{"a": 1}', '$.b', 2) => '{"a": 1, "b": 2}'

--- a/src/coprocessor/dag/dag.rs
+++ b/src/coprocessor/dag/dag.rs
@@ -71,7 +71,7 @@ impl<'s> DAGContext<'s> {
             match exec.next() {
                 Ok(Some(row)) => {
                     try!(check_if_outdated(self.deadline, REQ_TYPE_DAG));
-                    let mut chunk = get_chunk(&mut chunks);
+                    let chunk = get_chunk(&mut chunks);
                     let length = chunk.get_rows_data().len();
                     if self.has_aggr {
                         chunk.mut_rows_data().extend_from_slice(&row.data.value);

--- a/src/coprocessor/dag/executor/index_scan.rs
+++ b/src/coprocessor/dag/executor/index_scan.rs
@@ -45,7 +45,7 @@ impl<'a> IndexScanExecutor<'a> {
     ) -> IndexScanExecutor<'a> {
         let mut pk_col = None;
         let desc = meta.get_desc();
-        let mut cols = meta.mut_columns();
+        let cols = meta.mut_columns();
         if cols.last().map_or(false, |c| c.get_pk_handle()) {
             pk_col = Some(cols.pop().unwrap());
         }

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -315,7 +315,7 @@ impl BatchRunnable<Task> for Host {
                             ctx.get_peer().get_id(),
                         )
                     };
-                    let mut group = grouped_reqs.entry(key).or_insert_with(Vec::new);
+                    let group = grouped_reqs.entry(key).or_insert_with(Vec::new);
                     group.push(req);
                 }
                 Task::SnapRes(q_id, snap_res) => {

--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -626,8 +626,8 @@ impl Snap {
     }
 
     fn add_kv(&mut self, k: &[u8], v: &[u8]) -> io::Result<()> {
-        let mut cf_file = &mut self.cf_files[self.cf_index];
-        let mut writer = cf_file.sst_writer.as_mut().unwrap();
+        let cf_file = &mut self.cf_files[self.cf_index];
+        let writer = cf_file.sst_writer.as_mut().unwrap();
         if let Err(e) = writer.add(k, v) {
             return Err(io::Error::new(ErrorKind::Other, e));
         }
@@ -1011,8 +1011,8 @@ impl Write for Snap {
                 continue;
             }
 
-            let mut file = cf_file.file.as_mut().unwrap();
-            let mut digest = cf_file.write_digest.as_mut().unwrap();
+            let file = cf_file.file.as_mut().unwrap();
+            let digest = cf_file.write_digest.as_mut().unwrap();
             if next_buf.len() > left {
                 try!(file.write_all(&next_buf[0..left]));
                 digest.write(&next_buf[0..left]);

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -413,7 +413,7 @@ impl<T, C> Store<T, C> {
 
     fn report_snapshot_status(&mut self, region_id: u64, to_peer_id: u64, status: SnapshotStatus) {
         self.sent_snapshot_count -= 1;
-        if let Some(mut peer) = self.region_peers.get_mut(&region_id) {
+        if let Some(peer) = self.region_peers.get_mut(&region_id) {
             let to_peer = match peer.get_peer_from_cache(to_peer_id) {
                 Some(peer) => peer,
                 None => {
@@ -1189,7 +1189,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         first_index: u64,
         state: RaftTruncatedState,
     ) {
-        let mut peer = self.region_peers.get_mut(&region_id).unwrap();
+        let peer = self.region_peers.get_mut(&region_id).unwrap();
         let total_cnt = peer.last_applying_idx - first_index;
         // the size of current CompactLog command can be ignored.
         let remain_cnt = peer.last_applying_idx - state.get_index() - 1;
@@ -1433,7 +1433,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
 
         let mut resp = RaftCmdResponse::new();
         let region_id = msg.get_header().get_region_id();
-        let mut peer = self.region_peers.get_mut(&region_id).unwrap();
+        let peer = self.region_peers.get_mut(&region_id).unwrap();
         let term = peer.term();
         bind_term(&mut resp, term);
         if peer.propose(cb, msg, resp, &mut self.raft_metrics.propose) {
@@ -1466,7 +1466,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             }
 
             let region_id = msg.get_header().get_region_id();
-            let mut peer = self.region_peers.get_mut(&region_id).unwrap();
+            let peer = self.region_peers.get_mut(&region_id).unwrap();
             ret.push(peer.propose_snapshot(msg, &mut self.raft_metrics.propose));
         }
         on_finished.call_box((ret,));
@@ -2017,7 +2017,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
     }
 
     fn on_unreachable(&mut self, region_id: u64, to_peer_id: u64) {
-        if let Some(mut peer) = self.region_peers.get_mut(&region_id) {
+        if let Some(peer) = self.region_peers.get_mut(&region_id) {
             peer.raft_group.report_unreachable(to_peer_id);
         }
     }

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -122,7 +122,7 @@ impl RaftClient {
     }
 
     pub fn send(&mut self, store_id: u64, addr: SocketAddr, msg: RaftMessage) -> Result<()> {
-        let mut conn = self.get_conn(addr, msg.region_id, store_id);
+        let conn = self.get_conn(addr, msg.region_id, store_id);
         conn.buffer
             .as_mut()
             .unwrap()

--- a/src/storage/mvcc/reader.rs
+++ b/src/storage/mvcc/reader.rs
@@ -168,7 +168,7 @@ impl<'a> MvccReader<'a> {
             self.write_cursor = Some(iter);
         }
 
-        let mut cursor = self.write_cursor.as_mut().unwrap();
+        let cursor = self.write_cursor.as_mut().unwrap();
         let ok = if reverse {
             try!(cursor.near_seek_for_prev(&key.append_ts(ts), &mut self.statistics.write))
         } else {
@@ -297,7 +297,7 @@ impl<'a> MvccReader<'a> {
         assert!(self.scan_mode.is_some());
         try!(self.create_write_cursor());
 
-        let mut cursor = self.write_cursor.as_mut().unwrap();
+        let cursor = self.write_cursor.as_mut().unwrap();
         let mut ok = cursor.seek_to_first(&mut self.statistics.write);
 
         while ok {
@@ -320,8 +320,8 @@ impl<'a> MvccReader<'a> {
 
         loop {
             key = {
-                let mut w_cur = self.write_cursor.as_mut().unwrap();
-                let mut l_cur = self.lock_cursor.as_mut().unwrap();
+                let w_cur = self.write_cursor.as_mut().unwrap();
+                let l_cur = self.lock_cursor.as_mut().unwrap();
                 let (mut w_key, mut l_key) = (None, None);
                 if write_valid {
                     if try!(w_cur.near_seek(&key, &mut self.statistics.write)) {
@@ -366,8 +366,8 @@ impl<'a> MvccReader<'a> {
 
         loop {
             key = {
-                let mut w_cur = self.write_cursor.as_mut().unwrap();
-                let mut l_cur = self.lock_cursor.as_mut().unwrap();
+                let w_cur = self.write_cursor.as_mut().unwrap();
+                let l_cur = self.lock_cursor.as_mut().unwrap();
                 let (mut w_key, mut l_key) = (None, None);
                 if write_valid {
                     if try!(w_cur.near_reverse_seek(&key, &mut self.statistics.write)) {
@@ -413,7 +413,7 @@ impl<'a> MvccReader<'a> {
         F: Fn(&Lock) -> bool,
     {
         try!(self.create_lock_cursor());
-        let mut cursor = self.lock_cursor.as_mut().unwrap();
+        let cursor = self.lock_cursor.as_mut().unwrap();
         let ok = match start {
             Some(ref x) => try!(cursor.seek(x, &mut self.statistics.lock)),
             None => cursor.seek_to_first(&mut self.statistics.lock),
@@ -469,7 +469,7 @@ impl<'a> MvccReader<'a> {
     // Get all Value of the given key in CF_DEFAULT
     pub fn scan_values_in_default(&mut self, key: &Key) -> Result<Vec<(u64, Value)>> {
         try!(self.create_data_cursor());
-        let mut cursor = self.data_cursor.as_mut().unwrap();
+        let cursor = self.data_cursor.as_mut().unwrap();
         let mut ok = try!(cursor.seek(key, &mut self.statistics.data));
         if !ok {
             return Ok(vec![]);

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -1098,7 +1098,7 @@ impl Scheduler {
     ///
     /// Returns true if successful; returns false otherwise.
     fn acquire_lock(&mut self, cid: u64) -> bool {
-        let mut ctx = &mut self.cmd_ctxs.get_mut(&cid).unwrap();
+        let ctx = &mut self.cmd_ctxs.get_mut(&cid).unwrap();
         assert_eq!(ctx.cid, cid);
         let ok = self.latches.acquire(&mut ctx.lock, cid);
         if ok {
@@ -1341,7 +1341,7 @@ impl Scheduler {
     fn lock_and_register_get_snapshot(&mut self, cid: u64) {
         if self.acquire_lock(cid) {
             let ctx = self.extract_context(cid).clone();
-            let mut group = self.grouped_cmds
+            let group = self.grouped_cmds
                 .as_mut()
                 .unwrap()
                 .entry(HashableContext(ctx))


### PR DESCRIPTION
I use a higher version rustc and it warns me about these `mut`s.
@siddontang @BusyJay PTAL.

Signed-off-by: Cholerae Hu <huyingqian@pingcap.com>