### PR TITLE
tikv-ctl: set a region to tombstone.

### DIFF
--- a/src/bin/tikv-ctl.rs
+++ b/src/bin/tikv-ctl.rs
@@ -784,12 +784,14 @@ fn main() {
                 .about("set a region on the node to tombstone by manual")
                 .arg(
                     Arg::with_name("region")
+                        .required(true)
                         .short("r")
                         .takes_value(true)
                         .help("the target region"),
                 )
                 .arg(
                     Arg::with_name("pd")
+                        .required(true)
                         .short("p")
                         .takes_value(true)
                         .multiple(true)

--- a/src/bin/tikv-ctl.rs
+++ b/src/bin/tikv-ctl.rs
@@ -330,17 +330,17 @@ trait DebugExecutor {
             process::exit(-1);
         });
         match RpcClient::new(&endpoints)
-            .unwrap_or_else(perror_and_exit)
+            .unwrap_or_else(|e| perror_and_exit("RpcClient::new", e))
             .get_region_by_id(region)
             .wait()
-            .unwrap_or_else(perror_and_exit)
+            .unwrap_or_else(|e| perror_and_exit("Get region id from PD", e))
         {
             Some(mut meta_region) => {
                 let epoch = meta_region.take_region_epoch();
                 let peers = meta_region.take_peers();
                 debugger
                     .set_region_tombstone(region, epoch, peers)
-                    .unwrap_or_else(perror_and_exit);
+                    .unwrap_or_else(|e| perror_and_exit("Debugger::set_region_tombstone", e));
             }
             None => {
                 eprintln!("no such region in pd: {}", region);
@@ -374,7 +374,7 @@ trait DebugExecutor {
 
 impl DebugExecutor for DebugClient {
     fn get_local_debugger(&self) -> Option<&Debugger> {
-        unimplemented!();
+        None
     }
 
     fn get_all_meta_regions(&self) -> Vec<u64> {


### PR DESCRIPTION
This PR add a function to mark a region as tombstone.