### PR TITLE
tests: clean up log

### DIFF
--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -40,7 +40,7 @@ impl RpcClient {
         let env = Arc::new(
             EnvBuilder::new()
                 .cq_count(CQ_COUNT)
-                .name_prefix(CLIENT_PREFIX)
+                .name_prefix(thd_name!(CLIENT_PREFIX))
                 .build(),
         );
         let (client, members) = try!(validate_endpoints(env.clone(), endpoints));

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -16,7 +16,7 @@ use std::sync::mpsc::Sender;
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 
-use grpc::{ChannelBuilder, Environment, Server as GrpcServer, ServerBuilder};
+use grpc::{ChannelBuilder, EnvBuilder, Environment, Server as GrpcServer, ServerBuilder};
 use kvproto::tikvpb_grpc::*;
 use util::worker::Worker;
 use storage::Storage;
@@ -60,7 +60,12 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver + 'static> Server<T, S> {
         resolver: S,
         snap_mgr: SnapManager,
     ) -> Result<Server<T, S>> {
-        let env = Arc::new(Environment::new(cfg.grpc_concurrency));
+        let env = Arc::new(
+            EnvBuilder::new()
+                .cq_count(cfg.grpc_concurrency)
+                .name_prefix(thd_name!("grpc-server"))
+                .build(),
+        );
         let raft_client = Arc::new(RwLock::new(RaftClient::new(env.clone(), cfg.clone())));
         let end_point_worker = Worker::new("end-point-worker");
         let snap_worker = Worker::new("snap-handler");

--- a/src/util/logger.rs
+++ b/src/util/logger.rs
@@ -19,6 +19,8 @@ use log::{self, Log, LogMetadata, LogRecord, SetLoggerError};
 
 pub use log::LogLevelFilter;
 
+const VALID_PACKAGES: &[&'static str] = &["tikv::", "tests::", "benches::"];
+
 pub fn init_log<W: LogWriter + Sync + Send + 'static>(
     writer: W,
     level: LogLevelFilter,
@@ -28,6 +30,21 @@ pub fn init_log<W: LogWriter + Sync + Send + 'static>(
         Box::new(Logger {
             level: level,
             writer: writer,
+            tikv_only: false,
+        })
+    })
+}
+
+pub fn init_log_for_tikv_only<W: LogWriter + Sync + Send + 'static>(
+    writer: W,
+    level: LogLevelFilter,
+) -> Result<(), SetLoggerError> {
+    log::set_logger(|filter| {
+        filter.set(level);
+        Box::new(Logger {
+            level: level,
+            writer: writer,
+            tikv_only: true,
         })
     })
 }
