### PR TITLE
Stop thread pool before quitting scheduler

### DIFF
--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -1386,7 +1386,7 @@ impl Scheduler {
 
             for msg in msgs.drain(..) {
                 match msg {
-                    Msg::Quit => return Ok(()),
+                    Msg::Quit => return self.quit(),
                     Msg::RawCmd { cmd, cb } => self.on_receive_new_cmd(cmd, cb),
                     Msg::RetryGetSnapshots(tasks) => for (ctx, cids) in tasks {
                         self.get_snapshot(&ctx, cids);
@@ -1431,6 +1431,16 @@ impl Scheduler {
                 self.batch_get_snapshot(batch.collect());
             }
         }
+    }
+
+    fn quit(&mut self) -> Result<()> {
+        if let Err(e) = self.worker_pool.stop() {
+            return Err(Error::Other(box_err!("{:?}", e)));
+        }
+        if let Err(e) = self.high_priority_pool.stop() {
+            return Err(Error::Other(box_err!("{:?}", e)));
+        }
+        Ok(())
     }
 }
 

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -1386,7 +1386,7 @@ impl Scheduler {
 
             for msg in msgs.drain(..) {
                 match msg {
-                    Msg::Quit => return self.quit(),
+                    Msg::Quit => return self.on_quit(),
                     Msg::RawCmd { cmd, cb } => self.on_receive_new_cmd(cmd, cb),
                     Msg::RetryGetSnapshots(tasks) => for (ctx, cids) in tasks {
                         self.get_snapshot(&ctx, cids);
@@ -1433,7 +1433,7 @@ impl Scheduler {
         }
     }
 
-    fn quit(&mut self) -> Result<()> {
+    fn on_quit(&mut self) -> Result<()> {
         if let Err(e) = self.worker_pool.stop() {
             return Err(Error::Other(box_err!("{:?}", e)));
         }

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -1386,7 +1386,7 @@ impl Scheduler {
 
             for msg in msgs.drain(..) {
                 match msg {
-                    Msg::Quit => return self.on_quit(),
+                    Msg::Quit => return self.shutdown(),
                     Msg::RawCmd { cmd, cb } => self.on_receive_new_cmd(cmd, cb),
                     Msg::RetryGetSnapshots(tasks) => for (ctx, cids) in tasks {
                         self.get_snapshot(&ctx, cids);
@@ -1433,7 +1433,7 @@ impl Scheduler {
         }
     }
 
-    fn on_quit(&mut self) -> Result<()> {
+    fn shutdown(&mut self) -> Result<()> {
         if let Err(e) = self.worker_pool.stop() {
             return Err(Error::Other(box_err!("{:?}", e)));
         }


### PR DESCRIPTION
Quitting scheduler without stopping thread pool can cause potentially coredump.