### PR TITLE
util: add release version info

### DIFF
--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -274,8 +274,11 @@ fn main() {
     let long_version: String = {
         let (hash, branch, time, rust_ver) = util::build_info();
         format!(
-            "{}\nGit Commit Hash:   {}\nGit Commit Branch: {}\nUTC Build Time:    {}\nRust \
-             Version:      {}",
+            "\nRelease Version:   {}\
+             \nGit Commit Hash:   {}\
+             \nGit Commit Branch: {}\
+             \nUTC Build Time:    {}\
+             \nRust Version:      {}",
             crate_version!(),
             hash,
             branch,

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -350,7 +350,7 @@ pub fn build_info() -> (String, String, String, String) {
 pub fn print_tikv_info() {
     let (hash, branch, date, rustc) = build_info();
     info!("Welcome to TiKV.");
-    info!("Version:");
+    info!("Release Version:   {}", env!("CARGO_PKG_VERSION"));
     info!("Git Commit Hash:   {}", hash);
     info!("Git Commit Branch: {}", branch);
     info!("UTC Build Time:    {}", date);


### PR DESCRIPTION
Add version information in tikv's log and tikv-server -V output.

CC pingcap/tidb#4218