### PR TITLE
Document defer macro LIFO behavior

### DIFF
--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -147,6 +147,7 @@ macro_rules! thd_name {
 /// Simulating go's defer.
 ///
 /// Please note that, different from go, this defer is bound to scope.
+/// When exiting the scope, its deferred calls are executed in last-in-first-out order.
 #[macro_export]
 macro_rules! defer {
     ($t:expr) => (


### PR DESCRIPTION
Documenting perhaps counter intuitive behavior of the macro. It is in compliance with the behavior of golangs defer. Confirmed with the experimient here https://play.rust-lang.org/?gist=6cf3013b12610150436c21bc2d5459ad&version=nightly