@@ -39,6 +56,7 @@ pub trait LogWriter {
 struct Logger<W: LogWriter> {
     level: LogLevelFilter,
     writer: W,
+    tikv_only: bool,
 }
 
 impl<W: LogWriter + Sync + Send> Log for Logger<W> {
@@ -47,6 +65,13 @@ impl<W: LogWriter + Sync + Send> Log for Logger<W> {
     }
 
     fn log(&self, record: &LogRecord) {
+        if self.tikv_only &&
+            VALID_PACKAGES
+                .iter()
+                .all(|pkg| !record.target().starts_with(pkg))
+        {
+            return;
+        }
         if self.enabled(record.metadata()) {
             let t = time::now();
             let time_str = time::strftime("%Y/%m/%d %H:%M:%S.%f", &t).unwrap();

--- a/src/util/logger.rs
+++ b/src/util/logger.rs
@@ -19,7 +19,7 @@ use log::{self, Log, LogMetadata, LogRecord, SetLoggerError};
 
 pub use log::LogLevelFilter;
 
-const VALID_PACKAGES: &[&'static str] = &["tikv::", "tests::", "benches::"];
+const ENABLED_TARGETS: &[&'static str] = &["tikv::", "tests::", "benches::"];
 
 pub fn init_log<W: LogWriter + Sync + Send + 'static>(
     writer: W,
@@ -66,9 +66,9 @@ impl<W: LogWriter + Sync + Send> Log for Logger<W> {
 
     fn log(&self, record: &LogRecord) {
         if self.tikv_only &&
-            VALID_PACKAGES
+            ENABLED_TARGETS
                 .iter()
-                .all(|pkg| !record.target().starts_with(pkg))
+                .all(|target| !record.target().starts_with(target))
         {
             return;
         }

--- a/tests/pd/mock/server.rs
+++ b/tests/pd/mock/server.rs
@@ -14,7 +14,7 @@
 use std::sync::Arc;
 
 use futures::{Future, Sink, Stream};
-use grpc::{DuplexSink, Environment, RequestStream, RpcContext, RpcStatus, RpcStatusCode,
+use grpc::{DuplexSink, EnvBuilder, RequestStream, RpcContext, RpcStatus, RpcStatusCode,
            Server as GrpcServer, ServerBuilder, UnarySink, WriteFlags};
 use tikv::pd::Error as PdError;
 
@@ -49,7 +49,12 @@ impl Server {
             case: case.clone(),
         };
         let service = pdpb_grpc::create_pd(m);
-        let env = Arc::new(Environment::new(1));
+        let env = Arc::new(
+            EnvBuilder::new()
+                .cq_count(1)
+                .name_prefix(thd_name!("mock-server"))
+                .build(),
+        );
         let mut sb = ServerBuilder::new(env).register_service(service);
         for (host, port) in eps {
             sb = sb.bind(host, port);

--- a/tests/pd/test_rpc_client.rs
+++ b/tests/pd/test_rpc_client.rs
@@ -136,7 +136,12 @@ fn test_validate_endpoints() {
     let se = Arc::new(Service::new());
     let sp = Arc::new(Split::new());
     let server = MockServer::run(eps_count, se, Some(sp));
-    let env = Arc::new(EnvBuilder::new().cq_count(1).name_prefix("test_pd").build());
+    let env = Arc::new(
+        EnvBuilder::new()
+            .cq_count(1)
+            .name_prefix(thd_name!("test_pd"))
+            .build(),
+    );
     let eps: Vec<String> = server
         .bind_addrs()
         .into_iter()

--- a/tests/raftstore/server.rs
+++ b/tests/raftstore/server.rs
@@ -17,7 +17,7 @@ use std::sync::{mpsc, Arc, RwLock};
 use std::time::Duration;
 use std::boxed::FnBox;
 
-use grpc::Environment;
+use grpc::EnvBuilder;
 use tempdir::TempDir;
 
 use super::cluster::{Cluster, Simulator};
@@ -64,13 +64,19 @@ pub struct ServerCluster {
 
 impl ServerCluster {
     pub fn new(pd_client: Arc<TestPdClient>) -> ServerCluster {
+        let env = Arc::new(
+            EnvBuilder::new()
+                .cq_count(1)
+                .name_prefix(thd_name!("server-cluster"))
+                .build(),
+        );
         ServerCluster {
             metas: HashMap::new(),
             addrs: HashMap::new(),
             pd_client: pd_client,
             storages: HashMap::new(),
             snap_paths: HashMap::new(),
-            raft_client: RaftClient::new(Arc::new(Environment::new(1)), Config::default()),
+            raft_client: RaftClient::new(env, Config::default()),
         }
     }
 }

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -93,5 +93,5 @@ pub fn init_log() {
         .unwrap_or_else(|_| "debug".to_owned()));
     let writer = output.map(|f| Mutex::new(File::create(f).unwrap()));
     // we don't mind set it multiple times.
-    let _ = logger::init_log(CaseTraceLogger { f: writer }, level);
+    let _ = logger::init_log_for_tikv_only(CaseTraceLogger { f: writer }, level);
 }


### PR DESCRIPTION
This pr removes log from dependency crates like tokio-core in tests and fix thread name to make sure all logs are shown when a case fails.