### PR TITLE
src/*: use counter instead of histogram in metrics for`scan_details`

### DIFF
--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -104,7 +104,8 @@ impl Context for CopContext {
                 for (tag, count) in details {
                     COPR_SCAN_DETAILS
                         .with_label_values(&[type_str, cf, tag])
-                        .observe(count as f64 / this_statistics.count as f64);
+                        .inc_by(count as f64)
+                        .unwrap();
                 }
             }
             *this_statistics = Default::default();

--- a/src/coprocessor/metrics.rs
+++ b/src/coprocessor/metrics.rs
@@ -68,12 +68,11 @@ lazy_static! {
             exponential_buckets(1.0, 2.0, 20).unwrap()
         ).unwrap();
 
-     pub static ref COPR_SCAN_DETAILS: HistogramVec =
-         register_histogram_vec!(
+     pub static ref COPR_SCAN_DETAILS: CounterVec =
+         register_counter_vec!(
              "tikv_coprocessor_scan_details",
-             "Bucketed histogram of coprocessor scan details for each CF",
-             &["req", "cf", "tag"],
-              exponential_buckets(1.0, 2.0, 20).unwrap()
+             "Bucketed counter of coprocessor scan details for each CF",
+             &["req", "cf", "tag"]
          ).unwrap();
 
     pub static ref COPR_EXECUTOR_COUNT: CounterVec =

--- a/src/storage/metrics.rs
+++ b/src/storage/metrics.rs
@@ -79,12 +79,11 @@ lazy_static! {
             exponential_buckets(1.0, 2.0, 21).unwrap()
         ).unwrap();
 
-    pub static ref KV_COMMAND_SCAN_DETAILS: HistogramVec =
-        register_histogram_vec!(
+    pub static ref KV_COMMAND_SCAN_DETAILS: CounterVec =
+        register_counter_vec!(
             "tikv_scheudler_kv_scan_details",
-            "Bucketed histogram of kv keys scan details for each cf",
-            &["req","cf","tag"],
-              exponential_buckets(1.0, 2.0, 20).unwrap()
+            "Bucketed counter of kv keys scan details for each cf",
+            &["req","cf","tag"]
         ).unwrap();
 
     pub static ref RAWKV_COMMAND_COUNTER_VEC: CounterVec =

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -982,7 +982,8 @@ impl ThreadContext for ScheContext {
                 for (tag, count) in details {
                     KV_COMMAND_SCAN_DETAILS
                         .with_label_values(&[cmd, cf, tag])
-                        .observe(count as f64 / stat.count as f64);
+                        .inc_by(count as f64)
+                        .unwrap();
                 }
             }
         }


### PR DESCRIPTION
@BusyJay @disksing PTAL