### PR TITLE
tests: fix split check

### DIFF
--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -760,6 +760,14 @@ impl<T: Simulator> Cluster<T> {
                 self.reset_leader_of_region(region.get_id());
                 let key = split_key.to_vec();
                 let check = Box::new(move |mut resp: RaftCmdResponse| {
+                    if resp.get_header().has_error() {
+                        let error = resp.get_header().get_error();
+                        if error.has_stale_epoch() || error.has_not_leader() {
+                            warn!("fail to split: {:?}, ignore.", error);
+                            return;
+                        }
+                        panic!("failed to split: {:?}", error);
+                    }
                     let admin_resp = resp.mut_admin_response();
                     let split_resp = admin_resp.mut_split();
                     let mut left = split_resp.take_left();


### PR DESCRIPTION
Split may not succeed, and let it retry if possible.