### PR TITLE
*: unified region split message

### DIFF
--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -71,7 +71,7 @@ pub enum Msg {
         // It's an encoded key.
         // TODO: support meta key.
         split_key: Vec<u8>,
-        callback: Callback,
+        callback: Option<Callback>,
     },
 
     ReportUnreachable { region_id: u64, to_peer_id: u64 },

--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -65,18 +65,11 @@ pub enum Msg {
         on_finished: BatchCallback,
     },
 
-    // For split check
-    SplitCheckResult {
-        region_id: u64,
-        epoch: RegionEpoch,
-        // It's a data key, starts with `DATA_PREFIX_KEY`.
-        split_key: Vec<u8>,
-    },
-
     SplitRegion {
         region_id: u64,
         region_epoch: RegionEpoch,
         // It's an encoded key.
+        // TODO: support meta key.
         split_key: Vec<u8>,
         callback: Callback,
     },
@@ -103,7 +96,6 @@ impl fmt::Debug for Msg {
             Msg::RaftMessage(_) => write!(fmt, "Raft Message"),
             Msg::RaftCmd { .. } => write!(fmt, "Raft Command"),
             Msg::BatchRaftSnapCmds { .. } => write!(fmt, "Batch Raft Commands"),
-            Msg::SplitCheckResult { .. } => write!(fmt, "Split Check Result"),
             Msg::ReportUnreachable {
                 ref region_id,
                 ref to_peer_id,

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -2519,20 +2519,6 @@ impl<T: Transport, C: PdClient> mio::Handler for Store<T, C> {
                 info!("{} receive quit message", self.tag);
                 event_loop.shutdown();
             }
-            // TODO: Unified split region message.
-            Msg::SplitCheckResult {
-                region_id,
-                epoch,
-                split_key,
-            } => {
-                info!("[region {}] split check complete.", region_id);
-                self.on_prepare_split_region(
-                    region_id,
-                    epoch,
-                    keys::origin_key(split_key.as_slice()).to_vec(),
-                    None,
-                );
-            }
             Msg::ReportUnreachable {
                 region_id,
                 to_peer_id,

--- a/src/raftstore/store/worker/pd.rs
+++ b/src/raftstore/store/worker/pd.rs
@@ -45,7 +45,7 @@ pub enum Task {
         peer: metapb::Peer,
         // If true, right region derive origin region_id.
         right_derive: bool,
-        callback: Callback,
+        callback: Option<Callback>,
     },
     Heartbeat {
         region: metapb::Region,
@@ -135,7 +135,7 @@ impl<T: PdClient> Runner<T> {
         split_key: Vec<u8>,
         peer: metapb::Peer,
         right_derive: bool,
-        callback: Callback,
+        callback: Option<Callback>,
     ) {
         PD_REQ_COUNTER_VEC
             .with_label_values(&["ask split", "all"])
@@ -163,7 +163,7 @@ impl<T: PdClient> Runner<T> {
                     );
                     let region_id = region.get_id();
                     let epoch = region.take_region_epoch();
-                    send_admin_request(&ch, region_id, epoch, peer, req, Some(callback))
+                    send_admin_request(&ch, region_id, epoch, peer, req, callback)
                 }
                 Err(e) => {
                     debug!("[region {}] failed to ask split: {:?}", region.get_id(), e);

--- a/src/raftstore/store/worker/split_check.rs
+++ b/src/raftstore/store/worker/split_check.rs
@@ -255,7 +255,7 @@ fn new_split_region(region_id: u64, epoch: RegionEpoch, split_key: Vec<u8>) -> M
         region_id: region_id,
         region_epoch: epoch,
         split_key: key,
-        callback: Box::new(|_| {}),
+        callback: None,
     }
 }
 

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -943,7 +943,7 @@ impl<T: RaftStoreRouter + 'static> tikvpb_grpc::Tikv for Service<T> {
             region_id: req.get_context().get_region_id(),
             region_epoch: req.take_context().take_region_epoch(),
             split_key: Key::from_raw(req.get_split_key()).encoded().clone(),
-            callback: cb,
+            callback: Some(cb),
         };
 
         if let Err(e) = self.ch.try_send(req) {

--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -36,7 +36,6 @@ use tikv::pd::PdClient;
 use tikv::util::{escape, rocksdb, HandyRwLock};
 use tikv::util::transport::SendCh;
 use super::pd::TestPdClient;
-use tikv::raftstore::store::keys::data_key;
 use super::transport_simulate::*;
 
 // We simulate 3 or 5 nodes, each has a store.
@@ -737,7 +736,7 @@ impl<T: Simulator> Cluster<T> {
     // It's similar to `ask_split`, the difference is the msg, it sends, is `Msg::SplitRegion`,
     // and `region` will not be embedded to that msg.
     // Caller must ensure that the `split_key` is in the `region`.
-    pub fn split_region_by_key(&mut self, region: &metapb::Region, split_key: &[u8], cb: Callback) {
+    pub fn split_region(&mut self, region: &metapb::Region, split_key: &[u8], cb: Callback) {
         let leader = self.leader_of_region(region.get_id()).unwrap();
         let ch = self.sim
             .rl()
@@ -752,38 +751,7 @@ impl<T: Simulator> Cluster<T> {
         }).unwrap();
     }
 
-    fn split_region_by_split_check(
-        &mut self,
-        region: &metapb::Region,
-        split_key: &[u8],
-        _: Callback,
-    ) {
-        // Now we can't control split easily in pd, so here we use store send channel
-        // directly to send the AskSplit request.
-        let leader = self.leader_of_region(region.get_id()).unwrap();
-        let ch = self.sim
-            .rl()
-            .get_store_sendch(leader.get_store_id())
-            .unwrap();
-        ch.try_send(Msg::SplitCheckResult {
-            region_id: region.get_id(),
-            epoch: region.get_region_epoch().clone(),
-            split_key: data_key(split_key),
-        }).unwrap();
-    }
-
     pub fn must_split(&mut self, region: &metapb::Region, split_key: &[u8]) {
-        self.must_split_by(Self::split_region_by_split_check, region, split_key);
-    }
-
-    pub fn must_manual_split(&mut self, region: &metapb::Region, split_key: &[u8]) {
-        self.must_split_by(Self::split_region_by_key, region, split_key);
-    }
-
-    pub fn must_split_by<F>(&mut self, split: F, region: &metapb::Region, split_key: &[u8])
-    where
-        F: Fn(&mut Self, &metapb::Region, &[u8], Callback),
-    {
         let mut try_cnt = 0;
         let split_count = self.pd_client.get_split_count();
         loop {
@@ -799,7 +767,7 @@ impl<T: Simulator> Cluster<T> {
                     assert_eq!(left.get_end_key(), key.as_slice());
                     assert_eq!(left.take_end_key(), right.take_start_key());
                 });
-                split(self, region, split_key, check);
+                self.split_region(region, split_key, check);
             }
 
             if self.pd_client.check_split(region, split_key) &&

--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -747,7 +747,7 @@ impl<T: Simulator> Cluster<T> {
             region_id: region.get_id(),
             region_epoch: region.get_region_epoch().clone(),
             split_key: split_key.clone(),
-            callback: cb,
+            callback: Some(cb),
         }).unwrap();
     }
 

--- a/tests/raftstore/test_split_region.rs
+++ b/tests/raftstore/test_split_region.rs
@@ -133,14 +133,7 @@ fn test_server_base_split_region_right_derive() {
 }
 
 #[test]
-fn test_server_manual_split_region_right_derive() {
-    let count = 5;
-    let mut cluster = new_server_cluster(0, count);
-    test_base_split_region(&mut cluster, Cluster::must_manual_split, false);
-}
-
-#[test]
-fn test_server_manual_split_region_twice() {
+fn test_server_split_region_twice() {
     let count = 5;
     let mut cluster = new_server_cluster(0, count);
     cluster.run();
@@ -168,7 +161,7 @@ fn test_server_manual_split_region_twice() {
         assert_eq!(region2.get_end_key(), right.get_end_key());
         tx.send(right).unwrap();
     });
-    cluster.split_region_by_key(&region, split_key, c);
+    cluster.split_region(&region, split_key, c);
     let region3 = rx.recv_timeout(Duration::from_secs(5)).unwrap();
 
     cluster.must_put(split_key, b"v2");
@@ -180,7 +173,7 @@ fn test_server_manual_split_region_twice() {
         assert!(!resp.has_admin_response());
         tx1.send(()).unwrap();
     });
-    cluster.split_region_by_key(&region3, split_key, c);
+    cluster.split_region(&region3, split_key, c);
     rx1.recv_timeout(Duration::from_secs(5)).unwrap();
 }
 


### PR DESCRIPTION
Remove `SplitCheckResult` for unifying region split messages.
