### PR TITLE
*: remove opp_neg

### DIFF
--- a/src/coprocessor/codec/mysql/decimal.rs
+++ b/src/coprocessor/codec/mysql/decimal.rs
@@ -1662,7 +1662,7 @@ enable_conv_for_int!(isize, i64);
 impl From<i64> for Decimal {
     fn from(i: i64) -> Decimal {
         let (neg, mut d) = if i < 0 {
-            (true, Decimal::from(opp_neg!(i)))
+            (true, Decimal::from(i.overflowing_neg().0 as u64))
         } else {
             (false, Decimal::from(i as u64))
         };

--- a/src/coprocessor/dag/expr/arithmetic.rs
+++ b/src/coprocessor/dag/expr/arithmetic.rs
@@ -50,12 +50,16 @@ impl FnCall {
             (true, false) => if rhs >= 0 {
                 (lhs as u64).checked_add(rhs as u64).map(|t| t as i64)
             } else {
-                (lhs as u64).checked_sub(opp_neg!(rhs)).map(|t| t as i64)
+                (lhs as u64)
+                    .checked_sub(rhs.overflowing_neg().0 as u64)
+                    .map(|t| t as i64)
             },
             (false, true) => if lhs >= 0 {
                 (lhs as u64).checked_add(rhs as u64).map(|t| t as i64)
             } else {
-                (rhs as u64).checked_sub(opp_neg!(lhs)).map(|t| t as i64)
+                (rhs as u64)
+                    .checked_sub(lhs.overflowing_neg().0 as u64)
+                    .map(|t| t as i64)
             },
             (false, false) => lhs.checked_add(rhs),
         };
@@ -93,7 +97,9 @@ impl FnCall {
             (true, false) => if rhs >= 0 {
                 (lhs as u64).checked_sub(rhs as u64).map(|t| t as i64)
             } else {
-                (lhs as u64).checked_add(opp_neg!(rhs)).map(|t| t as i64)
+                (lhs as u64)
+                    .checked_add(rhs.overflowing_neg().0 as u64)
+                    .map(|t| t as i64)
             },
             (false, true) => if lhs >= 0 {
                 (lhs as u64).checked_sub(rhs as u64).map(|t| t as i64)

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -154,30 +154,6 @@ macro_rules! defer {
     );
 }
 
-/// Get the opposite numbers of negative numbers.
-#[cfg(debug_assertions)]
-#[macro_export]
-macro_rules! opp_neg {
-    ($r:ident) => {
-        // in debug mode, if r is `i64::min_value()`, `-r` will panic.
-        // but in release mode, `-r as u64` will get `|r|`.
-        if $r == i64::min_value() {
-            i64::max_value() as u64 + 1
-        } else {
-            -$r as u64
-        }
-    };
-}
-
-/// Get the opposite numbers of negative numbers.
-#[cfg(not(debug_assertions))]
-#[macro_export]
-macro_rules! opp_neg {
-    ($r:ident) => {
-        (-$r as u64)
-    };
-}
-
 /// `wait_op!` waits for async operation. It returns `Option<Res>`
 /// after the expression get executed.
 #[macro_export]


### PR DESCRIPTION
From rust 1.7, `overflowing_neg` is supported, so we don't need `opp_neg` anymore.