### PR TITLE
Stop thread pool on shutdown

### DIFF
--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -470,6 +470,12 @@ impl BatchRunnable<Task> for Host {
         if let Err(e) = self.pool.stop() {
             warn!("Stop threadpool failed with {:?}", e);
         }
+        if let Err(e) = self.low_priority_pool.stop() {
+            warn!("Stop threadpool failed with {:?}", e);
+        }
+        if let Err(e) = self.high_priority_pool.stop() {
+            warn!("Stop threadpool failed with {:?}", e);
+        }
     }
 }
 

--- a/src/raftstore/store/worker/region.rs
+++ b/src/raftstore/store/worker/region.rs
@@ -303,4 +303,10 @@ impl Runnable<Task> for Runner {
             } => self.ctx.handle_destroy(region_id, start_key, end_key),
         }
     }
+
+    fn shutdown(&mut self) {
+        if let Err(e) = self.pool.stop() {
+            warn!("Stop threadpool failed with {:?}", e);
+        }
+    }
 }


### PR DESCRIPTION
Shutdown without stopping thread pool may cause potentially
core dump. However, stopping thread pool before shutdown may slow down
the shutdown process, unless we can cancel the running task, which
seems not easy to do.