### PR TITLE
Fix typos in transport.rs

### DIFF
--- a/src/util/transport.rs
+++ b/src/util/transport.rs
@@ -46,7 +46,7 @@ quick_error! {
 impl<T: Debug> From<NotifyError<T>> for Error {
     fn from(e: NotifyError<T>) -> Error {
         match e {
-            // ALLERT!! May cause sensitive data leak.
+            // ALERT!! May cause sensitive data leak.
             NotifyError::Full(m) => Error::Discard(format!("Failed to send {:?} due to full", m)),
             NotifyError::Closed(..) => Error::Closed,
             _ => box_err!("{:?}", e),
@@ -86,7 +86,7 @@ impl<T> Sender<T> for mpsc::SyncSender<T> {
     }
 }
 
-/// A channel that handle error with retry automatically.
+/// A channel that handles errors with retry automatically.
 pub struct RetryableSendCh<T, C> {
     ch: C,
     name: &'static str,
@@ -134,7 +134,7 @@ impl<T: Debug, C: Sender<T>> RetryableSendCh<T, C> {
                 Err(e) => return Err(e.into()),
             };
 
-            // ALLERT!! make cause sensitive data leak.
+            // ALERT!! make cause sensitive data leak.
             warn!("notify queue is full, sleep and retry sending {:?}", t);
             thread::sleep(Duration::from_millis(100));
         }


### PR DESCRIPTION
Comment and doc changes only. No logical changes.