### PR TITLE
debug: add a new API Compact.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,7 +399,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git#6cdeb0dba3ea3d9ffd5092246b7bced373f473d0"
+source = "git+https://github.com/pingcap/kvproto.git#b70d97d49f8aff4bda45ede251de76911e56e9ef"
 dependencies = [
  "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,7 +399,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git#c249693d0a45be6649389206d936354bff14a098"
+source = "git+https://github.com/pingcap/kvproto.git#6cdeb0dba3ea3d9ffd5092246b7bced373f473d0"
 dependencies = [
  "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,7 +399,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git#0479661bcfa014e7a720973615ded186afb61cd1"
+source = "git+https://github.com/pingcap/kvproto.git#c249693d0a45be6649389206d936354bff14a098"
 dependencies = [
  "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/raftstore/store/debug.rs
+++ b/src/raftstore/store/debug.rs
@@ -163,8 +163,8 @@ impl Debugger {
         try!(validate_db_and_cf(db, cf));
         let db = try!(self.get_db_from_type(db));
         let handle = box_try!(get_cf_handle(db, cf));
-        let start = Some(start).into_iter().find(|s| !s.is_empty());
-        let end = Some(end).into_iter().find(|s| !s.is_empty());
+        let start = if start.is_empty() { None } else { Some(start) };
+        let end = if end.is_empty() { None } else { Some(end) };
         compact_range(db, handle, start, end, false);
         Ok(())
     }

--- a/src/raftstore/store/debug.rs
+++ b/src/raftstore/store/debug.rs
@@ -163,7 +163,7 @@ impl Debugger {
         try!(validate_db_and_cf(db, cf));
         let db = try!(self.get_db_from_type(db));
         let handle = box_try!(get_cf_handle(db, cf));
-        compact_range(db, handle, Some(start), Some(end), true);
+        compact_range(db, handle, Some(start), Some(end), false);
         Ok(())
     }
 }

--- a/src/raftstore/store/debug.rs
+++ b/src/raftstore/store/debug.rs
@@ -163,7 +163,9 @@ impl Debugger {
         try!(validate_db_and_cf(db, cf));
         let db = try!(self.get_db_from_type(db));
         let handle = box_try!(get_cf_handle(db, cf));
-        compact_range(db, handle, Some(start), Some(end), false);
+        let start = Some(start).into_iter().find(|s| s.len() > 0);
+        let end = Some(end).into_iter().find(|s| s.len() > 0);
+        compact_range(db, handle, start, end, false);
         Ok(())
     }
 }

--- a/src/raftstore/store/debug.rs
+++ b/src/raftstore/store/debug.rs
@@ -12,10 +12,10 @@
 // limitations under the License.
 
 use std::{error, result};
-use kvproto::debugpb::*;
+use kvproto::debugpb::DB as DBType;
 use kvproto::{eraftpb, raft_serverpb};
 
-use rocksdb::DB as RocksDB;
+use rocksdb::DB;
 use raftstore::store::{keys, Engines, Iterable, Peekable};
 use storage::{CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
 use util::rocksdb::{compact_range, get_cf_handle};
@@ -52,15 +52,15 @@ impl Debugger {
         Debugger { engines }
     }
 
-    fn get_db_from_type(&self, db: DB) -> Result<&RocksDB> {
+    fn get_db_from_type(&self, db: DBType) -> Result<&DB> {
         match db {
-            DB::KV => Ok(&self.engines.kv_engine),
-            DB::RAFT => Ok(&self.engines.raft_engine),
-            _ => Err(box_err!("invalid DB type")),
+            DBType::KV => Ok(&self.engines.kv_engine),
+            DBType::RAFT => Ok(&self.engines.raft_engine),
+            _ => Err(box_err!("invalid DBType type")),
         }
     }
 
-    pub fn get(&self, db: DB, cf: &str, key: &[u8]) -> Result<Vec<u8>> {
+    pub fn get(&self, db: DBType, cf: &str, key: &[u8]) -> Result<Vec<u8>> {
         try!(validate_db_and_cf(db, cf));
         let db = try!(self.get_db_from_type(db));
         match db.get_value_cf(cf, key) {
@@ -159,7 +159,7 @@ impl Debugger {
     }
 
     /// Compact the cf[start..end) in the db **by manual**.
-    pub fn compact(&self, db: DB, cf: &str, start: &[u8], end: &[u8]) -> Result<()> {
+    pub fn compact(&self, db: DBType, cf: &str, start: &[u8], end: &[u8]) -> Result<()> {
         try!(validate_db_and_cf(db, cf));
         let db = try!(self.get_db_from_type(db));
         let handle = box_try!(get_cf_handle(db, cf));
@@ -168,13 +168,13 @@ impl Debugger {
     }
 }
 
-pub fn validate_db_and_cf(db: DB, cf: &str) -> Result<()> {
+pub fn validate_db_and_cf(db: DBType, cf: &str) -> Result<()> {
     match (db, cf) {
-        (DB::KV, CF_DEFAULT) |
-        (DB::KV, CF_WRITE) |
-        (DB::KV, CF_LOCK) |
-        (DB::KV, CF_RAFT) |
-        (DB::RAFT, CF_DEFAULT) => Ok(()),
+        (DBType::KV, CF_DEFAULT) |
+        (DBType::KV, CF_WRITE) |
+        (DBType::KV, CF_LOCK) |
+        (DBType::KV, CF_RAFT) |
+        (DBType::RAFT, CF_DEFAULT) => Ok(()),
         _ => Err(Error::InvalidArgument(
             format!("invalid cf {:?} for db {:?}", cf, db),
         )),
@@ -186,7 +186,6 @@ mod tests {
     use std::sync::Arc;
 
     use rocksdb::{ColumnFamilyOptions, DBOptions, Writable};
-    use kvproto::debugpb::*;
     use kvproto::metapb;
     use tempdir::TempDir;
 
@@ -198,22 +197,22 @@ mod tests {
     #[test]
     fn test_validate_db_and_cf() {
         let valid_cases = vec![
-            (DB::KV, CF_DEFAULT),
-            (DB::KV, CF_WRITE),
-            (DB::KV, CF_LOCK),
-            (DB::KV, CF_RAFT),
-            (DB::RAFT, CF_DEFAULT),
+            (DBType::KV, CF_DEFAULT),
+            (DBType::KV, CF_WRITE),
+            (DBType::KV, CF_LOCK),
+            (DBType::KV, CF_RAFT),
+            (DBType::RAFT, CF_DEFAULT),
         ];
         for (db, cf) in valid_cases {
             validate_db_and_cf(db, cf).unwrap();
         }
 
         let invalid_cases = vec![
-            (DB::RAFT, CF_WRITE),
-            (DB::RAFT, CF_LOCK),
-            (DB::RAFT, CF_RAFT),
-            (DB::INVALID, CF_DEFAULT),
-            (DB::INVALID, "BAD_CF"),
+            (DBType::RAFT, CF_WRITE),
+            (DBType::RAFT, CF_LOCK),
+            (DBType::RAFT, CF_RAFT),
+            (DBType::INVALID, CF_DEFAULT),
+            (DBType::INVALID, "BAD_CF"),
         ];
         for (db, cf) in invalid_cases {
             validate_db_and_cf(db, cf).unwrap_err();
@@ -248,8 +247,10 @@ mod tests {
         engine.put(k, v).unwrap();
         assert_eq!(&*engine.get(k).unwrap().unwrap(), v);
 
-        assert_eq!(debugger.get(DB::KV, CF_DEFAULT, k).unwrap().as_slice(), v);
-        match debugger.get(DB::KV, CF_DEFAULT, b"foo") {
+        let got = debugger.get(DBType::KV, CF_DEFAULT, k).unwrap();
+        assert_eq!(&got, v);
+
+        match debugger.get(DBType::KV, CF_DEFAULT, b"foo") {
             Err(Error::NotFound(_)) => (),
             _ => panic!("expect Error::NotFound(_)"),
         }

--- a/src/raftstore/store/debug.rs
+++ b/src/raftstore/store/debug.rs
@@ -163,8 +163,8 @@ impl Debugger {
         try!(validate_db_and_cf(db, cf));
         let db = try!(self.get_db_from_type(db));
         let handle = box_try!(get_cf_handle(db, cf));
-        let start = Some(start).into_iter().find(|s| s.len() > 0);
-        let end = Some(end).into_iter().find(|s| s.len() > 0);
+        let start = Some(start).into_iter().find(|s| !s.is_empty());
+        let end = Some(end).into_iter().find(|s| !s.is_empty());
         compact_range(db, handle, start, end, false);
         Ok(())
     }

--- a/src/raftstore/store/worker/compact.rs
+++ b/src/raftstore/store/worker/compact.rs
@@ -14,8 +14,9 @@
 use util::worker::Runnable;
 use util::rocksdb;
 use util::escape;
+use util::rocksdb::compact_range;
 
-use rocksdb::{CompactOptions, DB};
+use rocksdb::DB;
 use std::sync::Arc;
 use std::fmt::{self, Display, Formatter};
 use std::error;
@@ -66,20 +67,13 @@ impl Runner {
         start_key: Option<Vec<u8>>,
         end_key: Option<Vec<u8>>,
     ) -> Result<(), Error> {
-        let cf_handle = box_try!(rocksdb::get_cf_handle(&self.engine, &cf_name));
+        let handle = box_try!(rocksdb::get_cf_handle(&self.engine, &cf_name));
         let compact_range_timer = COMPACT_RANGE_CF
             .with_label_values(&[&cf_name])
             .start_coarse_timer();
-        let mut compact_opts = CompactOptions::new();
-        // manual compaction can concurrently run with background compaction threads.
-        compact_opts.set_exclusive_manual_compaction(false);
-        self.engine.compact_range_cf_opt(
-            cf_handle,
-            &compact_opts,
-            start_key.as_ref().map(Vec::as_slice),
-            end_key.as_ref().map(Vec::as_slice),
-        );
-
+        let start = start_key.as_ref().map(Vec::as_slice);
+        let end = end_key.as_ref().map(Vec::as_slice);
+        compact_range(&self.engine, handle, start, end, false);
         compact_range_timer.observe_duration();
         Ok(())
     }

--- a/src/raftstore/store/worker/compact.rs
+++ b/src/raftstore/store/worker/compact.rs
@@ -41,7 +41,7 @@ impl Display for Task {
 
 quick_error! {
     #[derive(Debug)]
-    enum Error {
+    pub enum Error {
         Other(err: Box<error::Error + Sync + Send>) {
             from()
             cause(err.as_ref())
@@ -60,7 +60,7 @@ impl Runner {
         Runner { engine: engine }
     }
 
-    fn compact_range_cf(
+    pub fn compact_range_cf(
         &mut self,
         cf_name: String,
         start_key: Option<Vec<u8>>,

--- a/src/server/service/debug.rs
+++ b/src/server/service/debug.rs
@@ -181,11 +181,16 @@ impl debugpb_grpc::Debug for Service {
         unimplemented!()
     }
 
-    fn compact(&self, ctx: RpcContext, mut req: CompactRequest, sink: UnarySink<CompactResponse>) {
+    fn compact(&self, ctx: RpcContext, req: CompactRequest, sink: UnarySink<CompactResponse>) {
         let debugger = self.debugger.clone();
         let f = self.pool.spawn_fn(move || {
             debugger
-                .compact(req.take_cf(), req.take_from_key(), req.take_to_key())
+                .compact(
+                    req.get_db(),
+                    req.get_cf(),
+                    req.get_from_key(),
+                    req.get_to_key(),
+                )
                 .map(|_| CompactResponse::default())
         });
         self.handle_response(ctx, sink, f, "debug_compact");

--- a/src/server/service/debug.rs
+++ b/src/server/service/debug.rs
@@ -180,4 +180,14 @@ impl debugpb_grpc::Debug for Service {
     ) {
         unimplemented!()
     }
+
+    fn compact(&self, ctx: RpcContext, mut req: CompactRequest, sink: UnarySink<CompactResponse>) {
+        let debugger = self.debugger.clone();
+        let f = self.pool.spawn_fn(move || {
+            debugger
+                .compact(req.take_cf(), req.take_from_key(), req.take_to_key())
+                .map(|_| CompactResponse::default())
+        });
+        self.handle_response(ctx, sink, f, "debug_compact");
+    }
 }

--- a/src/util/rocksdb/mod.rs
+++ b/src/util/rocksdb/mod.rs
@@ -354,11 +354,11 @@ pub fn compact_range(
     handle: &CFHandle,
     start_key: Option<&[u8]>,
     end_key: Option<&[u8]>,
-    manual: bool,
+    exclusive_manual: bool,
 ) {
     let mut compact_opts = CompactOptions::new();
-    // manual compaction can concurrently run with background compaction threads.
-    compact_opts.set_exclusive_manual_compaction(manual);
+    // `exclusive_manual == false` means manual compaction can concurrently run with this.
+    compact_opts.set_exclusive_manual_compaction(exclusive_manual);
     db.compact_range_cf_opt(handle, &compact_opts, start_key, end_key);
 }
 

--- a/src/util/rocksdb/mod.rs
+++ b/src/util/rocksdb/mod.rs
@@ -357,7 +357,8 @@ pub fn compact_range(
     exclusive_manual: bool,
 ) {
     let mut compact_opts = CompactOptions::new();
-    // `exclusive_manual == false` means manual compaction can concurrently run with this.
+    // `exclusive_manual == false` means manual compaction can
+    // concurrently run with other backgroud compactions.
     compact_opts.set_exclusive_manual_compaction(exclusive_manual);
     db.compact_range_cf_opt(handle, &compact_opts, start_key, end_key);
 }

--- a/src/util/rocksdb/mod.rs
+++ b/src/util/rocksdb/mod.rs
@@ -25,8 +25,8 @@ use std::sync::Arc;
 use std::str::FromStr;
 
 use storage::{ALL_CFS, CF_DEFAULT, CF_LOCK};
-use rocksdb::{ColumnFamilyOptions, DBCompressionType, DBOptions, ReadOptions, SliceTransform,
-              Writable, WriteBatch, DB};
+use rocksdb::{ColumnFamilyOptions, CompactOptions, DBCompressionType, DBOptions, ReadOptions,
+              SliceTransform, Writable, WriteBatch, DB};
 use rocksdb::rocksdb::supported_compression;
 use util::rocksdb::engine_metrics::{ROCKSDB_COMPRESSION_RATIO_AT_LEVEL,
                                     ROCKSDB_CUR_SIZE_ALL_MEM_TABLES, ROCKSDB_TOTAL_SST_FILES_SIZE};
@@ -346,6 +346,20 @@ pub fn roughly_cleanup_range(db: &DB, start_key: &[u8], end_key: &[u8]) -> Resul
     }
 
     Ok(())
+}
+
+/// Compact the cf in the specified range by manual or not.
+pub fn compact_range(
+    db: &DB,
+    handle: &CFHandle,
+    start_key: Option<&[u8]>,
+    end_key: Option<&[u8]>,
+    manual: bool,
+) {
+    let mut compact_opts = CompactOptions::new();
+    // manual compaction can concurrently run with background compaction threads.
+    compact_opts.set_exclusive_manual_compaction(manual);
+    db.compact_range_cf_opt(handle, &compact_opts, start_key, end_key);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add debug API Compact. The Compact is running in `Debugger.CpuPool`.
And this Compact is **by manual** and doesn't have metrics. Do we need to add metrics or share a same metrics with `CompactWorker`?