### PR TITLE
copr/expr: optimize like

### DIFF
--- a/src/coprocessor/dag/expr/compare.rs
+++ b/src/coprocessor/dag/expr/compare.rs
@@ -267,15 +267,13 @@ fn like_match(target: &str, pattern: &str, escape: char, recurse_level: usize) -
                 }
             }
         }
-        let mut skip_cnt = 0;
         let next_char = loop {
             match pcs.next() {
-                Some('%') => skip_cnt += 1,
+                Some('%') => {},
                 Some('_') => {
                     if tcs.next().is_none() {
                         return Ok(false);
                     }
-                    skip_cnt += 1;
                 }
                 // So the pattern should be some thing like 'xxx%'
                 None => return Ok(true),

--- a/src/coprocessor/dag/expr/compare.rs
+++ b/src/coprocessor/dag/expr/compare.rs
@@ -288,7 +288,6 @@ fn like_match(target: &str, pattern: &str, escape: char, recurse_level: usize) -
                 }
             }
         };
-        let next_pattern = pcs.as_str();
         if recurse_level >= MAX_RECURSE_LEVEL {
             // TODO: maybe we should test if stack is actually about to overflow.
             return Err(box_err!(


### PR DESCRIPTION
This pr tries to optimize like by
- reducing recurses as many as possible
- reducing match as many as possible

According to bench, average match time is 2/3 less than before.