### PR TITLE
copr: use macro to generate eval function

### DIFF
--- a/src/coprocessor/dag/expr/fncall.rs
+++ b/src/coprocessor/dag/expr/fncall.rs
@@ -11,8 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
+
 use tipb::expression::ScalarFuncSig;
-use super::{FnCall, Result};
+
+use coprocessor::codec::Datum;
+use coprocessor::codec::mysql::{self, Decimal, Duration, Json, Time};
+use super::{Error, FnCall, Result, StatementContext};
+use super::compare::CmpOp;
 
 impl FnCall {
     pub fn check_args(sig: ScalarFuncSig, args: usize) -> Result<()> {
@@ -173,5 +179,310 @@ impl FnCall {
             return Err(box_err!("unexpected arguments"));
         }
         Ok(())
+    }
+}
+
+macro_rules! dispatch_call {
+    (
+        INT_CALLS {$($i_sig:ident => $i_func:ident $($i_arg:expr)*,)*}
+        REAL_CALLS {$($r_sig:ident => $r_func:ident $($r_arg:expr)*,)*}
+        DEC_CALLS {$($d_sig:ident => $d_func:ident $($d_arg:expr)*,)*}
+        BYTES_CALLS {$($b_sig:ident => $b_func:ident $($b_arg:expr)*,)*}
+        TIME_CALLS {$($t_sig:ident => $t_func:ident $($t_arg:expr)*,)*}
+        DUR_CALLS {$($u_sig:ident => $u_func:ident $($u_arg:expr)*,)*}
+        JSON_CALLS {$($j_sig:ident => $j_func:ident $($j_arg:expr)*,)*}
+    ) => {
+        impl FnCall {
+            pub fn eval_int(&self, ctx: &StatementContext, row: &[Datum]) -> Result<Option<i64>> {
+                match self.sig {
+                    $(ScalarFuncSig::$i_sig => self.$i_func(ctx, row, $($i_arg),*)),*,
+                    _ => Err(Error::UnknownSignature(self.sig))
+                }
+            }
+
+            pub fn eval_real(&self, ctx: &StatementContext, row: &[Datum]) -> Result<Option<f64>> {
+                match self.sig {
+                    $(ScalarFuncSig::$r_sig => self.$r_func(ctx, row, $($r_arg),*),)*
+                    _ => Err(Error::UnknownSignature(self.sig))
+                }
+            }
+
+            pub fn eval_decimal<'a, 'b: 'a>(
+                &'b self, ctx: &StatementContext,
+                row: &'a [Datum]
+            ) -> Result<Option<Cow<'a, Decimal>>> {
+                match self.sig {
+                    $(ScalarFuncSig::$d_sig => self.$d_func(ctx, row, $($d_arg),*),)*
+                    _ => Err(Error::UnknownSignature(self.sig))
+                }
+            }
+
+            pub fn eval_bytes<'a, 'b: 'a>(
+                &'b self,
+                ctx: &StatementContext,
+                row: &'a [Datum]
+            ) -> Result<Option<Cow<'a, Vec<u8>>>> {
+                match self.sig {
+                    $(ScalarFuncSig::$b_sig => self.$b_func(ctx, row, $($b_arg),*),)*
+                    _ => Err(Error::UnknownSignature(self.sig))
+                }
+            }
+
+            pub fn eval_time<'a, 'b: 'a>(
+                &'b self,
+                ctx: &StatementContext,
+                row: &'a [Datum]
+            ) -> Result<Option<Cow<'a, Time>>> {
+                match self.sig {
+                    $(ScalarFuncSig::$t_sig => self.$t_func(ctx, row, $($t_arg),*),)*
+                    _ => Err(Error::UnknownSignature(self.sig))
+                }
+            }
+
+            pub fn eval_duration<'a, 'b: 'a>(
+                &'b self,
+                ctx: &StatementContext,
+                row: &'a [Datum]
+            ) -> Result<Option<Cow<'a, Duration>>> {
+                match self.sig {
+                    $(ScalarFuncSig::$u_sig => self.$u_func(ctx, row, $($u_arg),*),)*
+                    _ => Err(Error::UnknownSignature(self.sig))
+                }
+            }
+
+            pub fn eval_json<'a, 'b: 'a>(
+                &'b self,
+                ctx: &StatementContext,
+                row: &'a [Datum]
+            ) -> Result<Option<Cow<'a, Json>>> {
+                match self.sig {
+                    $(ScalarFuncSig::$j_sig => self.$j_func(ctx, row, $($j_arg),*),)*
+                    _ => Err(Error::UnknownSignature(self.sig))
+                }
+            }
+
+            pub fn eval(&self, ctx: &StatementContext, row: &[Datum]) -> Result<Datum> {
+                match self.sig {
+                    $(ScalarFuncSig::$i_sig => {
+                        match self.$i_func(ctx, row, $($i_arg)*) {
+                            Ok(Some(i)) => {
+                                if mysql::has_unsigned_flag(self.tp.get_flag() as u64) {
+                                    Ok(Datum::U64(i as u64))
+                                } else {
+                                    Ok(Datum::I64(i))
+                                }
+                            }
+                            Ok(None) => Ok(Datum::Null),
+                            Err(e) => Err(e),
+                        }
+                    },)*
+                    $(ScalarFuncSig::$r_sig => {
+                        self.$r_func(ctx, row, $($r_arg)*).map(Datum::from)
+                    })*
+                    $(ScalarFuncSig::$d_sig => {
+                        self.$d_func(ctx, row, $($d_arg)*).map(Datum::from)
+                    })*
+                    $(ScalarFuncSig::$b_sig => {
+                        self.$b_func(ctx, row, $($b_arg)*).map(Datum::from)
+                    })*
+                    $(ScalarFuncSig::$t_sig => {
+                        self.$t_func(ctx, row, $($t_arg)*).map(Datum::from)
+                    })*
+                    $(ScalarFuncSig::$u_sig => {
+                        self.$u_func(ctx, row, $($u_arg)*).map(Datum::from)
+                    })*
+                    $(ScalarFuncSig::$j_sig => {
+                        self.$j_func(ctx, row, $($j_arg)*).map(Datum::from)
+                    })*
+                }
+            }
+        }
+    };
+}
+
+dispatch_call! {
+    INT_CALLS {
+        LTInt => compare_int CmpOp::LT,
+        LEInt => compare_int CmpOp::LE,
+        GTInt => compare_int CmpOp::GT,
+        GEInt => compare_int CmpOp::GE,
+        EQInt => compare_int CmpOp::EQ,
+        NEInt => compare_int CmpOp::NE,
+        NullEQInt => compare_int CmpOp::NullEQ,
+
+        LTReal => compare_real CmpOp::LT,
+        LEReal => compare_real CmpOp::LE,
+        GTReal => compare_real CmpOp::GT,
+        GEReal => compare_real CmpOp::GE,
+        EQReal => compare_real CmpOp::EQ,
+        NEReal => compare_real CmpOp::NE,
+        NullEQReal => compare_real CmpOp::NullEQ,
+
+        LTDecimal => compare_decimal CmpOp::LT,
+        LEDecimal => compare_decimal CmpOp::LE,
+        GTDecimal => compare_decimal CmpOp::GT,
+        GEDecimal => compare_decimal CmpOp::GE,
+        EQDecimal => compare_decimal CmpOp::EQ,
+        NEDecimal => compare_decimal CmpOp::NE,
+        NullEQDecimal => compare_decimal CmpOp::NullEQ,
+
+        LTString => compare_string CmpOp::LT,
+        LEString => compare_string CmpOp::LE,
+        GTString => compare_string CmpOp::GT,
+        GEString => compare_string CmpOp::GE,
+        EQString => compare_string CmpOp::EQ,
+        NEString => compare_string CmpOp::NE,
+        NullEQString => compare_string CmpOp::NullEQ,
+
+        LTTime => compare_time CmpOp::LT,
+        LETime => compare_time CmpOp::LE,
+        GTTime => compare_time CmpOp::GT,
+        GETime => compare_time CmpOp::GE,
+        EQTime => compare_time CmpOp::EQ,
+        NETime => compare_time CmpOp::NE,
+        NullEQTime => compare_time CmpOp::NullEQ,
+
+        LTDuration => compare_duration CmpOp::LT,
+        LEDuration => compare_duration CmpOp::LE,
+        GTDuration => compare_duration CmpOp::GT,
+        GEDuration => compare_duration CmpOp::GE,
+        EQDuration => compare_duration CmpOp::EQ,
+        NEDuration => compare_duration CmpOp::NE,
+        NullEQDuration => compare_duration CmpOp::NullEQ,
+
+        LTJson => compare_json CmpOp::LT,
+        LEJson => compare_json CmpOp::LE,
+        GTJson => compare_json CmpOp::GT,
+        GEJson => compare_json CmpOp::GE,
+        EQJson => compare_json CmpOp::EQ,
+        NEJson => compare_json CmpOp::NE,
+        NullEQJson => compare_json CmpOp::NullEQ,
+
+        CastIntAsInt => cast_int_as_int,
+        CastRealAsInt => cast_real_as_int,
+        CastDecimalAsInt => cast_decimal_as_int,
+        CastStringAsInt => cast_str_as_int,
+        CastTimeAsInt => cast_time_as_int,
+        CastDurationAsInt => cast_duration_as_int,
+        CastJsonAsInt => cast_json_as_int,
+
+        PlusInt => plus_int,
+        MinusInt => minus_int,
+        MultiplyInt => multiply_int,
+
+        LogicalAnd => logical_and,
+        LogicalOr => logical_or,
+        LogicalXor => logical_xor,
+
+        UnaryNot => unary_not,
+        UnaryMinusInt => unary_minus_int,
+        IntIsNull => int_is_null,
+        IntIsFalse => int_is_false,
+        RealIsTrue => real_is_true,
+        RealIsNull => real_is_null,
+        DecimalIsNull => decimal_is_null,
+        DecimalIsTrue => decimal_is_true,
+        StringIsNull => string_is_null,
+        TimeIsNull => time_is_null,
+        DurationIsNull => duration_is_null,
+
+        AbsInt => abs_int,
+        AbsUInt => abs_uint,
+        CeilIntToInt => ceil_int_to_int,
+        CeilDecToInt => ceil_dec_to_int,
+        FloorIntToInt => floor_int_to_int,
+        FloorDecToInt => floor_dec_to_int,
+
+        IfNullInt => if_null_int,
+        IfInt => if_int,
+    }
+    REAL_CALLS {
+        CastIntAsReal => cast_int_as_real,
+        CastRealAsReal => cast_real_as_real,
+        CastDecimalAsReal => cast_decimal_as_real,
+        CastStringAsReal => cast_str_as_real,
+        CastTimeAsReal => cast_time_as_real,
+        CastDurationAsReal => cast_duration_as_real,
+        CastJsonAsReal => cast_json_as_real,
+        UnaryMinusReal => unary_minus_real,
+
+        PlusReal => plus_real,
+        MinusReal => minus_real,
+        MultiplyReal => multiply_real,
+
+        AbsReal => abs_real,
+        CeilReal => ceil_real,
+        FloorReal => floor_real,
+
+        IfNullReal => if_null_real,
+        IfReal => if_real,
+    }
+    DEC_CALLS {
+        CastIntAsDecimal => cast_int_as_decimal,
+        CastRealAsDecimal => cast_real_as_decimal,
+        CastDecimalAsDecimal => cast_decimal_as_decimal,
+        CastStringAsDecimal => cast_str_as_decimal,
+        CastTimeAsDecimal => cast_time_as_decimal,
+        CastDurationAsDecimal => cast_duration_as_decimal,
+        CastJsonAsDecimal => cast_json_as_decimal,
+        UnaryMinusDecimal => unary_minus_decimal,
+
+        PlusDecimal => plus_decimal,
+        MinusDecimal => minus_decimal,
+        MultiplyDecimal => multiply_decimal,
+
+        AbsDecimal => abs_decimal,
+        CeilDecToDec => ceil_dec_to_dec,
+        CeilIntToDec => cast_int_as_decimal,
+        FloorDecToDec => floor_dec_to_dec,
+        FloorIntToDec => cast_int_as_decimal,
+
+        IfNullDecimal => if_null_decimal,
+        IfDecimal => if_decimal,
+    }
+    BYTES_CALLS {
+        CastIntAsString => cast_int_as_str,
+        CastRealAsString => cast_real_as_str,
+        CastDecimalAsString => cast_decimal_as_str,
+        CastStringAsString => cast_str_as_str,
+        CastTimeAsString => cast_time_as_str,
+        CastDurationAsString => cast_duration_as_str,
+        CastJsonAsString => cast_json_as_str,
+
+        IfNullString => if_null_string,
+        IfString => if_string,
+    }
+    TIME_CALLS {
+        CastIntAsTime => cast_int_as_time,
+        CastRealAsTime => cast_real_as_time,
+        CastDecimalAsTime => cast_decimal_as_time,
+        CastStringAsTime => cast_str_as_time,
+        CastTimeAsTime => cast_time_as_time,
+        CastDurationAsTime => cast_duration_as_time,
+        CastJsonAsTime => cast_json_as_time,
+
+        IfNullTime => if_null_time,
+        IfTime => if_time,
+    }
+    DUR_CALLS {
+        CastIntAsDuration => cast_int_as_duration,
+        CastRealAsDuration => cast_real_as_duration,
+        CastDecimalAsDuration => cast_decimal_as_duration,
+        CastStringAsDuration => cast_str_as_duration,
+        CastTimeAsDuration => cast_time_as_duration,
+        CastDurationAsDuration => cast_duration_as_duration,
+        CastJsonAsDuration => cast_json_as_duration,
+
+        IfNullDuration => if_null_duration,
+        IfDuration => if_duration,
+    }
+    JSON_CALLS {
+        CastIntAsJson => cast_int_as_json,
+        CastRealAsJson => cast_real_as_json,
+        CastDecimalAsJson => cast_decimal_as_json,
+        CastStringAsJson => cast_str_as_json,
+        CastTimeAsJson => cast_time_as_json,
+        CastDurationAsJson => cast_duration_as_json,
+        CastJsonAsJson => cast_json_as_json,
     }
 }

