### PR TITLE
txn/scheduler: fix unwrap panic

### DIFF
--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -17,7 +17,7 @@ use std::cmp::Ordering;
 use std::boxed::FnBox;
 use std::time::Duration;
 
-use self::rocksdb::EngineRocksdb;
+pub use self::rocksdb::EngineRocksdb;
 use rocksdb::TablePropertiesCollection;
 use storage::{CfName, Key, Value, CF_DEFAULT, CF_LOCK, CF_WRITE};
 use kvproto::kvrpcpb::Context;

--- a/src/storage/engine/rocksdb.rs
+++ b/src/storage/engine/rocksdb.rs
@@ -105,6 +105,13 @@ impl EngineRocksdb {
             })),
         })
     }
+
+    pub fn stop(&self) {
+        let mut core = self.core.lock().unwrap();
+        if let Some(h) = core.worker.stop() {
+            h.join().unwrap();
+        }
+    }
 }
 
 impl Debug for EngineRocksdb {

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -1399,6 +1399,10 @@ impl Scheduler {
             }
 
             if let Some(cmds) = self.grouped_cmds.take() {
+                self.grouped_cmds = Some(HashMap::with_capacity_and_hasher(
+                    CMD_BATCH_SIZE,
+                    Default::default(),
+                ));
                 let batch = cmds.into_iter().map(|(hash_ctx, cids)| {
                     BATCH_COMMANDS
                         .with_label_values(&["all"])
@@ -1406,10 +1410,6 @@ impl Scheduler {
                     (hash_ctx.0, cids)
                 });
                 self.batch_get_snapshot(batch.collect());
-                self.grouped_cmds = Some(HashMap::with_capacity_and_hasher(
-                    CMD_BATCH_SIZE,
-                    Default::default(),
-                ));
             }
         }
     }

--- a/tests/storage/sync_storage.rs
+++ b/tests/storage/sync_storage.rs
@@ -26,21 +26,35 @@ pub struct SyncStorage {
 
 impl SyncStorage {
     pub fn new(config: &Config) -> SyncStorage {
-        let mut storage = Storage::new(config).unwrap();
-        storage.start(config).unwrap();
+        let storage = Storage::new(config).unwrap();
+        let mut s = SyncStorage {
+            store: storage,
+            cnt: Arc::new(AtomicUsize::new(0)),
+        };
+        s.start(config);
+        s
+    }
+
+    pub fn from_engine(engine: Box<Engine>, config: &Config) -> SyncStorage {
+        let mut s = SyncStorage::prepare(engine, config);
+        s.start(config);
+        s
+    }
+
+    pub fn prepare(engine: Box<Engine>, config: &Config) -> SyncStorage {
+        let storage = Storage::from_engine(engine, config).unwrap();
         SyncStorage {
             store: storage,
             cnt: Arc::new(AtomicUsize::new(0)),
         }
     }
 
-    pub fn from_engine(engine: Box<Engine>, config: &Config) -> SyncStorage {
-        let mut storage = Storage::from_engine(engine, config).unwrap();
-        storage.start(config).unwrap();
-        SyncStorage {
-            store: storage,
-            cnt: Arc::new(AtomicUsize::new(0)),
-        }
+    pub fn start(&mut self, config: &Config) {
+        self.store.start(config).unwrap();
+    }
+
+    pub fn get_storage(&self) -> Storage {
+        self.store.clone()
     }
 
     pub fn get_engine(&self) -> Box<Engine> {

--- a/tests/storage/test_storage.rs
+++ b/tests/storage/test_storage.rs
@@ -854,12 +854,7 @@ fn test_conflict_commands_on_fault_engine() {
         )
         .unwrap();
     async_storage
-        .async_cleanup(
-            storage.ctx.clone(),
-            make_key(&k),
-            start_ts,
-            box |_| {},
-        )
+        .async_cleanup(storage.ctx.clone(), make_key(&k), start_ts, box |_| {})
         .unwrap();
     async_storage
         .async_rollback(

--- a/tests/storage/test_storage.rs
+++ b/tests/storage/test_storage.rs
@@ -20,7 +20,7 @@ use rand::random;
 use super::sync_storage::SyncStorage;
 use kvproto::kvrpcpb::{Context, LockInfo};
 use tikv::storage::{self, make_key, Key, Mutation, Storage, ALL_CFS};
-use tikv::storage::engine::{self, Engine, TEMP_DIR};
+use tikv::storage::engine::{self, Engine, EngineRocksdb, TEMP_DIR};
 use tikv::storage::txn::{GC_BATCH_SIZE, RESOLVE_LOCK_BATCH_SIZE};
 use tikv::storage::mvcc::MAX_TXN_WRITE_SIZE;
 use tikv::storage::config::Config;
@@ -810,10 +810,71 @@ fn test_storage_1gc_with_engine(engine: Box<Engine>, ctx: Context) {
     engine.unblock_snapshot();
     rx1.recv().unwrap();
 }
+
 #[test]
 fn test_storage_1gc() {
     let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
     test_storage_1gc_with_engine(engine, Context::new());
     let (_cluster, raft_engine, ctx) = new_raft_engine(3, "");
     test_storage_1gc_with_engine(raft_engine, ctx);
+}
+
+#[test]
+fn test_conflict_commands_on_fault_engine() {
+    let engine = EngineRocksdb::new(TEMP_DIR, ALL_CFS).unwrap();
+    let box_engine = engine.clone();
+    let config = Default::default();
+    let mut store = SyncStorage::prepare(box_engine, &config);
+    let async_storage = store.get_storage();
+    let storage = AssertionStorage {
+        store: store.clone(),
+        ctx: Context::new(),
+    };
+
+    let (k, v) = (b"k".to_vec(), b"v".to_vec());
+    let start_ts = 10;
+    let commit_ts = 20;
+
+    let (tx, rx) = channel();
+    async_storage.async_prewrite(
+        storage.ctx.clone(),
+        vec![Mutation::Put((make_key(&k), v.clone()))],
+        k.clone(),
+        start_ts,
+        Default::default(),
+        box move |res| { tx.send(res).unwrap(); },
+    ).unwrap();
+    async_storage
+        .async_commit(
+            storage.ctx.clone(),
+            vec![make_key(&k)],
+            start_ts,
+            commit_ts,
+            box |_| {},
+        )
+        .unwrap();
+    async_storage
+        .async_cleanup(
+            storage.ctx.clone(),
+            make_key(&k),
+            start_ts,
+            box |_| {},
+        )
+        .unwrap();
+    async_storage
+        .async_rollback(
+            storage.ctx.clone(),
+            vec![make_key(&k)],
+            start_ts,
+            box |_| {},
+        )
+        .unwrap();
+
+    // Stop the engine,
+    engine.stop();
+    // then start the Storage, so that it recives a batch of commands that are conflict.
+    store.start(&config);
+
+    // The first command should return an error and the other will be re-scheduled.
+    rx.recv().unwrap().unwrap_err();
 }


### PR DESCRIPTION
`finish_with_err()` access `grouped_cmds` for enqueueing
conflicted commands, but the `grouped_cmds` is None.
We should restore `grouped_cmds` before further accessing.