### PR TITLE
*: move significant send to raft router

### DIFF
--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -163,8 +163,8 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig) {
     let mut event_loop = store::create_event_loop(&cfg.raft_store)
         .unwrap_or_else(|e| fatal!("failed to create event loop: {:?}", e));
     let store_sendch = SendCh::new(event_loop.channel(), "raftstore");
-    let raft_router = ServerRaftStoreRouter::new(store_sendch.clone());
     let (significant_msg_sender, significant_msg_receiver) = mpsc::channel();
+    let raft_router = ServerRaftStoreRouter::new(store_sendch.clone(), significant_msg_sender);
 
     // Create kv engine, storage.
     let kv_db_opts = cfg.rocksdb.build_opt();
@@ -201,7 +201,6 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig) {
         cfg.raft_store.region_split_size.0 as usize,
         storage.clone(),
         raft_router,
-        significant_msg_sender,
         resolver,
         snap_mgr.clone(),
         Some(engines.clone()),

--- a/tests/raftstore/server.rs
+++ b/tests/raftstore/server.rs
@@ -107,9 +107,9 @@ impl Simulator for ServerCluster {
         // Initialize raftstore channels.
         let mut event_loop = store::create_event_loop(&cfg.raft_store).unwrap();
         let store_sendch = SendCh::new(event_loop.channel(), "raftstore");
-        let raft_router = ServerRaftStoreRouter::new(store_sendch.clone());
-        let sim_router = SimulateTransport::new(raft_router);
         let (snap_status_sender, snap_status_receiver) = mpsc::channel();
+        let raft_router = ServerRaftStoreRouter::new(store_sendch.clone(), snap_status_sender);
+        let sim_router = SimulateTransport::new(raft_router);
 
         // Create storage.
         let mut store =
@@ -126,7 +126,6 @@ impl Simulator for ServerCluster {
             cfg.raft_store.region_split_size.0 as usize,
             store.clone(),
             sim_router.clone(),
-            snap_status_sender,
             resolver,
             snap_mgr.clone(),
             Some(engines.clone()),


### PR DESCRIPTION
Now we use raft router and a significant sender to send messages to the raft store, this seems a little duplicated, so here move the significant sender to the raft router, so we can only use the raft router to send messages.

