### PR TITLE
raft: check leader request when become_follower after recv msg with higher term

### DIFF
--- a/src/raft/raft.rs
+++ b/src/raft/raft.rs
@@ -850,7 +850,7 @@ impl<T: Storage> Raft<T> {
         if m.get_term() == 0 {
             // local message
         } else if m.get_term() > self.term {
-            let leader_id = if m.get_msg_type() == MessageType::MsgRequestVote ||
+            if m.get_msg_type() == MessageType::MsgRequestVote ||
                 m.get_msg_type() == MessageType::MsgRequestPreVote
             {
                 let force = m.get_context() == CAMPAIGN_TRANSFER;
@@ -878,10 +878,7 @@ impl<T: Storage> Raft<T> {
 
                     return Ok(());
                 }
-                INVALID_ID
-            } else {
-                m.get_from()
-            };
+            }
 
             if m.get_msg_type() == MessageType::MsgRequestPreVote ||
                 (m.get_msg_type() == MessageType::MsgRequestPreVoteResponse && !m.get_reject())
@@ -904,7 +901,11 @@ impl<T: Storage> Raft<T> {
                     m.get_from(),
                     m.get_term()
                 );
-                self.become_follower(m.get_term(), leader_id);
+                // When we recv MsgApp, MsgHeartbeat, MsgSnap with higher term, will set leader to
+                // m.From in stepFollower.
+                // When we recv other messages with higher term (MsgAppResp, MsgVote,
+                // MsgPreVoteResp), set leader to None, because we don't know if it's leader or not.
+                self.become_follower(m.get_term(), INVALID_ID);
             }
         } else if m.get_term() < self.term {
             if self.check_quorum &&

--- a/tests/raft/test_raft.rs
+++ b/tests/raft/test_raft.rs
@@ -2156,6 +2156,10 @@ fn test_free_stuck_candidate_with_check_quorum() {
     // Disrupt the leader so that the stuck peer is freed
     assert_eq!(nt.peers[&1].state, StateRole::Follower);
     assert_eq!(nt.peers[&3].term, nt.peers[&1].term);
+
+    // Vote again, should become leader this time
+    nt.send(vec![new_message(3, 3, MessageType::MsgHup, 0)]);
+    assert_eq!(nt.peers[&3].state, StateRole::Leader);
 }
 
 #[test]


### PR DESCRIPTION
see https://github.com/coreos/etcd/issues/8553 and https://github.com/coreos/etcd/pull/8339 