### PR TITLE
pd: speed up reconnecting to a pd leader

### DIFF
--- a/src/pd/mod.rs
+++ b/src/pd/mod.rs
@@ -137,3 +137,5 @@ pub trait PdClient: Send + Sync {
     // Report pd the split region.
     fn report_split(&self, left: metapb::Region, right: metapb::Region) -> PdFuture<()>;
 }
+
+const REQUEST_TIMEOUT: u64 = 2; // 2s

--- a/src/pd/util.rs
+++ b/src/pd/util.rs
@@ -395,7 +395,7 @@ pub fn try_connect_leader(
     // Try to connect to other members, then the previous leader.
     'outer: for m in members
         .into_iter()
-        .filter(|m| *m == previous_leader)
+        .filter(|m| *m != previous_leader)
         .chain(&[previous_leader.clone()])
     {
         for ep in m.get_client_urls() {


### PR DESCRIPTION
Client may spend a lot to time to reconnect when the pd leader is isolated. Speed it up by adding a timeout.
Also it puts the previous leader at the last when reconnecting.