--- a/src/coprocessor/dag/expr/math.rs
+++ b/src/coprocessor/dag/expr/math.rs
@@ -45,6 +45,11 @@ impl FnCall {
     }
 
     #[inline]
+    pub fn abs_uint(&self, ctx: &StatementContext, row: &[Datum]) -> Result<Option<i64>> {
+        self.children[0].eval_int(ctx, row)
+    }
+
+    #[inline]
     pub fn ceil_real(&self, ctx: &StatementContext, row: &[Datum]) -> Result<Option<f64>> {
         let n = try_opt!(self.children[0].eval_real(ctx, row));
         Ok(Some(n.ceil()))
@@ -69,6 +74,11 @@ impl FnCall {
     }
 
     #[inline]
+    pub fn ceil_int_to_int(&self, ctx: &StatementContext, row: &[Datum]) -> Result<Option<i64>> {
+        self.children[0].eval_int(ctx, row)
+    }
+
+    #[inline]
     pub fn floor_real(&self, ctx: &StatementContext, row: &[Datum]) -> Result<Option<f64>> {
         let n = try_opt!(self.children[0].eval_real(ctx, row));
         Ok(Some(n.floor()))
@@ -90,6 +100,11 @@ impl FnCall {
         let d = try_opt!(self.children[0].eval_decimal(ctx, row));
         let result: Result<Decimal> = d.floor().into();
         result.map(|t| Some(Cow::Owned(t)))
+    }
+
+    #[inline]
+    pub fn floor_int_to_int(&self, ctx: &StatementContext, row: &[Datum]) -> Result<Option<i64>> {
+        self.children[0].eval_int(ctx, row)
     }
 }
 

--- a/src/coprocessor/dag/expr/mod.rs
+++ b/src/coprocessor/dag/expr/mod.rs
@@ -22,7 +22,6 @@ mod builtin_op;
 mod compare;
 mod arithmetic;
 mod math;
-use self::compare::CmpOp;
 
 use std::{error, io};
 use std::borrow::Cow;
@@ -31,7 +30,7 @@ use std::str::Utf8Error;
 
 use tipb::expression::{Expr, ExprType, FieldType, ScalarFuncSig};
 
-use coprocessor::codec::mysql::{self, Decimal, Duration, Json, Res, Time, MAX_FSP};
+use coprocessor::codec::mysql::{Decimal, Duration, Json, Res, Time, MAX_FSP};
 use coprocessor::codec::mysql::decimal::DecimalDecoder;
 use coprocessor::codec::mysql::types;
 use coprocessor::codec::Datum;
@@ -167,103 +166,7 @@ impl Expression {
         match *self {
             Expression::Constant(ref constant) => constant.eval_int(),
             Expression::ColumnRef(ref column) => column.eval_int(row),
-            Expression::ScalarFn(ref f) => match f.sig {
-                ScalarFuncSig::LTInt => f.compare_int(ctx, row, CmpOp::LT),
-                ScalarFuncSig::LEInt => f.compare_int(ctx, row, CmpOp::LE),
-                ScalarFuncSig::GTInt => f.compare_int(ctx, row, CmpOp::GT),
-                ScalarFuncSig::GEInt => f.compare_int(ctx, row, CmpOp::GE),
-                ScalarFuncSig::EQInt => f.compare_int(ctx, row, CmpOp::EQ),
-                ScalarFuncSig::NEInt => f.compare_int(ctx, row, CmpOp::NE),
-                ScalarFuncSig::NullEQInt => f.compare_int(ctx, row, CmpOp::NullEQ),
-
-                ScalarFuncSig::LTReal => f.compare_real(ctx, row, CmpOp::LT),
-                ScalarFuncSig::LEReal => f.compare_real(ctx, row, CmpOp::LE),
-                ScalarFuncSig::GTReal => f.compare_real(ctx, row, CmpOp::GT),
-                ScalarFuncSig::GEReal => f.compare_real(ctx, row, CmpOp::GE),
-                ScalarFuncSig::EQReal => f.compare_real(ctx, row, CmpOp::EQ),
-                ScalarFuncSig::NEReal => f.compare_real(ctx, row, CmpOp::NE),
-                ScalarFuncSig::NullEQReal => f.compare_real(ctx, row, CmpOp::NullEQ),
-
-                ScalarFuncSig::LTDecimal => f.compare_decimal(ctx, row, CmpOp::LT),
-                ScalarFuncSig::LEDecimal => f.compare_decimal(ctx, row, CmpOp::LE),
-                ScalarFuncSig::GTDecimal => f.compare_decimal(ctx, row, CmpOp::GT),
-                ScalarFuncSig::GEDecimal => f.compare_decimal(ctx, row, CmpOp::GE),
-                ScalarFuncSig::EQDecimal => f.compare_decimal(ctx, row, CmpOp::EQ),
-                ScalarFuncSig::NEDecimal => f.compare_decimal(ctx, row, CmpOp::NE),
-                ScalarFuncSig::NullEQDecimal => f.compare_decimal(ctx, row, CmpOp::NullEQ),
-
-                ScalarFuncSig::LTString => f.compare_string(ctx, row, CmpOp::LT),
-                ScalarFuncSig::LEString => f.compare_string(ctx, row, CmpOp::LE),
-                ScalarFuncSig::GTString => f.compare_string(ctx, row, CmpOp::GT),
-                ScalarFuncSig::GEString => f.compare_string(ctx, row, CmpOp::GE),
-                ScalarFuncSig::EQString => f.compare_string(ctx, row, CmpOp::EQ),
-                ScalarFuncSig::NEString => f.compare_string(ctx, row, CmpOp::NE),
-                ScalarFuncSig::NullEQString => f.compare_string(ctx, row, CmpOp::NullEQ),
-
-                ScalarFuncSig::LTTime => f.compare_time(ctx, row, CmpOp::LT),
-                ScalarFuncSig::LETime => f.compare_time(ctx, row, CmpOp::LE),
-                ScalarFuncSig::GTTime => f.compare_time(ctx, row, CmpOp::GT),
-                ScalarFuncSig::GETime => f.compare_time(ctx, row, CmpOp::GE),
-                ScalarFuncSig::EQTime => f.compare_time(ctx, row, CmpOp::EQ),
-                ScalarFuncSig::NETime => f.compare_time(ctx, row, CmpOp::NE),
-                ScalarFuncSig::NullEQTime => f.compare_time(ctx, row, CmpOp::NullEQ),
-
-                ScalarFuncSig::LTDuration => f.compare_duration(ctx, row, CmpOp::LT),
-                ScalarFuncSig::LEDuration => f.compare_duration(ctx, row, CmpOp::LE),
-                ScalarFuncSig::GTDuration => f.compare_duration(ctx, row, CmpOp::GT),
-                ScalarFuncSig::GEDuration => f.compare_duration(ctx, row, CmpOp::GE),
-                ScalarFuncSig::EQDuration => f.compare_duration(ctx, row, CmpOp::EQ),
-                ScalarFuncSig::NEDuration => f.compare_duration(ctx, row, CmpOp::NE),
-                ScalarFuncSig::NullEQDuration => f.compare_duration(ctx, row, CmpOp::NullEQ),
-
-                ScalarFuncSig::LTJson => f.compare_json(ctx, row, CmpOp::LT),
-                ScalarFuncSig::LEJson => f.compare_json(ctx, row, CmpOp::LE),
-                ScalarFuncSig::GTJson => f.compare_json(ctx, row, CmpOp::GT),
-                ScalarFuncSig::GEJson => f.compare_json(ctx, row, CmpOp::GE),
-                ScalarFuncSig::EQJson => f.compare_json(ctx, row, CmpOp::EQ),
-                ScalarFuncSig::NEJson => f.compare_json(ctx, row, CmpOp::NE),
-                ScalarFuncSig::NullEQJson => f.compare_json(ctx, row, CmpOp::NullEQ),
-
-                ScalarFuncSig::CastIntAsInt => f.cast_int_as_int(ctx, row),
-                ScalarFuncSig::CastRealAsInt => f.cast_real_as_int(ctx, row),
-                ScalarFuncSig::CastDecimalAsInt => f.cast_decimal_as_int(ctx, row),
-                ScalarFuncSig::CastStringAsInt => f.cast_str_as_int(ctx, row),
-                ScalarFuncSig::CastTimeAsInt => f.cast_time_as_int(ctx, row),
-                ScalarFuncSig::CastDurationAsInt => f.cast_duration_as_int(ctx, row),
-                ScalarFuncSig::CastJsonAsInt => f.cast_json_as_int(ctx, row),
-
-                ScalarFuncSig::PlusInt => f.plus_int(ctx, row),
-                ScalarFuncSig::MinusInt => f.minus_int(ctx, row),
-                ScalarFuncSig::MultiplyInt => f.multiply_int(ctx, row),
-
-                ScalarFuncSig::LogicalAnd => f.logical_and(ctx, row),
-                ScalarFuncSig::LogicalOr => f.logical_or(ctx, row),
-                ScalarFuncSig::LogicalXor => f.logical_xor(ctx, row),
-
-                ScalarFuncSig::UnaryNot => f.unary_not(ctx, row),
-                ScalarFuncSig::UnaryMinusInt => f.unary_minus_int(ctx, row),
-                ScalarFuncSig::IntIsNull => f.int_is_null(ctx, row),
-                ScalarFuncSig::IntIsFalse => f.int_is_false(ctx, row),
-                ScalarFuncSig::RealIsTrue => f.real_is_true(ctx, row),
-                ScalarFuncSig::RealIsNull => f.real_is_null(ctx, row),
-                ScalarFuncSig::DecimalIsNull => f.decimal_is_null(ctx, row),
-                ScalarFuncSig::DecimalIsTrue => f.decimal_is_true(ctx, row),
-                ScalarFuncSig::StringIsNull => f.string_is_null(ctx, row),
-                ScalarFuncSig::TimeIsNull => f.time_is_null(ctx, row),
-                ScalarFuncSig::DurationIsNull => f.duration_is_null(ctx, row),
-
-                ScalarFuncSig::AbsInt => f.abs_int(ctx, row),
-                ScalarFuncSig::AbsUInt => f.children[0].eval_int(ctx, row),
-                ScalarFuncSig::CeilIntToInt => f.children[0].eval_int(ctx, row),
-                ScalarFuncSig::CeilDecToInt => f.ceil_dec_to_int(ctx, row),
-                ScalarFuncSig::FloorIntToInt => f.children[0].eval_int(ctx, row),
-                ScalarFuncSig::FloorDecToInt => f.floor_dec_to_int(ctx, row),
-
-                ScalarFuncSig::IfNullInt => f.if_null_int(ctx, row),
-                ScalarFuncSig::IfInt => f.if_int(ctx, row),
-
-                _ => Err(Error::UnknownSignature(f.sig)),
-            },
+            Expression::ScalarFn(ref f) => f.eval_int(ctx, row),
         }
     }
 
@@ -271,29 +174,7 @@ impl Expression {
         match *self {
             Expression::Constant(ref constant) => constant.eval_real(),
             Expression::ColumnRef(ref column) => column.eval_real(row),
-            Expression::ScalarFn(ref f) => match f.sig {
-                ScalarFuncSig::CastIntAsReal => f.cast_int_as_real(ctx, row),
-                ScalarFuncSig::CastRealAsReal => f.cast_real_as_real(ctx, row),
-                ScalarFuncSig::CastDecimalAsReal => f.cast_decimal_as_real(ctx, row),
-                ScalarFuncSig::CastStringAsReal => f.cast_str_as_real(ctx, row),
-                ScalarFuncSig::CastTimeAsReal => f.cast_time_as_real(ctx, row),
-                ScalarFuncSig::CastDurationAsReal => f.cast_duration_as_real(ctx, row),
-                ScalarFuncSig::CastJsonAsReal => f.cast_json_as_real(ctx, row),
-                ScalarFuncSig::UnaryMinusReal => f.unary_minus_real(ctx, row),
-
-                ScalarFuncSig::PlusReal => f.plus_real(ctx, row),
-                ScalarFuncSig::MinusReal => f.minus_real(ctx, row),
-                ScalarFuncSig::MultiplyReal => f.multiply_real(ctx, row),
-
-                ScalarFuncSig::AbsReal => f.abs_real(ctx, row),
-                ScalarFuncSig::CeilReal => f.ceil_real(ctx, row),
-                ScalarFuncSig::FloorReal => f.floor_real(ctx, row),
-
-                ScalarFuncSig::IfNullReal => f.if_null_real(ctx, row),
-                ScalarFuncSig::IfReal => f.if_real(ctx, row),
-
-                _ => Err(Error::UnknownSignature(f.sig)),
-            },
+            Expression::ScalarFn(ref f) => f.eval_real(ctx, row),
         }
     }
 
@@ -306,31 +187,7 @@ impl Expression {
         match *self {
             Expression::Constant(ref constant) => constant.eval_decimal(),
             Expression::ColumnRef(ref column) => column.eval_decimal(row),
-            Expression::ScalarFn(ref f) => match f.sig {
-                ScalarFuncSig::CastIntAsDecimal => f.cast_int_as_decimal(ctx, row),
-                ScalarFuncSig::CastRealAsDecimal => f.cast_real_as_decimal(ctx, row),
-                ScalarFuncSig::CastDecimalAsDecimal => f.cast_decimal_as_decimal(ctx, row),
-                ScalarFuncSig::CastStringAsDecimal => f.cast_str_as_decimal(ctx, row),
-                ScalarFuncSig::CastTimeAsDecimal => f.cast_time_as_decimal(ctx, row),
-                ScalarFuncSig::CastDurationAsDecimal => f.cast_duration_as_decimal(ctx, row),
-                ScalarFuncSig::CastJsonAsDecimal => f.cast_json_as_decimal(ctx, row),
-                ScalarFuncSig::UnaryMinusDecimal => f.unary_minus_decimal(ctx, row),
-
-                ScalarFuncSig::PlusDecimal => f.plus_decimal(ctx, row),
-                ScalarFuncSig::MinusDecimal => f.minus_decimal(ctx, row),
-                ScalarFuncSig::MultiplyDecimal => f.multiply_decimal(ctx, row),
-
-                ScalarFuncSig::AbsDecimal => f.abs_decimal(ctx, row),
-                ScalarFuncSig::CeilDecToDec => f.ceil_dec_to_dec(ctx, row),
-                ScalarFuncSig::CeilIntToDec => f.cast_int_as_decimal(ctx, row),
-                ScalarFuncSig::FloorDecToDec => f.floor_dec_to_dec(ctx, row),
-                ScalarFuncSig::FloorIntToDec => f.cast_int_as_decimal(ctx, row),
-
-                ScalarFuncSig::IfNullDecimal => f.if_null_decimal(ctx, row),
-                ScalarFuncSig::IfDecimal => f.if_decimal(ctx, row),
-
-                _ => Err(Error::UnknownSignature(f.sig)),
-            },
+            Expression::ScalarFn(ref f) => f.eval_decimal(ctx, row),
         }
     }
 
@@ -342,19 +199,7 @@ impl Expression {
         match *self {
             Expression::Constant(ref constant) => constant.eval_string(),
             Expression::ColumnRef(ref column) => column.eval_string(row),
-            Expression::ScalarFn(ref f) => match f.sig {
-                ScalarFuncSig::CastIntAsString => f.cast_int_as_str(ctx, row),
-                ScalarFuncSig::CastRealAsString => f.cast_real_as_str(ctx, row),
-                ScalarFuncSig::CastDecimalAsString => f.cast_decimal_as_str(ctx, row),
-                ScalarFuncSig::CastStringAsString => f.cast_str_as_str(ctx, row),
-                ScalarFuncSig::CastTimeAsString => f.cast_time_as_str(ctx, row),
-                ScalarFuncSig::CastDurationAsString => f.cast_duration_as_str(ctx, row),
-                ScalarFuncSig::CastJsonAsString => f.cast_json_as_str(ctx, row),
-
-                ScalarFuncSig::IfNullString => f.if_null_string(ctx, row),
-                ScalarFuncSig::IfString => f.if_string(ctx, row),
-                _ => Err(Error::UnknownSignature(f.sig)),
-            },
+            Expression::ScalarFn(ref f) => f.eval_bytes(ctx, row),
         }
     }
 
@@ -366,19 +211,7 @@ impl Expression {
         match *self {
             Expression::Constant(ref constant) => constant.eval_time(),
             Expression::ColumnRef(ref column) => column.eval_time(row),
-            Expression::ScalarFn(ref f) => match f.sig {
-                ScalarFuncSig::CastIntAsTime => f.cast_int_as_time(ctx, row),
-                ScalarFuncSig::CastRealAsTime => f.cast_real_as_time(ctx, row),
-                ScalarFuncSig::CastDecimalAsTime => f.cast_decimal_as_time(ctx, row),
-                ScalarFuncSig::CastStringAsTime => f.cast_str_as_time(ctx, row),
-                ScalarFuncSig::CastTimeAsTime => f.cast_time_as_time(ctx, row),
-                ScalarFuncSig::CastDurationAsTime => f.cast_duration_as_time(ctx, row),
-                ScalarFuncSig::CastJsonAsTime => f.cast_json_as_time(ctx, row),
-
-                ScalarFuncSig::IfNullTime => f.if_null_time(ctx, row),
-                ScalarFuncSig::IfTime => f.if_time(ctx, row),
-                _ => Err(Error::UnknownSignature(f.sig)),
-            },
+            Expression::ScalarFn(ref f) => f.eval_time(ctx, row),
         }
     }
 
@@ -390,19 +223,7 @@ impl Expression {
         match *self {
             Expression::Constant(ref constant) => constant.eval_duration(),
             Expression::ColumnRef(ref column) => column.eval_duration(row),
-            Expression::ScalarFn(ref f) => match f.sig {
-                ScalarFuncSig::CastIntAsDuration => f.cast_int_as_duration(ctx, row),
-                ScalarFuncSig::CastRealAsDuration => f.cast_real_as_duration(ctx, row),
-                ScalarFuncSig::CastDecimalAsDuration => f.cast_decimal_as_duration(ctx, row),
-                ScalarFuncSig::CastStringAsDuration => f.cast_str_as_duration(ctx, row),
-                ScalarFuncSig::CastTimeAsDuration => f.cast_time_as_duration(ctx, row),
-                ScalarFuncSig::CastDurationAsDuration => f.cast_duration_as_duration(ctx, row),
-                ScalarFuncSig::CastJsonAsDuration => f.cast_json_as_duration(ctx, row),
-
-                ScalarFuncSig::IfNullDuration => f.if_null_duration(ctx, row),
-                ScalarFuncSig::IfDuration => f.if_duration(ctx, row),
-                _ => Err(Error::UnknownSignature(f.sig)),
-            },
+            Expression::ScalarFn(ref f) => f.eval_duration(ctx, row),
         }
     }
 
@@ -414,16 +235,7 @@ impl Expression {
         match *self {
             Expression::Constant(ref constant) => constant.eval_json(),
             Expression::ColumnRef(ref column) => column.eval_json(row),
-            Expression::ScalarFn(ref f) => match f.sig {
-                ScalarFuncSig::CastIntAsJson => f.cast_int_as_json(ctx, row),
-                ScalarFuncSig::CastRealAsJson => f.cast_real_as_json(ctx, row),
-                ScalarFuncSig::CastDecimalAsJson => f.cast_decimal_as_json(ctx, row),
-                ScalarFuncSig::CastStringAsJson => f.cast_str_as_json(ctx, row),
-                ScalarFuncSig::CastTimeAsJson => f.cast_time_as_json(ctx, row),
-                ScalarFuncSig::CastDurationAsJson => f.cast_duration_as_json(ctx, row),
-                ScalarFuncSig::CastJsonAsJson => f.cast_json_as_json(ctx, row),
-                _ => Err(Error::UnknownSignature(f.sig)),
-            },
+            Expression::ScalarFn(ref f) => f.eval_json(ctx, row),
         }
     }
 
@@ -459,26 +271,7 @@ impl Expression {
         match *self {
             Expression::Constant(ref constant) => Ok(constant.eval()),
             Expression::ColumnRef(ref column) => Ok(column.eval(row)),
-            Expression::ScalarFn(ref f) => {
-                let eval_int = self.eval_int(ctx, row).map(|v| {
-                    v.map_or(Datum::Null, |v| {
-                        if mysql::has_unsigned_flag(self.get_tp().get_flag() as u64) {
-                            Datum::U64(v as u64)
-                        } else {
-                            Datum::I64(v)
-                        }
-                    })
-                });
-
-                let res = filter(eval_int)
-                    .or_else(|| filter(self.eval_real(ctx, row)))
-                    .or_else(|| filter(self.eval_decimal(ctx, row)))
-                    .or_else(|| filter(self.eval_time(ctx, row)))
-                    .or_else(|| filter(self.eval_duration(ctx, row)))
-                    .or_else(|| filter(self.eval_string(ctx, row)))
-                    .or_else(|| filter(self.eval_json(ctx, row)));
-                res.unwrap_or_else(|| Err(Error::UnknownSignature(f.sig)))
-            }
+            Expression::ScalarFn(ref f) => f.eval(ctx, row),
         }
     }
 


### PR DESCRIPTION
So we don't need to write the long match twice.