### PR TITLE
copr: introduce try_opt

### DIFF
--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -201,3 +201,15 @@ macro_rules! wait_op {
         }
     }
 }
+
+/// `try_opt` check `Result<Option<T>>`, return early when met `Err` or `Ok(None)`.
+#[macro_export]
+macro_rules! try_opt {
+    ($expr:expr) => ({
+        match $expr {
+            Err(e) => return Err(e.into()),
+            Ok(None) => return Ok(None),
+            Ok(Some(res)) => res,
+        }
+    });
+}


### PR DESCRIPTION
We deal with None a lot in coprocessor, hence I introduce `try_opt` to reduce the duplicate code.