### PR TITLE
tikv-server: fix capacity parsing

### DIFF
--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -303,9 +303,9 @@ fn overwrite_config_with_cmd_args(config: &mut TiKvConfig, matches: &ArgMatches)
     }
 
     if let Some(capacity_str) = matches.value_of("capacity") {
-        let capacity = capacity_str
-            .parse()
-            .unwrap_or_else(|e| fatal_stderr!("invalid capacity {}: {}", capacity_str, e));
+        let capacity = capacity_str.parse().unwrap_or_else(|e| {
+            fatal_stderr!("invalid capacity {}: {}", capacity_str, e)
+        });
         config.raft_store.capacity = capacity;
     }
 }

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -303,9 +303,9 @@ fn overwrite_config_with_cmd_args(config: &mut TiKvConfig, matches: &ArgMatches)
     }
 
     if let Some(capacity_str) = matches.value_of("capacity") {
-        let capacity = capacity_str.parse().unwrap_or_else(|e| {
-            fatal_stderr!("invalid capacity {}: {}", capacity_str, e)
-        });
+        let capacity = capacity_str
+            .parse()
+            .unwrap_or_else(|e| fatal_stderr!("invalid capacity: {}", e));
         config.raft_store.capacity = capacity;
     }
 }

--- a/src/util/config.rs
+++ b/src/util/config.rs
@@ -373,6 +373,54 @@ impl Serialize for ReadableSize {
     }
 }
 
+impl FromStr for ReadableSize {
+    type Err = &'static str;
+
+    fn from_str(size_str: &str) -> Result<ReadableSize, &'static str> {
+        let err_msg = "valid size, only KB, MB, GB, TB, PB are supported.";
+        let size_str = size_str.trim();
+        if size_str.len() < 2 {
+            // When it's a string, it should contains a unit and a number.
+            // So its length should be at least 2.
+            return Err(err_msg);
+        }
+
+        if !size_str.is_ascii() {
+            return Err("ascii str");
+        }
+
+        let mut chrs = size_str.chars();
+        let mut number_str = size_str;
+        let mut unit_char = chrs.next_back().unwrap();
+        if unit_char < '0' || unit_char > '9' {
+            number_str = chrs.as_str();
+            if unit_char == 'B' {
+                let b = chrs.next_back().unwrap();
+                if b < '0' || b > '9' {
+                    number_str = chrs.as_str();
+                    unit_char = b;
+                }
+            }
+        } else {
+            unit_char = 'B';
+        }
+
+        let unit = match unit_char {
+            'K' => KB,
+            'M' => MB,
+            'G' => GB,
+            'T' => TB,
+            'P' => PB,
+            'B' => UNIT,
+            _ => return Err(err_msg),
+        };
+        match number_str.trim().parse::<f64>() {
+            Ok(n) => Ok(ReadableSize((n * unit as f64) as u64)),
+            Err(_) => Err(err_msg),
+        }
+    }
+}
+
 impl<'de> Deserialize<'de> for ReadableSize {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -409,41 +457,9 @@ impl<'de> Deserialize<'de> for ReadableSize {
             where
                 E: de::Error,
             {
-                let err_msg = "valid size, only KB, MB, GB, TB, PB are supported.";
-                let size_str = size_str.trim();
-                if size_str.len() < 2 {
-                    // When it's a string, it should contains a unit and a number.
-                    // So its length should be at least 2.
-                    return Err(E::invalid_value(Unexpected::Str(size_str), &err_msg));
-                }
-
-                if !size_str.is_ascii() {
-                    return Err(E::invalid_value(Unexpected::Str(size_str), &"ascii str"));
-                }
-
-                let mut chrs = size_str.chars();
-                let mut unit_char = chrs.next_back().unwrap();
-                let mut number_str = chrs.as_str();
-                if unit_char == 'B' {
-                    let b = chrs.next_back().unwrap();
-                    if b < '0' || b > '9' {
-                        number_str = chrs.as_str();
-                        unit_char = b;
-                    }
-                }
-
-                let unit = match unit_char {
-                    'K' => KB,
-                    'M' => MB,
-                    'G' => GB,
-                    'T' => TB,
-                    'P' => PB,
-                    _ => return Err(E::invalid_value(Unexpected::Str(size_str), &err_msg)),
-                };
-                match number_str.trim().parse::<f64>() {
-                    Ok(n) => Ok(ReadableSize((n * unit as f64) as u64)),
-                    Err(_) => Err(E::invalid_value(Unexpected::Str(size_str), &err_msg)),
-                }
+                size_str
+                    .parse()
+                    .map_err(|e: &str| E::invalid_value(Unexpected::Str(size_str), &e))
             }
         }
 
@@ -848,6 +864,8 @@ mod test {
             ("0.5G", GB / 2),
             ("0.5M", MB / 2),
             ("0.5K", KB / 2),
+            ("23", 23),
+            ("1024B", KB),
         ];
         for (src, exp) in decode_cases {
             let src = format!("s = {:?}", src);


### PR DESCRIPTION
This pr tries to enable readable int parsing for args and print error message to stderr when log service is unavailable yet.