### PR TITLE
*: move out pd work from raftstore

### DIFF
--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -62,6 +62,7 @@ use tikv::util::collections::HashMap;
 use tikv::util::logger::{self, StderrLogger};
 use tikv::util::file_log::RotatingFileLogger;
 use tikv::util::transport::SendCh;
+use tikv::util::worker::FutureWorker;
 use tikv::storage::DEFAULT_ROCKSDB_SUB_DIR;
 use tikv::server::{create_raft_storage, Node, Server, DEFAULT_CLUSTER_ID};
 use tikv::server::transport::ServerRaftStoreRouter;
@@ -188,7 +189,7 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig) {
     );
     let engines = Engines::new(kv_engine.clone(), raft_engine.clone());
 
-    // Create pd client, snapshot manager, server.
+    // Create pd client and pd work, snapshot manager, server.
     let pd_client = Arc::new(pd_client);
     let (mut worker, resolver) = resolve::new_resolver(pd_client.clone())
         .unwrap_or_else(|e| fatal!("failed to start address resolver: {:?}", e));
@@ -196,6 +197,9 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig) {
         snap_path.as_path().to_str().unwrap().to_owned(),
         Some(store_sendch),
     );
+    let pd_worker = FutureWorker::new("pd worker");
+
+    // Create server
     let mut server = Server::new(
         &cfg.server,
         cfg.raft_store.region_split_size.0 as usize,
@@ -216,6 +220,7 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig) {
         trans,
         snap_mgr,
         significant_msg_receiver,
+        pd_worker,
     ).unwrap_or_else(|e| fatal!("failed to start node: {:?}", e));
     initial_metric(&cfg.metric, Some(node.id()));
 

--- a/src/pd/metrics.rs
+++ b/src/pd/metrics.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use prometheus::{exponential_buckets, Histogram};
+use prometheus::*;
 
 lazy_static! {
     pub static ref PD_SEND_MSG_HISTOGRAM: Histogram =
@@ -19,5 +19,33 @@ lazy_static! {
             "tikv_pd_msg_send_duration_seconds",
             "Bucketed histogram of PD message send duration",
              exponential_buckets(0.0005, 10.0, 7).unwrap()
+        ).unwrap();
+
+    pub static ref PD_REQ_COUNTER_VEC: CounterVec =
+        register_counter_vec!(
+            "tikv_pd_request_sent_total",
+            "Total number of pd client request sent.",
+            &["type", "status"]
+        ).unwrap();
+
+    pub static ref PD_HEARTBEAT_COUNTER_VEC: CounterVec =
+        register_counter_vec!(
+            "tikv_pd_heartbeat_sent_total",
+            "Total number of pd client heartbeat sent.",
+            &["type"]
+        ).unwrap();
+
+    pub static ref PD_VALIDATE_PEER_COUNTER_VEC: CounterVec =
+        register_counter_vec!(
+            "tikv_pd_validate_peer_total",
+            "Total number of pd worker validate peer task.",
+            &["type"]
+        ).unwrap();
+
+    pub static ref STORE_SIZE_GAUGE_VEC: GaugeVec =
+        register_gauge_vec!(
+            "tikv_store_size_bytes",
+            "Size of storage.",
+            &["type"]
         ).unwrap();
 }

--- a/src/pd/mod.rs
+++ b/src/pd/mod.rs
@@ -17,9 +17,11 @@ mod client;
 mod util;
 
 pub mod errors;
+pub mod pd;
 pub use self::errors::{Error, Result};
 pub use self::client::RpcClient;
 pub use self::util::validate_endpoints;
+pub use self::pd::{Runner as PdRunner, Task as PdTask};
 
 use kvproto::metapb;
 use kvproto::pdpb;

--- a/src/pd/pd.rs
+++ b/src/pd/pd.rs
@@ -32,7 +32,6 @@ use util::rocksdb::*;
 use pd::{PdClient, RegionStat};
 use raftstore::store::Msg;
 use raftstore::store::util::{get_region_approximate_size, is_epoch_stale};
-use raftstore::store::metrics::*;
 use raftstore::store::store::StoreInfo;
 use raftstore::store::Callback;
 use super::metrics::*;

--- a/src/raftstore/store/metrics.rs
+++ b/src/raftstore/store/metrics.rs
@@ -70,13 +70,6 @@ lazy_static! {
             &["type"]
         ).unwrap();
 
