### PR TITLE
raftstore: fix stale peer check

### DIFF
--- a/src/raftstore/store/local_metrics.rs
+++ b/src/raftstore/store/local_metrics.rs
@@ -170,6 +170,7 @@ pub struct RaftMessageDropMetrics {
     pub region_no_peer: u64,
     pub region_tombstone_peer: u64,
     pub region_nonexistent: u64,
+    pub applying_snap: u64,
 }
 
 impl RaftMessageDropMetrics {
@@ -229,6 +230,13 @@ impl RaftMessageDropMetrics {
                 .inc_by(self.region_nonexistent as f64)
                 .unwrap();
             self.region_nonexistent = 0;
+        }
+        if self.applying_snap > 0 {
+            STORE_RAFT_DROPPED_MESSAGE_COUNTER_VEC
+                .with_label_values(&["applying_snap"])
+                .inc_by(self.applying_snap as f64)
+                .unwrap();
+            self.applying_snap = 0;
         }
     }
 }

--- a/src/raftstore/store/local_metrics.rs
+++ b/src/raftstore/store/local_metrics.rs
@@ -165,7 +165,6 @@ pub struct RaftMessageDropMetrics {
     pub mismatch_store_id: u64,
     pub mismatch_region_epoch: u64,
     pub stale_msg: u64,
-    pub stale_peer: u64,
     pub region_overlap: u64,
     pub region_no_peer: u64,
     pub region_tombstone_peer: u64,
@@ -188,13 +187,6 @@ impl RaftMessageDropMetrics {
                 .inc_by(self.mismatch_region_epoch as f64)
                 .unwrap();
             self.mismatch_region_epoch = 0;
-        }
-        if self.stale_peer > 0 {
-            STORE_RAFT_DROPPED_MESSAGE_COUNTER_VEC
-                .with_label_values(&["stale_peer"])
-                .inc_by(self.stale_peer as f64)
-                .unwrap();
-            self.stale_peer = 0;
         }
         if self.stale_msg > 0 {
             STORE_RAFT_DROPPED_MESSAGE_COUNTER_VEC

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -672,31 +672,18 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         // we may encounter a message with larger peer id, which means
         // current peer is stale, then we should remove current peer
         let mut has_peer = false;
-        let mut async_remove = false;
-        let mut stale_peer = None;
-        let mut initialized = false;
+        let mut state = None;
         if let Some(p) = self.region_peers.get_mut(&region_id) {
             has_peer = true;
             let target_peer_id = target.get_id();
             if p.peer_id() < target_peer_id {
-                initialized = p.get_store().is_initialized();
-                async_remove = initialized;
-                if p.is_applying_snapshot() {
-                    if !p.mut_store().cancel_applying_snap() {
-                        info!(
-                            "[region {}] Stale peer {} is applying snapshot, will destroy next \
-                             time.",
-                            region_id,
-                            p.peer_id()
-                        );
-                        self.raft_metrics.message_dropped.stale_peer += 1;
+                state = match p.maybe_destroy() {
+                    None => {
+                        self.raft_metrics.message_dropped.applying_snap += 1;
                         return Ok(false);
                     }
-                    // There is no tasks in apply worker.
-                    async_remove = false;
-                }
-                p.pending_remove = true;
-                stale_peer = Some(p.peer.clone());
+                    Some(job) => Some((job, p.peer.clone())),
+                };
             } else if p.peer_id() > target_peer_id {
                 info!(
                     "[region {}] target peer id {} is less than {}, msg maybe stale.",
@@ -708,23 +695,12 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                 return Ok(false);
             }
         }
-        if let Some(p) = stale_peer {
-            if initialized {
-                self.apply_worker
-                    .schedule(ApplyTask::destroy(region_id))
-                    .unwrap();
-            }
-            if async_remove {
-                info!(
-                    "[region {}] asking destroying stale peer {:?}",
-                    region_id,
-                    p
-                );
-                self.raft_metrics.message_dropped.stale_peer += 1;
+
+        if let Some((job, p)) = state {
+            info!("[region {}] try to destroy stale peer {:?}", region_id, p);
+            if !job.execute(self) {
                 return Ok(false);
             }
-            info!("[region {}] destroying stale peer {:?}", region_id, p);
-            self.destroy_peer(region_id, p);
             has_peer = false;
         }
 
@@ -986,32 +962,28 @@ impl<T: Transport, C: PdClient> Store<T, C> {
     fn handle_gc_peer_msg(&mut self, msg: &RaftMessage) {
         let region_id = msg.get_region_id();
 
-        let mut need_remove = false;
-        let mut async_remove = true;
+        let mut job = None;
         if let Some(peer) = self.region_peers.get_mut(&region_id) {
+            assert_eq!(peer.peer, *msg.get_to_peer());
             // TODO: need checking peer id changed?
             let from_epoch = msg.get_region_epoch();
             if util::is_epoch_stale(peer.get_store().region.get_region_epoch(), from_epoch) {
                 // TODO: ask pd to guarantee we are stale now.
                 info!(
-                    "[region {}] peer {:?} receives gc message, remove",
+                    "[region {}] peer {:?} receives gc message, trying to remove",
                     region_id,
                     msg.get_to_peer()
                 );
-                need_remove = true;
-                peer.pending_remove = true;
-                async_remove = peer.get_store().is_initialized();
+                job = peer.maybe_destroy();
+                if job.is_none() {
+                    self.raft_metrics.message_dropped.applying_snap += 1;
+                    return;
+                }
             }
         }
 
-        if need_remove {
-            if async_remove {
-                self.apply_worker
-                    .schedule(ApplyTask::destroy(region_id))
-                    .unwrap();
-            } else {
-                self.destroy_peer(region_id, msg.get_to_peer().clone());
-            }
+        if let Some(job) = job {
+            job.execute(self);
         }
     }
 
@@ -1199,7 +1171,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         slow_log!(t, "{} on {} regions raft ready", self.tag, pending_count);
     }
 
-    fn destroy_peer(&mut self, region_id: u64, peer: metapb::Peer) {
+    pub fn destroy_peer(&mut self, region_id: u64, peer: metapb::Peer) {
         // Can we destroy it in another thread later?
 
         // Suppose cluster removes peer a from store and then add a new


### PR DESCRIPTION
If a TiKV is inactive for a while (block on IO for instance), all the replicas on the store may be removed by pd. So when the inactive monitor checks pd and finds out that a replica is removed, it will schedule GC message to raftstore. However, if the replica is applying snapshot at that time, TiKV will panic because a peer in applying state shouldn't be removed for safety.

This pr fixes it by checking if a peer is applying snapshot before accepting GC message.