### PR TITLE
coprocessor: fix bug about reverse scan.

### DIFF
--- a/src/coprocessor/dag/executor/index_scan.rs
+++ b/src/coprocessor/dag/executor/index_scan.rs
@@ -275,24 +275,19 @@ mod test {
         let mut wrapper = IndexTestWrapper::default();
         wrapper.scan.set_desc(true);
 
-        let (ref start_key, _) = wrapper.data.kv_data[0];
-        let (ref split_key, _) = wrapper.data.kv_data[KEY_NUMBER / 2];
-        let (ref end_key, _) = wrapper.data.kv_data[KEY_NUMBER - 1];
-        let mut r1 = KeyRange::new();
-        r1.set_start(start_key.clone());
-        r1.set_end(split_key.clone());
-        let mut r2 = KeyRange::new();
-        r2.set_start(split_key.clone());
-        r2.set_end(end_key.clone());
-        wrapper.ranges = vec![r1, r2];
+        let r1 = get_idx_range(TABLE_ID, INDEX_ID, i64::MIN, 0);
+        let r2 = get_idx_range(TABLE_ID, INDEX_ID, 0, (KEY_NUMBER / 2) as i64);
+        let r3 = get_idx_range(TABLE_ID, INDEX_ID, (KEY_NUMBER / 2) as i64, i64::MAX);
+        wrapper.ranges = vec![r1, r2, r3];
+
         let (snapshot, start_ts) = wrapper.store.get_snapshot();
         let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI);
 
         let mut scanner =
             IndexScanExecutor::new(wrapper.scan, wrapper.ranges, store, &mut statistics);
 
-        for tid in 0..KEY_NUMBER - 1 {
-            let handle = KEY_NUMBER - tid - 2;
+        for tid in 0..KEY_NUMBER {
+            let handle = KEY_NUMBER - tid - 1;
             let row = scanner.next().unwrap().unwrap();
             assert_eq!(row.handle, handle as i64);
             assert_eq!(row.data.len(), 2);

--- a/src/coprocessor/dag/executor/table_scan.rs
+++ b/src/coprocessor/dag/executor/table_scan.rs
@@ -26,7 +26,7 @@ use super::scanner::Scanner;
 
 
 pub struct TableScanExecutor<'a> {
-    meta: TableScan,
+    desc: bool,
     col_ids: HashSet<i64>,
     cursor: usize,
     key_ranges: Vec<KeyRange>,
@@ -36,7 +36,7 @@ pub struct TableScanExecutor<'a> {
 impl<'a> TableScanExecutor<'a> {
     pub fn new(
         meta: TableScan,
-        key_ranges: Vec<KeyRange>,
+        mut key_ranges: Vec<KeyRange>,
         store: SnapshotStore<'a>,
         statistics: &'a mut Statistics,
     ) -> TableScanExecutor<'a> {
@@ -45,10 +45,14 @@ impl<'a> TableScanExecutor<'a> {
             .filter(|c| !c.get_pk_handle())
             .map(|c| c.get_column_id())
             .collect();
-        let scanner = Scanner::new(store, meta.get_desc(), false, statistics);
+        let desc = meta.get_desc();
+        if desc {
+            key_ranges.reverse();
+        }
+        let scanner = Scanner::new(store, desc, false, statistics);
         COPR_EXECUTOR_COUNT.with_label_values(&["tblscan"]).inc();
         TableScanExecutor {
-            meta: meta,
+            desc: desc,
             col_ids: col_ids,
             scanner: scanner,
             key_ranges: key_ranges,
@@ -65,7 +69,7 @@ impl<'a> TableScanExecutor<'a> {
         };
         let h = box_try!(table::decode_handle(&key));
         let row_data = box_try!(table::cut_row(value, &self.col_ids));
-        let seek_key = if self.meta.get_desc() {
+        let seek_key = if self.desc {
             box_try!(table::truncate_as_row_key(&key)).to_vec()
         } else {
             prefix_next(&key)
@@ -234,6 +238,18 @@ mod test {
         let mut statistics = Statistics::default();
         let mut wrapper = TableScanTestWrapper::default();
         wrapper.table_scan.set_desc(true);
+
+        // prepare range
+        let r1 = get_range(TABLE_ID, i64::MIN, 0);
+        let r2 = get_range(TABLE_ID, 0, (KEY_NUMBER / 2) as i64);
+
+        // prepare point get
+        let handle = KEY_NUMBER / 2;
+        let r3 = wrapper.get_point_range(handle as i64);
+
+        let r4 = get_range(TABLE_ID, (handle + 1) as i64, i64::MAX);
+        wrapper.ranges = vec![r1, r2, r3, r4];
+
         let (snapshot, start_ts) = wrapper.store.get_snapshot();
         let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI);
         let mut table_scanner =


### PR DESCRIPTION
There was a bug in dag plan: we supposed the input ranges has already been reversed if we need desc-scan, but it didn't . This PR fix it and add some tests.

@AndreMouche @hicqu @BusyJay PTAL