### PR TITLE
engine/metrics: move CURSOR_OVER_SEEK_BOUND_COUNTER to CFStatistics

### DIFF
--- a/src/storage/engine/metrics.rs
+++ b/src/storage/engine/metrics.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use prometheus::{exponential_buckets, Counter, CounterVec, HistogramVec};
+use prometheus::{exponential_buckets, CounterVec, HistogramVec};
 
 lazy_static! {
     pub static ref ASYNC_REQUESTS_COUNTER_VEC: CounterVec =
@@ -27,11 +27,5 @@ lazy_static! {
             "Bucketed histogram of processing successful asynchronous requests.",
             &["type"],
             exponential_buckets(0.0005, 2.0, 20).unwrap()
-        ).unwrap();
-
-    pub static ref CURSOR_OVER_SEEK_BOUND_COUNTER: Counter =
-        register_counter!(
-            "tikv_storage_engine_cursor_over_seek_bound_total",
-            "Total number of cursor next over seek bound number"
         ).unwrap();
 }

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -156,7 +156,7 @@ pub trait Iterator {
 }
 
 macro_rules! near_loop {
-    ($cond:expr, $fallback:expr,$st:expr) => ({
+    ($cond:expr, $fallback:expr, $st:expr) => ({
         let mut cnt = 0;
         while $cond {
             cnt += 1;


### PR DESCRIPTION
Hi,
    this PR would fix https://github.com/pingcap/tikv/issues/2314
@BusyJay @siddontang @hicqu  PTAL