### PR TITLE
coprocessor/*: use util:time:instant instead of std::time::instant

### DIFF
--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -17,14 +17,14 @@ mod dag;
 pub mod select;
 pub mod codec;
 
+use std::result;
+use std::error;
+
 use kvproto::kvrpcpb::LockInfo;
 use kvproto::errorpb;
 
-use std::result;
-use std::time::Instant;
-use std::error;
-
 use storage::{engine, mvcc, txn};
+use util::time::Instant;
 
 quick_error! {
     #[derive(Debug)]

--- a/src/coprocessor/select/select.rs
+++ b/src/coprocessor/select/select.rs
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 use std::usize;
-use std::time::Instant;
 use std::rc::Rc;
 use tipb::select::{Chunk, RowMeta, SelectRequest, SelectResponse};
 use tipb::schema::ColumnInfo;
@@ -29,7 +28,7 @@ use coprocessor::{Error, Result};
 use coprocessor::endpoint::{get_chunk, get_pk, is_point, prefix_next, to_pb_error, ReqContext,
                             BATCH_ROW_COUNT, SINGLE_GROUP};
 use util::{escape, Either};
-use util::time::duration_to_ms;
+use util::time::{duration_to_ms, Instant};
 use util::collections::{HashMap, HashMapEntry as Entry, HashSet};
 use util::codec::number::NumberDecoder;
 use storage::{Key, ScanMode, Snapshot, SnapshotStore, Statistics};
@@ -103,7 +102,7 @@ impl<'a> SelectContext<'a> {
             if collected >= self.core.limit {
                 break;
             }
-            let timer = Instant::now();
+            let timer = Instant::now_coarse();
             let row_cnt = try!(self.get_rows_from_range(ran));
             debug!(
                 "fetch {} rows takes {} ms",

--- a/src/util/time.rs
+++ b/src/util/time.rs
@@ -14,7 +14,7 @@
 use std::time::{Duration, SystemTime};
 use std::thread::{self, Builder, JoinHandle};
 use std::sync::mpsc::{self, Sender};
-use std::ops::{Add, Sub};
+use std::ops::{Add, AddAssign, Sub, SubAssign};
 use std::cmp::Ordering;
 
 use time::{Duration as TimeDuration, Timespec};
@@ -335,6 +335,12 @@ impl Add<Duration> for Instant {
     }
 }
 
+impl AddAssign<Duration> for Instant {
+    fn add_assign(&mut self, rhs: Duration) {
+        *self = self.add(rhs)
+    }
+}
+
 impl Sub<Duration> for Instant {
     type Output = Instant;
 
@@ -345,6 +351,12 @@ impl Sub<Duration> for Instant {
                 Instant::MonotonicCoarse(t - TimeDuration::from_std(other).unwrap())
             }
         }
+    }
+}
+
+impl SubAssign<Duration> for Instant {
+    fn sub_assign(&mut self, rhs: Duration) {
+        *self = self.sub(rhs)
     }
 }
 
@@ -452,9 +464,27 @@ mod tests {
         assert_eq!(late_raw - zero, late_raw);
         assert_eq!(late_coarse - zero, late_coarse);
 
+        // Sub asign Duration
+        let mut tmp_late_row = late_raw;
+        tmp_late_row -= zero;
+        assert_eq!(tmp_late_row, late_raw);
+
+        let mut tmp_late_coarse = late_coarse;
+        tmp_late_coarse -= zero;
+        assert_eq!(tmp_late_coarse, late_coarse);
+
         // Add Duration.
         assert_eq!(late_raw + zero, late_raw);
         assert_eq!(late_coarse + zero, late_coarse);
+
+        // add asign
+        let mut tmp_late_row = late_raw;
+        tmp_late_row += zero;
+        assert_eq!(tmp_late_row, late_raw);
+
+        let mut tmp_coarse = late_coarse;
+        tmp_coarse += zero;
+        assert_eq!(tmp_coarse, late_coarse);
 
         // PartialEq and PartialOrd
         let ts = Timespec::new(1, 1);


### PR DESCRIPTION
@overvenus @BusyJay @hicqu PTAL