### PR TITLE
raftstore: enhance sync_log

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -20,6 +20,7 @@ use std::time::{Duration, Instant};
 
 use time::Timespec;
 use rocksdb::{WriteBatch, DB};
+use rocksdb::rocksdb_options::WriteOptions;
 use protobuf::{self, Message, MessageStatic};
 use kvproto::metapb;
 use kvproto::eraftpb::{self, ConfChangeType, MessageType};
@@ -400,8 +401,10 @@ impl Peer {
             PeerState::Tombstone
         ));
         // write kv rocksdb first in case of restart happen between two write
-        try!(self.kv_engine.write(kv_wb));
-        try!(self.raft_engine.write(raft_wb));
+        let mut write_opts = WriteOptions::new();
+        write_opts.set_sync(self.cfg.sync_log);
+        try!(self.kv_engine.write_opt(kv_wb, &write_opts));
+        try!(self.raft_engine.write_opt(raft_wb, &write_opts));
 
         if self.get_store().is_initialized() {
             // If we meet panic when deleting data and raft log, the dirty data

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -245,6 +245,7 @@ impl<T, C> Store<T, C> {
         let t = Instant::now();
         let mut kv_wb = WriteBatch::new();
         let mut raft_wb = WriteBatch::new();
+        let mut applying_regions = vec![];
         try!(kv_engine.scan_cf(
             CF_RAFT,
             start_key,
@@ -276,22 +277,15 @@ impl<T, C> Store<T, C> {
                     try!(peer_storage::recover_from_applying_state(
                         &self.kv_engine,
                         &self.raft_engine,
+                        &raft_wb,
                         region_id
                     ));
-                }
-
-                let mut peer = try!(Peer::create(self, region));
-
-                if local_state.get_state() == PeerState::Applying {
                     applying_count += 1;
-                    info!(
-                        "region {:?} is applying in store {}",
-                        local_state.get_region(),
-                        self.store_id()
-                    );
-                    peer.mut_store().schedule_applying_snapshot();
+                    applying_regions.push(region.clone());
+                    return Ok(true);
                 }
 
+                let peer = try!(Peer::create(self, region));
                 self.region_ranges.insert(enc_end_key(region), region_id);
                 // No need to check duplicated here, because we use region id as the key
                 // in DB.
@@ -302,10 +296,25 @@ impl<T, C> Store<T, C> {
 
         if !kv_wb.is_empty() {
             self.kv_engine.write(kv_wb).unwrap();
+            self.kv_engine.sync_wal().unwrap();
         }
-
         if !raft_wb.is_empty() {
             self.raft_engine.write(raft_wb).unwrap();
+            self.raft_engine.sync_wal().unwrap();
+        }
+
+        // schedule applying snapshot after raft writebatch were written.
+        for region in applying_regions {
+            info!(
+                "region {:?} is applying in store {}",
+                region,
+                self.store_id()
+            );
+            let mut peer = try!(Peer::create(self, &region));
+            peer.mut_store().schedule_applying_snapshot();
+            self.region_ranges
+                .insert(enc_end_key(&region), region.get_id());
+            self.region_peers.insert(region.get_id(), peer);
         }
 
         info!(
@@ -525,7 +534,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         );
 
         let (tx, rx) = mpsc::channel();
-        let apply_runner = ApplyRunner::new(self, tx);
+        let apply_runner = ApplyRunner::new(self, tx, self.cfg.sync_log);
         self.apply_res_receiver = Some(rx);
         box_try!(self.apply_worker.start(apply_runner));
 


### PR DESCRIPTION
so now we have two rocksdb, we have two WAL.
```
raftsotre.sync-log = true means we need prevent data loss when power failure.
take raft log gc for example, we write kv WAL first, then write raft WAL,
if power failure happen, raft WAL may synced to disk, but kv WAL may not.
so we use sync-log flag here.
```
