### PR TITLE
raftstore: flush leader message ASAP

### DIFF
--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -1105,6 +1105,11 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             self.apply_worker
                 .schedule(ApplyTask::Proposals(region_proposals))
                 .unwrap();
+
+            // In most cases, if the leader proposes a message, it will also
+            // broadcast the message to other followers, so we should flush the
+            // messages ASAP.
+            self.trans.flush();
         }
 
         self.raft_metrics.ready.has_ready_region += append_res.len() as u64;


### PR DESCRIPTION
We should let the leader send message ASAP. Using 100% write YCSB test `ycsb -concurrency 200 -workload=F -duration=10m`, I see that the write performance improve a little. 

The QPS is:

|| no sync| sync|
|-|-|-|
|master| 32041.7 | 24759.2 |
|Flush| 32308.4 | 25089.6 |

I have done many YCSB tests and get the same results, so I think the performance can be improved a little.

PTAL @BusyJay @zhangjinpeng1987 