-    pub static ref STORE_SIZE_GAUGE_VEC: GaugeVec =
-        register_gauge_vec!(
-            "tikv_raftstore_store_size_bytes",
-            "Size of raftstore storage.",
-            &["type"]
-        ).unwrap();
-
     pub static ref STORE_SNAPSHOT_TRAFFIC_GAUGE_VEC: GaugeVec =
         register_gauge_vec!(
             "tikv_raftstore_snapshot_traffic_total",

--- a/src/raftstore/store/mod.rs
+++ b/src/raftstore/store/mod.rs
@@ -20,8 +20,8 @@ pub mod bootstrap;
 pub mod cmd_resp;
 pub mod util;
 pub mod debug;
+pub mod store;
 
-mod store;
 mod peer;
 mod peer_storage;
 mod snap;

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -33,7 +33,7 @@ use raft::{self, Progress, ProgressState, RawNode, Ready, SnapshotStatus, StateR
 use raftstore::{Error, Result};
 use raftstore::coprocessor::CoprocessorHost;
 use raftstore::store::Config;
-use raftstore::store::worker::{apply, PdTask, Proposal, RegionProposal};
+use raftstore::store::worker::{apply, Proposal, RegionProposal};
 use raftstore::store::worker::apply::ExecResult;
 
 use util::worker::{FutureWorker, Scheduler};
@@ -42,7 +42,7 @@ use util::Either;
 use util::time::monotonic_raw_now;
 use util::collections::{FlatMap, FlatMapValues as Values, HashSet};
 
-use pd::INVALID_ID;
+use pd::{PdTask, INVALID_ID};
 
 use super::store::{Store, StoreStat};
 use super::peer_storage::{write_peer_state, ApplySnapResult, InvokeContext, PeerStorage};

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -33,7 +33,7 @@ use kvproto::eraftpb::{ConfChangeType, MessageType};
 use kvproto::pdpb::StoreStats;
 use util::{escape, rocksdb};
 use util::time::{duration_to_sec, SlowTimer};
-use pd::PdClient;
+use pd::{PdClient, PdRunner, PdTask};
 use kvproto::raft_cmdpb::{AdminCmdType, AdminRequest, RaftCmdRequest, RaftCmdResponse,
                           StatusCmdType, StatusResponse};
 use protobuf::Message;
@@ -48,9 +48,8 @@ use storage::{CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
 use raftstore::coprocessor::CoprocessorHost;
 use raftstore::coprocessor::split_observer::SplitObserver;
 use super::worker::{ApplyRunner, ApplyTask, ApplyTaskRes, CompactRunner, CompactTask,
-                    ConsistencyCheckRunner, ConsistencyCheckTask, PdRunner, PdTask,
-                    RaftlogGcRunner, RaftlogGcTask, RegionRunner, RegionTask, SplitCheckRunner,
-                    SplitCheckTask};
+                    ConsistencyCheckRunner, ConsistencyCheckTask, RaftlogGcRunner, RaftlogGcTask,
+                    RegionRunner, RegionTask, SplitCheckRunner, SplitCheckTask};
 use super::worker::apply::{ChangePeer, ExecResult};
 use super::{util, Msg, SignificantMsg, SnapManager, SnapshotDeleter, Tick};
 use super::keys::{self, data_end_key, data_key, enc_end_key, enc_start_key};
@@ -195,6 +194,7 @@ where
 }
 
 impl<T, C> Store<T, C> {
+    #[allow(too_many_arguments)]
     pub fn new(
         ch: StoreChannel,
         meta: metapb::Store,
@@ -203,6 +203,7 @@ impl<T, C> Store<T, C> {
         trans: T,
         pd_client: Arc<C>,
         mgr: SnapManager,
+        pd_worker: FutureWorker<PdTask>,
     ) -> Result<Store<T, C>> {
         // TODO: we can get cluster meta regularly too later.
         try!(cfg.validate());
@@ -229,7 +230,7 @@ impl<T, C> Store<T, C> {
             region_worker: Worker::new("snapshot worker"),
             raftlog_gc_worker: Worker::new("raft gc worker"),
             compact_worker: Worker::new("compact worker"),
-            pd_worker: FutureWorker::new("pd worker"),
+            pd_worker: pd_worker,
             consistency_check_worker: Worker::new("consistency check worker"),
             apply_worker: Worker::new("apply worker"),
             apply_res_receiver: None,

--- a/src/raftstore/store/worker/metrics.rs
+++ b/src/raftstore/store/worker/metrics.rs
@@ -14,27 +14,6 @@
 use prometheus::{exponential_buckets, CounterVec, Histogram, HistogramVec};
 
 lazy_static! {
-    pub static ref PD_REQ_COUNTER_VEC: CounterVec =
-        register_counter_vec!(
-            "tikv_raftstore_pd_request_sent_total",
-            "Total number of pd client request sent.",
-            &["type", "status"]
-        ).unwrap();
-
-    pub static ref PD_HEARTBEAT_COUNTER_VEC: CounterVec =
-        register_counter_vec!(
-            "tikv_raftstore_pd_heartbeat_sent_total",
-            "Total number of raftstore pd client heartbeat sent.",
-            &["type"]
-        ).unwrap();
-
-    pub static ref PD_VALIDATE_PEER_COUNTER_VEC: CounterVec =
-        register_counter_vec!(
-            "tikv_raftstore_pd_validate_peer_total",
-            "Total number of raftstore pd worker validate peer task.",
-            &["type"]
-        ).unwrap();
-
     pub static ref SNAP_COUNTER_VEC: CounterVec =
         register_counter_vec!(
             "tikv_raftstore_snapshot_total",

--- a/src/raftstore/store/worker/mod.rs
+++ b/src/raftstore/store/worker/mod.rs
@@ -49,7 +49,6 @@ mod region;
 mod split_check;
 mod compact;
 mod raftlog_gc;
-mod pd;
 mod metrics;
 mod consistency_check;
 pub mod apply;
@@ -58,7 +57,6 @@ pub use self::region::{Runner as RegionRunner, Task as RegionTask};
 pub use self::split_check::{Runner as SplitCheckRunner, Task as SplitCheckTask};
 pub use self::compact::{Runner as CompactRunner, Task as CompactTask};
 pub use self::raftlog_gc::{Runner as RaftlogGcRunner, Task as RaftlogGcTask};
-pub use self::pd::{Runner as PdRunner, Task as PdTask};
 pub use self::consistency_check::{Runner as ConsistencyCheckRunner, Task as ConsistencyCheckTask};
 pub use self::apply::{Apply, ApplyMetrics, ApplyRes, Proposal, RegionProposal, Registration,
                       Runner as ApplyRunner, Task as ApplyTask, TaskRes as ApplyTaskRes};

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -20,11 +20,12 @@ use std::process;
 use mio::EventLoop;
 use rocksdb::DB;
 
-use pd::{Error as PdError, PdClient, INVALID_ID};
+use pd::{Error as PdError, PdClient, PdTask, INVALID_ID};
 use kvproto::raft_serverpb::StoreIdent;
 use kvproto::metapb;
 use protobuf::RepeatedField;
 use util::transport::SendCh;
+use util::worker::FutureWorker;
 use raftstore::store::{self, keys, Config as StoreConfig, Engines, Msg, Peekable, SignificantMsg,
                        SnapManager, Store, StoreChannel, Transport};
 use super::Result;
@@ -124,6 +125,7 @@ where
         trans: T,
         snap_mgr: SnapManager,
         significant_msg_receiver: Receiver<SignificantMsg>,
+        pd_worker: FutureWorker<PdTask>,
     ) -> Result<()>
     where
         T: Transport + 'static,
@@ -160,7 +162,8 @@ where
             engines,
             trans,
             snap_mgr,
-            significant_msg_receiver
+            significant_msg_receiver,
+            pd_worker,
         ));
         Ok(())
     }
@@ -316,6 +319,7 @@ where
         Err(box_err!("check cluster bootstrapped failed"))
     }
 
+    #[allow(too_many_arguments)]
     fn start_store<T>(
         &mut self,
         mut event_loop: EventLoop<Store<T, C>>,
@@ -324,6 +328,7 @@ where
         trans: T,
         snap_mgr: SnapManager,
         significant_msg_receiver: Receiver<SignificantMsg>,
+        pd_worker: FutureWorker<PdTask>,
     ) -> Result<()>
     where
         T: Transport + 'static,
@@ -346,7 +351,16 @@ where
                 sender,
                 significant_msg_receiver,
             };
-            let mut store = match Store::new(ch, store, cfg, engines, trans, pd_client, snap_mgr) {
+            let mut store = match Store::new(
+                ch,
+                store,
+                cfg,
+                engines,
+                trans,
+                pd_client,
+                snap_mgr,
+                pd_worker,
+            ) {
                 Err(e) => panic!("construct store {} err {:?}", store_id, e),
                 Ok(s) => s,
             };

--- a/tests/raftstore/node.rs
+++ b/tests/raftstore/node.rs
@@ -31,6 +31,7 @@ use kvproto::eraftpb::MessageType;
 use tikv::config::TiKvConfig;
 use tikv::raftstore::{Error, Result};
 use tikv::util::HandyRwLock;
+use tikv::util::worker::FutureWorker;
 use tikv::util::transport::SendCh;
 use tikv::server::transport::{RaftStoreRouter, ServerRaftStoreRouter};
 use tikv::raft::SnapshotStatus;
@@ -164,6 +165,7 @@ impl Simulator for NodeCluster {
 
         let mut event_loop = create_event_loop(&cfg.raft_store).unwrap();
         let (snap_status_sender, snap_status_receiver) = mpsc::channel();
+        let pd_worker = FutureWorker::new("pd worker");
 
         let simulate_trans = SimulateTransport::new(self.trans.clone());
         let mut node = Node::new(
@@ -191,6 +193,7 @@ impl Simulator for NodeCluster {
             simulate_trans.clone(),
             snap_mgr.clone(),
             snap_status_receiver,
+            pd_worker,
         ).unwrap();
         assert!(
             engines

--- a/tests/raftstore/node.rs
+++ b/tests/raftstore/node.rs
@@ -165,7 +165,7 @@ impl Simulator for NodeCluster {
 
         let mut event_loop = create_event_loop(&cfg.raft_store).unwrap();
         let (snap_status_sender, snap_status_receiver) = mpsc::channel();
-        let pd_worker = FutureWorker::new("pd worker");
+        let pd_worker = FutureWorker::new("test-pd-worker");
 
         let simulate_trans = SimulateTransport::new(self.trans.clone());
         let mut node = Node::new(

--- a/tests/raftstore/server.rs
+++ b/tests/raftstore/server.rs
@@ -30,7 +30,7 @@ use tikv::server::transport::RaftStoreRouter;
 use tikv::raftstore::{store, Error, Result};
 use tikv::raftstore::store::{Engines, Msg as StoreMsg, SnapManager};
 use tikv::util::transport::SendCh;
-use tikv::util::worker::Worker;
+use tikv::util::worker::{FutureWorker, Worker};
 use tikv::storage::{CfName, Engine};
 use kvproto::raft_serverpb::{self, RaftMessage};
 use kvproto::raft_cmdpb::*;
@@ -121,6 +121,7 @@ impl Simulator for ServerCluster {
         // Create pd client, snapshot manager, server.
         let (worker, resolver) = resolve::new_resolver(self.pd_client.clone()).unwrap();
         let snap_mgr = SnapManager::new(tmp_str, Some(store_sendch));
+        let pd_worker = FutureWorker::new("test-pd-worker");
         let mut server = Server::new(
             &cfg.server,
             cfg.raft_store.region_split_size.0 as usize,
@@ -149,6 +150,7 @@ impl Simulator for ServerCluster {
             simulate_trans.clone(),
             snap_mgr.clone(),
             snap_status_receiver,
+            pd_worker,
         ).unwrap();
         assert!(node_id == 0 || node_id == node.id());
         let node_id = node.id();

--- a/tests/raftstore/test_bootstrap.rs
+++ b/tests/raftstore/test_bootstrap.rs
@@ -18,6 +18,7 @@ use tikv::raftstore::store::{bootstrap_store, create_event_loop, keys, Engines, 
 use tikv::server::Node;
 use tikv::storage::{ALL_CFS, CF_RAFT};
 use tikv::util::rocksdb;
+use tikv::util::worker::FutureWorker;
 use tempdir::TempDir;
 use kvproto::metapb;
 use kvproto::raft_serverpb::RegionLocalState;
@@ -69,6 +70,7 @@ fn test_node_bootstrap_with_prepared_data() {
     );
     let snap_mgr = SnapManager::new(tmp_mgr.path().to_str().unwrap(), Some(node.get_sendch()));
     let (_, snapshot_status_receiver) = mpsc::channel();
+    let pd_worker = FutureWorker::new("test-pd-worker");
 
 
     // assume there is a node has bootstrapped the cluster and add region in pd successfully
@@ -99,6 +101,7 @@ fn test_node_bootstrap_with_prepared_data() {
         simulate_trans,
         snap_mgr,
         snapshot_status_receiver,
+        pd_worker,
     ).unwrap();
     assert!(
         engine


### PR DESCRIPTION
In order to let PD work be able to receive messages from any module, extract it from raftstore. and then I will refactor coprocessor report mechanism in https://github.com/pingcap/tikv/pull/2337