### PR TITLE
util/panic_hook: cache elf sections for backtrace

### DIFF
--- a/src/util/panic_hook.rs
+++ b/src/util/panic_hook.rs
@@ -66,6 +66,11 @@ fn track_hook(p: &PanicInfo) {
 
 /// Exit the whole process when panic.
 pub fn set_exit_hook() {
+    // HACK! New a backtrace ahead for caching necessary elf sections of this
+    // tikv-server, in case it can not open more files during panicking
+    // which leads to no stack info (0x5648bdfe4ff2 - <no info>).
+    Backtrace::new();
+
     let orig_hook = panic::take_hook();
     panic::set_hook(box move |info: &PanicInfo| {
         if log_enabled!(LogLevel::Error) {

--- a/src/util/panic_hook.rs
+++ b/src/util/panic_hook.rs
@@ -69,6 +69,12 @@ pub fn set_exit_hook() {
     // HACK! New a backtrace ahead for caching necessary elf sections of this
     // tikv-server, in case it can not open more files during panicking
     // which leads to no stack info (0x5648bdfe4ff2 - <no info>).
+    //
+    // Crate backtrace caches debug info in a static variable `STATE`,
+    // and the `STATE` lives forever once it has been created.
+    // See more: https://github.com/alexcrichton/backtrace-rs/blob/\
+    //           597ad44b131132f17ed76bf94ac489274dd16c7f/\
+    //           src/symbolize/libbacktrace.rs#L126-L159
     Backtrace::new();
 
     let orig_hook = panic::take_hook();


### PR DESCRIPTION
New a backtrace ahead for caching necessary elf sections of this
tikv-server, in case it can not open more files during panicking
which leads to no stack info (0x5648bdfe4ff2 - \<no info\>).

The cache takes about 33,936 KB. 
