### PR TITLE
config: add wal bytes per sync

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -232,7 +232,7 @@
 # backup-dir = "/tmp/tikv/store/backup"
 
 # Allows OS to incrementally sync WAL to disk while it is being written.
-# wal-bytes-per-sync = "1MB"
+# wal-bytes-per-sync = 0
 
 # Column Family default used to store actual data of the database.
 [rocksdb.defaultcf]
@@ -389,4 +389,4 @@
 # pin-l0-filter-and-index-blocks = true
 # compaction-pri = 0
 # read-amp-bytes-per-bit = 0
-# wal-bytes-per-sync = "1MB"
+# wal-bytes-per-sync = 0

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -231,6 +231,9 @@
 # set backup path, if not set, use "backup" under store path.
 # backup-dir = "/tmp/tikv/store/backup"
 
+# Allows OS to incrementally sync WAL to disk while it is being written.
+# wal-bytes-per-sync = "1MB"
+
 # Column Family default used to store actual data of the database.
 [rocksdb.defaultcf]
 # compression method (if any) is used to compress a block.
@@ -386,3 +389,4 @@
 # pin-l0-filter-and-index-blocks = true
 # compaction-pri = 0
 # read-amp-bytes-per-bit = 0
+# wal-bytes-per-sync = "1MB"

--- a/src/config.rs
+++ b/src/config.rs
@@ -321,6 +321,7 @@ pub struct DbConfig {
     pub info_log_roll_time: ReadableDuration,
     pub info_log_dir: String,
     pub rate_bytes_per_sec: ReadableSize,
+    pub wal_bytes_per_sync: ReadableSize,
     pub max_sub_compactions: u32,
     pub writable_file_max_buffer_size: ReadableSize,
     pub use_direct_io_for_flush_and_compaction: bool,
@@ -351,6 +352,7 @@ impl Default for DbConfig {
             info_log_roll_time: ReadableDuration::secs(0),
             info_log_dir: "".to_owned(),
             rate_bytes_per_sec: ReadableSize::kb(0),
+            wal_bytes_per_sync: ReadableSize::kb(0),
             max_sub_compactions: 1,
             writable_file_max_buffer_size: ReadableSize::mb(1),
             use_direct_io_for_flush_and_compaction: false,
@@ -399,6 +401,7 @@ impl DbConfig {
         if self.rate_bytes_per_sec.0 > 0 {
             opts.set_ratelimiter(self.rate_bytes_per_sec.0 as i64);
         }
+        opts.set_wal_bytes_per_sync(self.wal_bytes_per_sync.0 as u64);
         opts.set_max_subcompactions(self.max_sub_compactions);
         opts.set_writable_file_max_buffer_size(self.writable_file_max_buffer_size.0 as i32);
         opts.set_use_direct_io_for_flush_and_compaction(
@@ -502,6 +505,7 @@ pub struct RaftDbConfig {
     pub use_direct_io_for_flush_and_compaction: bool,
     pub enable_pipelined_write: bool,
     pub allow_concurrent_memtable_write: bool,
+    pub wal_bytes_per_sync: ReadableSize,
     pub defaultcf: RaftDefaultCfConfig,
 }
 
@@ -527,6 +531,7 @@ impl Default for RaftDbConfig {
             use_direct_io_for_flush_and_compaction: false,
             enable_pipelined_write: true,
             allow_concurrent_memtable_write: false,
+            wal_bytes_per_sync: ReadableSize::kb(0),
             defaultcf: RaftDefaultCfConfig::default(),
         }
     }
@@ -571,6 +576,8 @@ impl RaftDbConfig {
         opts.enable_pipelined_write(self.enable_pipelined_write);
         opts.allow_concurrent_memtable_write(self.allow_concurrent_memtable_write);
         opts.add_event_listener(EventListener::new("raft"));
+        opts.set_wal_bytes_per_sync(self.wal_bytes_per_sync.0 as u64);
+
         opts
     }
 

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -126,6 +126,7 @@ fn test_serde_custom_tikv_config() {
         info_log_roll_time: ReadableDuration::secs(12),
         info_log_dir: "/var".to_owned(),
         rate_bytes_per_sec: ReadableSize::kb(1),
+        wal_bytes_per_sync: ReadableSize::kb(1),
         max_sub_compactions: 12,
         writable_file_max_buffer_size: ReadableSize::mb(12),
         use_direct_io_for_flush_and_compaction: true,
@@ -272,6 +273,7 @@ fn test_serde_custom_tikv_config() {
         use_direct_io_for_flush_and_compaction: true,
         enable_pipelined_write: false,
         allow_concurrent_memtable_write: true,
+        wal_bytes_per_sync: ReadableSize::kb(1),
         defaultcf: RaftDefaultCfConfig {
             block_size: ReadableSize::kb(12),
             block_cache_size: ReadableSize::gb(12),

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -126,7 +126,7 @@ fn test_serde_custom_tikv_config() {
         info_log_roll_time: ReadableDuration::secs(12),
         info_log_dir: "/var".to_owned(),
         rate_bytes_per_sec: ReadableSize::kb(1),
-        wal_bytes_per_sync: ReadableSize::kb(1),
+        wal_bytes_per_sync: ReadableSize::mb(1),
         max_sub_compactions: 12,
         writable_file_max_buffer_size: ReadableSize::mb(12),
         use_direct_io_for_flush_and_compaction: true,
@@ -273,7 +273,7 @@ fn test_serde_custom_tikv_config() {
         use_direct_io_for_flush_and_compaction: true,
         enable_pipelined_write: false,
         allow_concurrent_memtable_write: true,
-        wal_bytes_per_sync: ReadableSize::kb(1),
+        wal_bytes_per_sync: ReadableSize::mb(1),
         defaultcf: RaftDefaultCfConfig {
             block_size: ReadableSize::kb(12),
             block_cache_size: ReadableSize::gb(12),

--- a/tests/config/test-custom.toml
+++ b/tests/config/test-custom.toml
@@ -89,6 +89,7 @@ info-log-max-size = "1KB"
 info-log-roll-time = "12s"
 info-log-dir = "/var"
 rate-bytes-per-sec = "1KB"
+wal-bytes-per-sync = "1MB"
 max-sub-compactions = 12
 writable-file-max-buffer-size = "12MB"
 use-direct-io-for-flush-and-compaction = true
@@ -235,6 +236,7 @@ writable-file-max-buffer-size = "12MB"
 use-direct-io-for-flush-and-compaction = true
 enable-pipelined-write = false
 allow-concurrent-memtable-write = true
+wal-bytes-per-sync = "1MB"
 
 [raftdb.defaultcf]
 block-size = "12KB"


### PR DESCRIPTION
Use ycsb `tidb-ycsb -concurrency 200 -workload=F -duration=10m  raw://172.16.20.1:2379`, we can find that using`wal_bytes_per_sync` can improve the 3% QPS if sync = false, but have no big effect if sync = true.

We need to do more benchmark to ensure a suitable value, so here I just add the configuration.
For `bytes_per_sync`, we can use rate limiter which sets `bytes_per_sync` to 1 MB by default.

 ||Raft 0 MB|Raft 64 KB|Raft 1 MB|
 |-|-|-|-|
 |KV 1 MB + Sync false|32038.3|32880.7|32938.9|
 |KV 0 MB + Sync false|31533.7|32876.3|32742.1|
 |KV 0 MB + Sync true|25017.8|24993.2|24492.9|

/cc @zhangjinpeng1987 @huachaohuang 