### PR TITLE
[WIP] Add Import Service and IngestSST/UploadSST RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
  "futures-cpupool 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)",
- "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=huachao/upload)",
+ "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=huachao/ingest)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -416,7 +416,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git?branch=huachao/upload#578c9750a8fc4a95462122efec55d8914a96e719"
+source = "git+https://github.com/pingcap/kvproto.git?branch=huachao/ingest#42ec27f967e8ec060b2d6a88b2536ef27e0a574c"
 dependencies = [
  "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1134,7 +1134,7 @@ dependencies = [
 "checksum jemalloc-sys 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=huachao/upload)" = "<none>"
+"checksum kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=huachao/ingest)" = "<none>"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git?branch=huachao/upload#be72d7fe91a545ecb99128fa9c0ea50abd03caea"
+source = "git+https://github.com/pingcap/kvproto.git?branch=huachao/upload#578c9750a8fc4a95462122efec55d8914a96e719"
 dependencies = [
  "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,6 +785,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -1049,6 +1054,10 @@ dependencies = [
 name = "uuid"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "vec_map"
@@ -1173,6 +1182,7 @@ dependencies = [
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 "checksum semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+"checksum serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"
 "checksum serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c2f530d36fb84ec48fb7146936881f026cdbf4892028835fd9398475f82c1bb4"
 "checksum serde_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "10552fad5500771f3902d0c5ba187c5881942b811b7ba0d8fbbfbf84d80806d3"
 "checksum serde_derive_internals 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37aee4e0da52d801acfbc0cc219eb1eda7142112339726e427926a6f6ee65d3a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,7 @@ dependencies = [
  "toml 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "utime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -415,7 +416,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git?branch=huachao/upload#80a04a6bab3242fc1986f8d1a99d571213ed8ecb"
+source = "git+https://github.com/pingcap/kvproto.git?branch=huachao/upload#be72d7fe91a545ecb99128fa9c0ea50abd03caea"
 dependencies = [
  "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1045,6 +1046,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "vec_map"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,6 +1206,7 @@ dependencies = [
 "checksum url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eeb819346883532a271eb626deb43c4a1bb4c4dd47c519bd78137c3e72a4fe27"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum utime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4a9c0ddf7a5a39cd0c316dac124303d71fa197f8607027546c3be3e1c6f7bd9b"
+"checksum uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7cfec50b0842181ba6e713151b72f4ec84a6a7e2c9c8a8a3ffc37bb1cd16b231"
 "checksum vec_map 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8cdc8b93bd0198ed872357fb2e667f7125646b1762f16d60b2c96350d361897"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
  "futures-cpupool 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)",
- "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=huachao/upload)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -415,7 +415,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git#146f02770efa42296666ca2e6974c6cb48fecdcf"
+source = "git+https://github.com/pingcap/kvproto.git?branch=huachao/upload#80a04a6bab3242fc1986f8d1a99d571213ed8ecb"
 dependencies = [
  "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1119,7 +1119,7 @@ dependencies = [
 "checksum jemalloc-sys 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)" = "<none>"
+"checksum kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=huachao/upload)" = "<none>"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ grpcio = "0.1"
 rustc-serialize = "0.3"
 murmur3 = "0.4.0"
 futures-cpupool = "0.1"
+uuid = "0.4"
 
 [target.'cfg(unix)'.dependencies]
 signal = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ grpcio = "0.1"
 rustc-serialize = "0.3"
 murmur3 = "0.4.0"
 futures-cpupool = "0.1"
-uuid = "0.4"
+uuid = { version = "0.4", features = ["serde", "v4"] }
 
 [target.'cfg(unix)'.dependencies]
 signal = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ git = "https://github.com/pingcap/rust-rocksdb.git"
 
 [dependencies.kvproto]
 git = "https://github.com/pingcap/kvproto.git"
-branch = "huachao/upload"
+branch = "huachao/ingest"
 
 [dependencies.tipb]
 git = "https://github.com/pingcap/tipb.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ git = "https://github.com/pingcap/rust-rocksdb.git"
 
 [dependencies.kvproto]
 git = "https://github.com/pingcap/kvproto.git"
+branch = "huachao/upload"
 
 [dependencies.tipb]
 git = "https://github.com/pingcap/tipb.git"

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -38,6 +38,9 @@
 # stack size of endpoint, complicated tasks may involve very deep recursion.
 # end-point-stack-size = "10MB"
 
+# size of thread pool for import service.
+# import-concurrency = 2
+
 # set attributes about this server, e.g. { zone = "us-west-1", disk = "ssd" }.
 # labels = {}
 

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -211,9 +211,9 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig) {
         raft_router,
         resolver,
         snap_mgr.clone(),
-        upload_dir.clone(),
         pd_worker.scheduler(),
         Some(engines.clone()),
+        upload_dir.clone(),
     ).unwrap_or_else(|e| fatal!("failed to create server: {:?}", e));
     let trans = server.transport();
 

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -226,6 +226,7 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig) {
         snap_mgr,
         significant_msg_receiver,
         pd_worker,
+        upload_dir,
     ).unwrap_or_else(|e| fatal!("failed to start node: {:?}", e));
     initial_metric(&cfg.metric, Some(node.id()));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ extern crate sys_info;
 extern crate utime;
 #[macro_use]
 extern crate fail;
+extern crate uuid;
 
 #[macro_use]
 pub mod util;

--- a/src/raftstore/store/mod.rs
+++ b/src/raftstore/store/mod.rs
@@ -25,6 +25,7 @@ pub mod store;
 mod peer;
 mod peer_storage;
 mod snap;
+mod upload;
 mod worker;
 mod metrics;
 mod local_metrics;
@@ -41,3 +42,4 @@ pub use self::peer_storage::{do_snapshot, CacheQueryStats, PeerStorage, SnapStat
                              RAFT_INIT_LOG_INDEX, RAFT_INIT_LOG_TERM};
 pub use self::snap::{check_abort, copy_snapshot, ApplyOptions, SnapEntry, SnapKey, SnapManager,
                      Snapshot, SnapshotDeleter, SnapshotStatistics};
+pub use self::upload::Uploader;

--- a/src/raftstore/store/mod.rs
+++ b/src/raftstore/store/mod.rs
@@ -42,4 +42,4 @@ pub use self::peer_storage::{do_snapshot, CacheQueryStats, PeerStorage, SnapStat
                              RAFT_INIT_LOG_INDEX, RAFT_INIT_LOG_TERM};
 pub use self::snap::{check_abort, copy_snapshot, ApplyOptions, SnapEntry, SnapKey, SnapManager,
                      Snapshot, SnapshotDeleter, SnapshotStatistics};
-pub use self::upload::Uploader;
+pub use self::upload::{UploadDir, Uploader};

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -1138,7 +1138,9 @@ impl Peer {
         for r in req.get_requests() {
             match r.get_cmd_type() {
                 CmdType::Get | CmdType::Snap => is_read = true,
-                CmdType::Delete | CmdType::Put | CmdType::DeleteRange => is_write = true,
+                CmdType::Delete | CmdType::Put | CmdType::DeleteRange | CmdType::IngestSST => {
+                    is_write = true
+                }
                 CmdType::Prewrite | CmdType::Invalid => {
                     return Err(box_err!(
                         "invalid cmd type {:?}, message maybe currupted",
@@ -1698,6 +1700,7 @@ impl Peer {
                 CmdType::Put |
                 CmdType::Delete |
                 CmdType::DeleteRange |
+                CmdType::IngestSST |
                 CmdType::Invalid => unreachable!(),
             };
 

--- a/src/raftstore/store/upload.rs
+++ b/src/raftstore/store/upload.rs
@@ -1,0 +1,239 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::{Error, ErrorKind, Result, Write};
+use std::fmt::{self, Display, Formatter};
+use std::fs::{self, File};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::collections::HashMap;
+
+use crc::crc32::{self, Hasher32};
+use kvproto::importpb::*;
+
+pub type Token = usize;
+
+pub struct Uploader {
+    dir: UploadDir,
+    token: AtomicUsize,
+    files: Mutex<HashMap<Token, UploadFile>>,
+}
+
+impl Uploader {
+    pub fn new<P: AsRef<Path>>(root: P) -> Result<Uploader> {
+        Ok(Uploader {
+            dir: UploadDir::new(root)?,
+            token: AtomicUsize::new(1),
+            files: Mutex::new(HashMap::new()),
+        })
+    }
+
+    pub fn token(&self) -> Token {
+        self.token.fetch_add(1, Ordering::SeqCst) as Token
+    }
+
+    pub fn create(&self, token: Token, meta: &SSTMeta) -> Result<()> {
+        match self.dir.create(meta.clone()) {
+            Ok(f) => {
+                info!("create {}", f);
+                self.insert(token, f);
+                Ok(())
+            }
+            Err(e) => {
+                error!("create {:?}: {:?}", meta, e);
+                Err(e)
+            }
+        }
+    }
+
+    pub fn append(&self, token: Token, data: &[u8]) -> Result<()> {
+        match self.remove(token) {
+            Some(mut f) => match f.append(data) {
+                Ok(_) => {
+                    self.insert(token, f);
+                    Ok(())
+                }
+                Err(e) => {
+                    error!("append {}: {:?}", f, e);
+                    Err(e)
+                }
+            },
+            None => Err(Self::token_not_found(token)),
+        }
+    }
+
+    pub fn finish(&self, token: Token) -> Result<()> {
+        match self.remove(token) {
+            Some(mut f) => match f.finish() {
+                Ok(_) => {
+                    info!("finish {}", f);
+                    Ok(())
+                }
+                Err(e) => {
+                    error!("finish {}: {:?}", f, e);
+                    Err(e)
+                }
+            },
+            None => Err(Self::token_not_found(token)),
+        }
+    }
+
+    fn insert(&self, token: Token, file: UploadFile) {
+        let mut files = self.files.lock().unwrap();
+        assert!(files.insert(token, file).is_none());
+    }
+
+    pub fn remove(&self, token: Token) -> Option<UploadFile> {
+        let mut files = self.files.lock().unwrap();
+        files.remove(&token)
+    }
+
+    fn token_not_found(token: usize) -> Error {
+        let error = format!("token {} not found", token);
+        Error::new(ErrorKind::NotFound, error)
+    }
+}
+
+// TODO: Add size limit and rate limit.
+pub struct UploadDir {
+    root: Mutex<PathBuf>,
+}
+
+impl UploadDir {
+    const TEMP_DIR: &'static str = ".temp";
+
+    pub fn new<P: AsRef<Path>>(root: P) -> Result<UploadDir> {
+        let root_dir = root.as_ref().to_owned();
+        let temp_dir = root_dir.join(Self::TEMP_DIR);
+        if temp_dir.exists() {
+            fs::remove_dir_all(&temp_dir)?;
+        }
+        fs::create_dir_all(&temp_dir)?;
+        Ok(UploadDir {
+            root: Mutex::new(root_dir),
+        })
+    }
+
+    pub fn create(&self, meta: SSTMeta) -> Result<UploadFile> {
+        let path = sst_handle_to_path(meta.get_handle());
+        let root = self.root.lock().unwrap();
+        let save_path = root.join(&path);
+        let temp_path = root.join(Self::TEMP_DIR).join(&path);
+        if save_path.exists() {
+            return Err(file_exists(&save_path));
+        }
+        if temp_path.exists() {
+            return Err(file_exists(&temp_path));
+        }
+        UploadFile::create(meta, save_path, temp_path)
+    }
+}
+
+pub struct UploadFile {
+    meta: SSTMeta,
+    save_path: PathBuf,
+    temp_path: PathBuf,
+    temp_file: Option<File>,
+    temp_digest: crc32::Digest,
+}
+
+impl UploadFile {
+    fn create(meta: SSTMeta, save_path: PathBuf, temp_path: PathBuf) -> Result<UploadFile> {
+        let temp_file = File::create(&temp_path)?;
+        Ok(UploadFile {
+            meta: meta,
+            save_path: save_path,
+            temp_path: temp_path,
+            temp_file: Some(temp_file),
+            temp_digest: crc32::Digest::new(crc32::IEEE),
+        })
+    }
+
+    fn append(&mut self, data: &[u8]) -> Result<()> {
+        self.temp_file.as_mut().unwrap().write_all(data)?;
+        self.temp_digest.write(data);
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<()> {
+        self.validate()?;
+        self.temp_file.take();
+        assert!(self.temp_path.exists());
+        assert!(!self.save_path.exists());
+        fs::rename(&self.temp_path, &self.save_path)
+    }
+
+    fn remove(&mut self) -> Result<()> {
+        self.temp_file.take();
+        if self.temp_path.exists() {
+            fs::remove_file(&self.temp_path)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn validate(&self) -> Result<()> {
+        let f = self.temp_file.as_ref().unwrap();
+        if f.metadata()?.len() != self.meta.get_len() {
+            return Err(file_corrupted(&self.temp_path));
+        }
+        if self.temp_digest.sum32() != self.meta.get_crc32() {
+            return Err(file_corrupted(&self.temp_path));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for UploadFile {
+    fn drop(&mut self) {
+        if let Err(e) = self.remove() {
+            warn!("failed to remove {}: {:?}", self, e);
+        }
+    }
+}
+
+impl Display for UploadFile {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(
+            f,
+            "UploadFile {{meta: {{{:?}}}, save_path: {:?}, temp_path: {:?}}}",
+            self.meta,
+            self.save_path,
+            self.temp_path
+        )
+    }
+}
+
+fn sst_handle_to_path(h: &SSTHandle) -> PathBuf {
+    PathBuf::from(format!(
+        "{}_{}_{}_{}_{}.sst",
+        h.get_uuid(),
+        h.get_cfname(),
+        h.get_region_id(),
+        h.get_region_epoch().get_conf_ver(),
+        h.get_region_epoch().get_version(),
+    ))
+}
+
+fn file_exists<P: AsRef<Path>>(path: P) -> Error {
+    let path = path.as_ref().as_os_str();
+    let error = format!("file {:?} exists", path);
+    Error::new(ErrorKind::AlreadyExists, error)
+}
+
+fn file_corrupted<P: AsRef<Path>>(path: P) -> Error {
+    let path = path.as_ref().as_os_str();
+    let error = format!("file {:?} corrupted", path);
+    Error::new(ErrorKind::InvalidData, error)
+}

--- a/src/raftstore/store/upload.rs
+++ b/src/raftstore/store/upload.rs
@@ -140,6 +140,12 @@ impl UploadDir {
         }
         UploadFile::create(meta, save_path, temp_path)
     }
+
+    pub fn join_handle(&self, handle: &SSTHandle) -> Result<PathBuf> {
+        let path = sst_handle_to_path(handle)?;
+        let root = self.root.lock().unwrap();
+        Ok(root.join(&path))
+    }
 }
 
 pub struct UploadFile {

--- a/src/raftstore/store/upload.rs
+++ b/src/raftstore/store/upload.rs
@@ -226,7 +226,7 @@ fn sst_handle_to_path(h: &SSTHandle) -> Result<PathBuf> {
         }
     };
 
-    if h.get_cfname().is_empty() || h.get_region_id() == 0 ||
+    if h.get_cf_name().is_empty() || h.get_region_id() == 0 ||
         h.get_region_epoch().get_conf_ver() == 0 || h.get_region_epoch().get_version() == 0
     {
         let error = format!("invalid sst handle {:?}", h);
@@ -236,7 +236,7 @@ fn sst_handle_to_path(h: &SSTHandle) -> Result<PathBuf> {
     Ok(PathBuf::from(format!(
         "{}_{}_{}_{}_{}.sst",
         uuid.simple().to_string(),
-        h.get_cfname(),
+        h.get_cf_name(),
         h.get_region_id(),
         h.get_region_epoch().get_conf_ver(),
         h.get_region_epoch().get_version(),
@@ -273,7 +273,7 @@ mod test {
         let mut h = SSTHandle::new();
         let uuid = Uuid::new_v4();
         h.set_uuid(uuid.as_bytes().to_vec());
-        h.set_cfname("default".to_owned());
+        h.set_cf_name("default".to_owned());
         h.set_region_id(1);
         h.mut_region_epoch().set_conf_ver(2);
         h.mut_region_epoch().set_version(3);

--- a/src/raftstore/store/upload.rs
+++ b/src/raftstore/store/upload.rs
@@ -133,10 +133,10 @@ impl UploadDir {
         let save_path = root.join(&path);
         let temp_path = root.join(Self::TEMP_DIR).join(&path);
         if save_path.exists() {
-            return Err(file_exists(&save_path));
+            return Err(file_exists_error(&save_path));
         }
         if temp_path.exists() {
-            return Err(file_exists(&temp_path));
+            return Err(file_exists_error(&temp_path));
         }
         UploadFile::create(meta, save_path, temp_path)
     }
@@ -188,10 +188,10 @@ impl UploadFile {
     fn validate(&self) -> Result<()> {
         let f = self.temp_file.as_ref().unwrap();
         if f.metadata()?.len() != self.meta.get_len() {
-            return Err(file_corrupted(&self.temp_path));
+            return Err(file_corrupted_error(&self.temp_path));
         }
         if self.temp_digest.sum32() != self.meta.get_crc32() {
-            return Err(file_corrupted(&self.temp_path));
+            return Err(file_corrupted_error(&self.temp_path));
         }
         Ok(())
     }
@@ -243,13 +243,13 @@ fn sst_handle_to_path(h: &SSTHandle) -> Result<PathBuf> {
     )))
 }
 
-fn file_exists<P: AsRef<Path>>(path: P) -> Error {
+fn file_exists_error<P: AsRef<Path>>(path: P) -> Error {
     let path = path.as_ref().as_os_str();
     let error = format!("file {:?} exists", path);
     Error::new(ErrorKind::AlreadyExists, error)
 }
 
-fn file_corrupted<P: AsRef<Path>>(path: P) -> Error {
+fn file_corrupted_error<P: AsRef<Path>>(path: P) -> Error {
     let path = path.as_ref().as_os_str();
     let error = format!("file {:?} corrupted", path);
     Error::new(ErrorKind::InvalidData, error)

--- a/src/raftstore/store/upload.rs
+++ b/src/raftstore/store/upload.rs
@@ -311,9 +311,9 @@ mod test {
         assert!(uploader.append(token, &data).is_err());
         assert!(uploader.finish(token).is_err());
 
-        assert!(uploader.create(token, &meta).is_ok());
-        assert!(uploader.append(token, &data).is_ok());
-        assert!(uploader.finish(token).is_ok());
+        uploader.create(token, &meta).unwrap();
+        uploader.append(token, &data).unwrap();
+        uploader.finish(token).unwrap();
     }
 
     #[test]
@@ -368,7 +368,7 @@ mod test {
 
         let mut f = create_upload_file(data.len(), crc32);
         f.append(&data).unwrap();
-        assert!(f.finish().is_ok());
+        f.finish().unwrap();
     }
 
     #[test]

--- a/src/raftstore/store/worker/apply.rs
+++ b/src/raftstore/store/worker/apply.rs
@@ -1205,13 +1205,13 @@ impl ApplyDelegate {
                 return Err(Error::StaleEpoch(error, new_regions));
             }
             match cfname {
-                Some(cf) => if h.get_cfname() != cf {
+                Some(cf) => if h.get_cf_name() != cf {
                     return Err(box_err!(
                         "can not ingest files of different column families"
                     ));
                 },
                 None => {
-                    cfname = Some(h.get_cfname());
+                    cfname = Some(h.get_cf_name());
                 }
             }
             match self.upload_dir.join_handle(h) {

--- a/src/raftstore/store/worker/apply.rs
+++ b/src/raftstore/store/worker/apply.rs
@@ -1220,6 +1220,8 @@ impl ApplyDelegate {
                     return Err(box_err!("invalid ingest handle {:?}: {:?}", h, e));
                 }
             }
+
+            // TODO: Check SST file range
         }
 
         let resp = Response::new();

--- a/src/raftstore/store/worker/apply.rs
+++ b/src/raftstore/store/worker/apply.rs
@@ -17,7 +17,7 @@ use std::sync::mpsc::Sender;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::collections::VecDeque;
 
-use rocksdb::{Writable, WriteBatch, DB};
+use rocksdb::{IngestExternalFileOptions, Writable, WriteBatch, DB};
 use rocksdb::rocksdb_options::WriteOptions;
 use protobuf::RepeatedField;
 
@@ -34,7 +34,7 @@ use util::collections::{HashMap, HashMapEntry as MapEntry};
 use storage::{ALL_CFS, CF_DEFAULT, CF_LOCK, CF_RAFT};
 use raftstore::{Error, Result};
 use raftstore::coprocessor::CoprocessorHost;
-use raftstore::store::{cmd_resp, keys, util, Store};
+use raftstore::store::{cmd_resp, keys, util, Store, UploadDir};
 use raftstore::store::msg::Callback;
 use raftstore::store::engine::{Mutable, Peekable, Snapshot};
 use raftstore::store::peer_storage::{self, compact_raft_log, write_initial_apply_state,
@@ -263,10 +263,13 @@ fn should_flush_to_engine(cmd: &RaftCmdRequest, wb_keys: usize) -> bool {
         return true;
     }
 
-    // When encounter DeleteRange command, we must flush current write batch to engine first,
-    // because current write batch may contains keys are covered by DeleteRange.
+    // Some commands may modify keys covered by the current write batch, so we
+    // must flush the current write batch to the engine first.
     for req in cmd.get_requests() {
         if req.has_delete_range() {
+            return true;
+        }
+        if req.has_ingest_sst() {
             return true;
         }
     }
@@ -294,6 +297,8 @@ pub struct ApplyDelegate {
     term: u64,
     pending_cmds: PendingCmdQueue,
     metrics: ApplyMetrics,
+
+    upload_dir: Arc<UploadDir>,
 }
 
 impl ApplyDelegate {
@@ -305,12 +310,16 @@ impl ApplyDelegate {
         self.id
     }
 
-    fn from_peer(peer: &Peer) -> ApplyDelegate {
+    fn from_peer(peer: &Peer, upload_dir: Arc<UploadDir>) -> ApplyDelegate {
         let reg = Registration::new(peer);
-        ApplyDelegate::from_registration(peer.kv_engine(), reg)
+        ApplyDelegate::from_registration(peer.kv_engine(), upload_dir, reg)
     }
 
-    fn from_registration(db: Arc<DB>, reg: Registration) -> ApplyDelegate {
+    fn from_registration(
+        db: Arc<DB>,
+        upload_dir: Arc<UploadDir>,
+        reg: Registration,
+    ) -> ApplyDelegate {
         ApplyDelegate {
             id: reg.id,
             tag: format!("[region {}] {}", reg.region.get_id(), reg.id),
@@ -322,6 +331,7 @@ impl ApplyDelegate {
             term: reg.term,
             pending_cmds: Default::default(),
             metrics: Default::default(),
+            upload_dir: upload_dir,
         }
     }
 
@@ -1013,6 +1023,7 @@ impl ApplyDelegate {
                 CmdType::Put => self.handle_put(ctx, req),
                 CmdType::Delete => self.handle_delete(ctx, req),
                 CmdType::DeleteRange => self.handle_delete_range(req, &mut ranges),
+                CmdType::IngestSST => self.handle_ingest_sst(req),
                 // Readonly commands are handled in raftstore directly.
                 // Don't panic here in case there are old entries need to be applied.
                 // It's also safe to skip them here, because a restart must have happened,
@@ -1173,6 +1184,57 @@ impl ApplyDelegate {
         });
 
         ranges.push(Range::new(cf.to_owned(), start_key, end_key));
+
+        Ok(resp)
+    }
+
+    fn handle_ingest_sst(&mut self, req: &Request) -> Result<Response> {
+        let mut cfname = None;
+        let ingest = req.get_ingest_sst();
+        let region_id = self.region.get_id();
+        let region_epoch = self.region.get_region_epoch();
+
+        let mut ingest_paths = vec![];
+        for h in ingest.get_handles() {
+            if h.get_region_id() != region_id ||
+                h.get_region_epoch().get_conf_ver() != region_epoch.get_conf_ver() ||
+                h.get_region_epoch().get_version() != region_epoch.get_version()
+            {
+                let error = "ingest sst files".to_owned();
+                let new_regions = vec![self.region.clone()];
+                return Err(Error::StaleEpoch(error, new_regions));
+            }
+            match cfname {
+                Some(cf) => if h.get_cfname() != cf {
+                    return Err(box_err!(
+                        "can not ingest files of different column families"
+                    ));
+                },
+                None => {
+                    cfname = Some(h.get_cfname());
+                }
+            }
+            match self.upload_dir.join_handle(h) {
+                Ok(path) => ingest_paths.push(path),
+                Err(e) => {
+                    return Err(box_err!("invalid ingest handle {:?}: {:?}", h, e));
+                }
+            }
+        }
+
+        let resp = Response::new();
+        let cf = match cfname {
+            Some(cfname) => rocksdb::get_cf_handle(&self.engine, cfname)?,
+            None => return Ok(resp),
+        };
+
+        let mut opt = IngestExternalFileOptions::new();
+        opt.move_files(true);
+        let files: Vec<_> = ingest_paths
+            .iter()
+            .map(|path| path.to_str().unwrap())
+            .collect();
+        self.engine.ingest_external_file_cf(cf, &opt, &files)?;
 
         Ok(resp)
     }
@@ -1422,6 +1484,7 @@ pub struct Runner {
     notifier: Sender<TaskRes>,
     sync_log: bool,
     tag: String,
+    upload_dir: Arc<UploadDir>,
 }
 
 impl Runner {
@@ -1429,7 +1492,10 @@ impl Runner {
         let mut delegates =
             HashMap::with_capacity_and_hasher(store.get_peers().len(), Default::default());
         for (&region_id, p) in store.get_peers() {
-            delegates.insert(region_id, ApplyDelegate::from_peer(p));
+            delegates.insert(
+                region_id,
+                ApplyDelegate::from_peer(p, store.upload_dir.clone()),
+            );
         }
         Runner {
             db: store.kv_engine(),
@@ -1438,6 +1504,7 @@ impl Runner {
             notifier: notifier,
             sync_log: sync_log,
             tag: format!("[store {}]", store.store_id()),
+            upload_dir: store.upload_dir.clone(),
         }
     }
 
@@ -1550,7 +1617,8 @@ impl Runner {
         let peer_id = s.id;
         let region_id = s.region.get_id();
         let term = s.term;
-        let delegate = ApplyDelegate::from_registration(self.db.clone(), s);
+        let delegate =
+            ApplyDelegate::from_registration(self.db.clone(), self.upload_dir.clone(), s);
         info!(
             "{} register to apply delegates at term {}",
             delegate.tag,
@@ -1617,6 +1685,11 @@ mod tests {
         (path, db)
     }
 
+    fn create_tmp_upload_dir<P: AsRef<Path>>(path: P) -> Arc<UploadDir> {
+        let upload_dir = TempDir::new(path).unwrap();
+        Arc::new(UploadDir::new(upload_dir.path()).unwrap())
+    }
+
     fn new_runner(db: Arc<DB>, host: Arc<CoprocessorHost>, tx: Sender<TaskRes>) -> Runner {
         Runner {
             db: db,
@@ -1625,6 +1698,7 @@ mod tests {
             notifier: tx,
             sync_log: false,
             tag: "".to_owned(),
+            upload_dir: create_tmp_upload_dir("test"),
         }
     }
 
@@ -1895,10 +1969,11 @@ mod tests {
     #[test]
     fn test_handle_raft_committed_entries() {
         let (_path, db) = create_tmp_engine("test-delegate");
+        let upload_dir = create_tmp_upload_dir("test-delegate");
         let mut reg = Registration::default();
         reg.region.set_end_key(b"k5".to_vec());
         reg.region.mut_region_epoch().set_version(3);
-        let mut delegate = ApplyDelegate::from_registration(db.clone(), reg);
+        let mut delegate = ApplyDelegate::from_registration(db.clone(), upload_dir.clone(), reg);
         let (tx, rx) = mpsc::channel();
 
         let put_entry = EntryBuilder::new(1, 1)

--- a/src/raftstore/store/worker/apply.rs
+++ b/src/raftstore/store/worker/apply.rs
@@ -1685,7 +1685,7 @@ mod tests {
         (path, db)
     }
 
-    fn create_tmp_upload_dir<P: AsRef<Path>>(path: P) -> Arc<UploadDir> {
+    fn create_tmp_upload_dir(path: &str) -> Arc<UploadDir> {
         let upload_dir = TempDir::new(path).unwrap();
         Arc::new(UploadDir::new(upload_dir.path()).unwrap())
     }

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -31,7 +31,6 @@ const DEFAULT_GRPC_CONCURRENCY: usize = 4;
 const DEFAULT_GRPC_CONCURRENT_STREAM: usize = 1024;
 const DEFAULT_GRPC_RAFT_CONN_NUM: usize = 10;
 const DEFAULT_GRPC_STREAM_INITIAL_WINDOW_SIZE: u64 = 2 * 1024 * 1024;
-const DEFAULT_IMPORT_CONCURRENCY: usize = 2;
 const DEFAULT_MESSAGES_PER_TICK: usize = 4096;
 // Enpoints may occur very deep recursion,
 // so enlarge their stack size to 10 MB.

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -31,6 +31,7 @@ const DEFAULT_GRPC_CONCURRENCY: usize = 4;
 const DEFAULT_GRPC_CONCURRENT_STREAM: usize = 1024;
 const DEFAULT_GRPC_RAFT_CONN_NUM: usize = 10;
 const DEFAULT_GRPC_STREAM_INITIAL_WINDOW_SIZE: u64 = 2 * 1024 * 1024;
+const DEFAULT_IMPORT_CONCURRENCY: usize = 2;
 const DEFAULT_MESSAGES_PER_TICK: usize = 4096;
 // Enpoints may occur very deep recursion,
 // so enlarge their stack size to 10 MB.

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -35,6 +35,7 @@ const DEFAULT_MESSAGES_PER_TICK: usize = 4096;
 // Enpoints may occur very deep recursion,
 // so enlarge their stack size to 10 MB.
 const DEFAULT_ENDPOINT_STACK_SIZE_MB: u64 = 10;
+const DEFAULT_IMPORT_CONCURRENCY: usize = 2;
 
 // Assume a request can be finished in 1ms, a request at position x will wait about
 // 0.001 * x secs to be actual started. A server-is-busy error will trigger 2 seconds
@@ -64,6 +65,7 @@ pub struct Config {
     pub end_point_concurrency: usize,
     pub end_point_max_tasks: usize,
     pub end_point_stack_size: ReadableSize,
+    pub import_concurrency: usize,
     // Server labels to specify some attributes about this server.
     #[serde(with = "config::order_map_serde")]
     pub labels: HashMap<String, String>,
@@ -91,6 +93,7 @@ impl Default for Config {
             end_point_concurrency: concurrency,
             end_point_max_tasks: DEFAULT_MAX_RUNNING_TASK_COUNT,
             end_point_stack_size: ReadableSize::mb(DEFAULT_ENDPOINT_STACK_SIZE_MB),
+            import_concurrency: DEFAULT_IMPORT_CONCURRENCY,
         }
     }
 }

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -27,7 +27,7 @@ use protobuf::RepeatedField;
 use util::transport::SendCh;
 use util::worker::FutureWorker;
 use raftstore::store::{self, keys, Config as StoreConfig, Engines, Msg, Peekable, SignificantMsg,
-                       SnapManager, Store, StoreChannel, Transport};
+                       SnapManager, Store, StoreChannel, Transport, UploadDir};
 use super::Result;
 use server::Config as ServerConfig;
 use storage::{Config as StorageConfig, RaftKv, Storage};
@@ -126,6 +126,7 @@ where
         snap_mgr: SnapManager,
         significant_msg_receiver: Receiver<SignificantMsg>,
         pd_worker: FutureWorker<PdTask>,
+        upload_dir: Arc<UploadDir>,
     ) -> Result<()>
     where
         T: Transport + 'static,
@@ -164,6 +165,7 @@ where
             snap_mgr,
             significant_msg_receiver,
             pd_worker,
+            upload_dir,
         )?;
         Ok(())
     }
@@ -317,6 +319,7 @@ where
         snap_mgr: SnapManager,
         significant_msg_receiver: Receiver<SignificantMsg>,
         pd_worker: FutureWorker<PdTask>,
+        upload_dir: Arc<UploadDir>,
     ) -> Result<()>
     where
         T: Transport + 'static,
@@ -348,6 +351,7 @@ where
                 pd_client,
                 snap_mgr,
                 pd_worker,
+                upload_dir,
             ) {
                 Err(e) => panic!("construct store {} err {:?}", store_id, e),
                 Ok(s) => s,

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -118,6 +118,7 @@ where
         }
     }
 
+    #[allow(too_many_arguments)]
     pub fn start<T>(
         &mut self,
         event_loop: EventLoop<Store<T, C>>,

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -103,10 +103,6 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver + 'static> Server<T, S> {
             if let Some(engines) = debug_engines {
                 sb = sb.register_service(create_debug(DebugService::new(engines)));
             }
-            if let Some(uploader) = uploader {
-                let service = ImportService::new(cfg.import_concurrency, uploader);
-                sb = sb.register_service(create_import(service));
-            }
             sb.build()?
         };
 

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -102,6 +102,10 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver + 'static> Server<T, S> {
             if let Some(engines) = debug_engines {
                 sb = sb.register_service(create_debug(DebugService::new(engines)));
             }
+            if let Some(uploader) = uploader {
+                let service = ImportService::new(cfg.import_concurrency, uploader);
+                sb = sb.register_service(create_import(service));
+            }
             sb.build()?
         };
 

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -83,7 +83,8 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver + 'static> Server<T, S> {
             raft_router.clone(),
             snap_worker.scheduler(),
         );
-        let import_service = ImportService::new(cfg.import_concurrency, upload_dir);
+        let import_service =
+            ImportService::new(cfg.import_concurrency, storage.clone(), upload_dir);
         let addr = SocketAddr::from_str(&cfg.addr)?;
         info!("listening on {}", addr);
         let ip = format!("{}", addr.ip());

--- a/src/server/service/import.rs
+++ b/src/server/service/import.rs
@@ -1,0 +1,96 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use grpc::{ClientStreamingSink, RequestStream, RpcContext, RpcStatus, RpcStatusCode};
+use futures::{future, Future, Stream};
+use futures_cpupool::{Builder, CpuPool};
+use kvproto::importpb::*;
+use kvproto::importpb_grpc;
+
+use server::errors::Error;
+use raftstore::store::Uploader;
+
+#[derive(Clone)]
+pub struct Service {
+    pool: CpuPool,
+    uploader: Arc<Uploader>,
+}
+
+impl Service {
+    pub fn new(pool_size: usize, uploader: Arc<Uploader>) -> Service {
+        let pool = Builder::new()
+            .name_prefix(thd_name!("import"))
+            .pool_size(pool_size)
+            .create();
+        Service {
+            pool: pool,
+            uploader: uploader,
+        }
+    }
+}
+
+impl importpb_grpc::Import for Service {
+    fn upload_sst(
+        &self,
+        ctx: RpcContext,
+        stream: RequestStream<UploadSSTRequest>,
+        sink: ClientStreamingSink<UploadSSTResponse>,
+    ) {
+        let pool = self.pool.clone();
+        let up1 = self.uploader.clone();
+        let up2 = self.uploader.clone();
+        let token = self.uploader.token();
+        ctx.spawn(
+            stream
+                .map_err(Error::from)
+                .for_each(move |chunk| {
+                    let up1 = up1.clone();
+                    pool.spawn_fn(move || {
+                        if chunk.has_meta() {
+                            up1.create(token, chunk.get_meta())?;
+                        }
+                        if !chunk.get_data().is_empty() {
+                            up1.append(token, chunk.get_data())?;
+                        }
+                        Ok(())
+                    })
+                })
+                .then(move |res| match res {
+                    Ok(_) => up2.finish(token).map_err(Error::from),
+                    Err(e) => {
+                        if let Some(f) = up2.remove(token) {
+                            error!("remove {}: {:?}", f, e);
+                        }
+                        Err(e)
+                    }
+                })
+                .then(|res| match res {
+                    Ok(_) => {
+                        let resp = UploadSSTResponse::new();
+                        sink.success(resp).map_err(Error::from)
+                    }
+                    Err(e) => {
+                        let status = rpc_unknown_error(e);
+                        sink.fail(status).map_err(Error::from)
+                    }
+                })
+                .then(|_| future::ok::<_, ()>(())),
+        );
+    }
+}
+
+fn rpc_unknown_error(e: Error) -> RpcStatus {
+    RpcStatus::new(RpcStatusCode::Unknown, Some(format!("{:?}", e)))
+}

--- a/src/server/service/import.rs
+++ b/src/server/service/import.rs
@@ -152,9 +152,9 @@ fn make_cb<T: Debug + Send + 'static>() -> (Box<FnBox(T) + Send>, oneshot::Recei
 }
 
 fn extract_error<T>(res: &storage::Result<T>) -> Option<errorpb::Error> {
-    super::kv::extract_region_error(res).or(match res {
-        &Ok(_) => None,
-        &Err(ref e) => {
+    super::kv::extract_region_error(res).or(match *res {
+        Ok(_) => None,
+        Err(ref e) => {
             let mut err = errorpb::Error::new();
             err.set_message(format!("{:?}", e));
             Some(err)

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -17,7 +17,8 @@ use std::io::Write;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use mio::Token;
-use grpc::{ClientStreamingSink, RequestStream, RpcContext, RpcStatus, RpcStatusCode, UnarySink};
+use grpc::{ClientStreamingSink, RequestStream, RpcContext, RpcStatus, RpcStatusCode,
+           ServerStreamingSink, UnarySink};
 use futures::{future, Future, Stream};
 use futures::sync::oneshot;
 use protobuf::RepeatedField;
@@ -974,6 +975,8 @@ impl<T: RaftStoreRouter + 'static> tikvpb_grpc::Tikv for Service<T> {
 
         ctx.spawn(future);
     }
+
+    fn coprocessor_stream(&self, _: RpcContext, _: Request, _: ServerStreamingSink<Response>) {}
 }
 
 fn extract_region_error<T>(res: &storage::Result<T>) -> Option<RegionError> {

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -979,7 +979,7 @@ impl<T: RaftStoreRouter + 'static> tikvpb_grpc::Tikv for Service<T> {
     fn coprocessor_stream(&self, _: RpcContext, _: Request, _: ServerStreamingSink<Response>) {}
 }
 
-fn extract_region_error<T>(res: &storage::Result<T>) -> Option<RegionError> {
+pub fn extract_region_error<T>(res: &storage::Result<T>) -> Option<RegionError> {
     use storage::Error;
     match *res {
         // TODO: use `Error::cause` instead.

--- a/src/server/service/mod.rs
+++ b/src/server/service/mod.rs
@@ -13,6 +13,8 @@
 
 mod kv;
 mod debug;
+mod import;
 
 pub use self::kv::Service as KvService;
 pub use self::debug::Service as DebugService;
+pub use self::import::Service as ImportService;

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -22,6 +22,7 @@ use rocksdb::TablePropertiesCollection;
 use storage::{CfName, Key, Value, CF_DEFAULT, CF_LOCK, CF_WRITE};
 use kvproto::kvrpcpb::Context;
 use kvproto::errorpb::Error as ErrorHeader;
+use kvproto::importpb::SSTHandle;
 
 mod rocksdb;
 pub mod raftkv;
@@ -80,6 +81,11 @@ pub trait Engine: Send + Debug {
         batch: Vec<Context>,
         on_finished: BatchCallback<Box<Snapshot>>,
     ) -> Result<()>;
+
+    // Ingest external SST files specified by the handles to the engine.
+    fn async_ingest_sst(&self, _: &Context, _: Vec<SSTHandle>, _: Callback<()>) -> Result<()> {
+        unimplemented!();
+    }
 
     fn write(&self, ctx: &Context, batch: Vec<Modify>) -> Result<()> {
         let timeout = Duration::from_secs(DEFAULT_TIMEOUT_SECS);

--- a/src/storage/engine/raftkv.rs
+++ b/src/storage/engine/raftkv.rs
@@ -19,10 +19,10 @@ use raftstore::coprocessor::{RegionIterator, RegionSnapshot};
 use raftstore::store::engine::{Peekable, Snapshot as EngineSnapshot};
 use rocksdb::TablePropertiesCollection;
 use storage;
-use kvproto::raft_cmdpb::{CmdType, DeleteRangeRequest, DeleteRequest, PutRequest, RaftCmdRequest,
-                          RaftCmdResponse, RaftRequestHeader, Request, Response};
+use kvproto::raft_cmdpb::*;
 use kvproto::errorpb;
 use kvproto::kvrpcpb::Context;
+use kvproto::importpb::SSTHandle;
 
 use std::sync::Arc;
 use std::fmt::{self, Debug, Formatter};
@@ -456,6 +456,54 @@ impl<S: RaftStoreRouter> Engine for RaftKv<S> {
                     .with_label_values(&["snapshot", tag])
                     .inc_by(batch_size as f64)
                     .unwrap();
+                e.into()
+            })
+    }
+
+    fn async_ingest_sst(
+        &self,
+        ctx: &Context,
+        handles: Vec<SSTHandle>,
+        cb: Callback<()>,
+    ) -> engine::Result<()> {
+        let label = "ingest_sst";
+        let timer = ASYNC_REQUESTS_DURATIONS_VEC
+            .with_label_values(&[label])
+            .start_coarse_timer();
+        ASYNC_REQUESTS_COUNTER_VEC
+            .with_label_values(&[label, "all"])
+            .inc();
+
+        let mut ingest = IngestSSTRequest::new();
+        ingest.set_handles(RepeatedField::from_vec(handles));
+        let mut req = Request::new();
+        req.set_cmd_type(CmdType::IngestSST);
+        req.set_ingest_sst(ingest);
+
+        self.exec_requests(ctx, vec![req], box move |(cb_ctx, res)| match res {
+            Ok(CmdRes::Resp(_)) => {
+                timer.observe_duration();
+                ASYNC_REQUESTS_COUNTER_VEC
+                    .with_label_values(&[label, "success"])
+                    .inc();
+                cb((cb_ctx, Ok(())))
+            }
+            Ok(CmdRes::Snap(_)) => cb((
+                cb_ctx,
+                Err(box_err!("unexpect snapshot for ingest requests.")),
+            )),
+            Err(e) => {
+                let tag = get_tag_from_engine_error(&e);
+                ASYNC_REQUESTS_COUNTER_VEC
+                    .with_label_values(&[label, tag])
+                    .inc();
+                cb((cb_ctx, Err(e)))
+            }
+        }).map_err(|e| {
+                let tag = get_tag_from_error(&e);
+                ASYNC_REQUESTS_COUNTER_VEC
+                    .with_label_values(&[label, tag])
+                    .inc();
                 e.into()
             })
     }

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -64,6 +64,7 @@ fn test_serde_custom_tikv_config() {
         end_point_concurrency: 12,
         end_point_max_tasks: 12,
         end_point_stack_size: ReadableSize::mb(12),
+        import_concurrency: 123,
     };
     value.metric = MetricConfig {
         interval: ReadableDuration::secs(12),

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -64,7 +64,7 @@ fn test_serde_custom_tikv_config() {
         end_point_concurrency: 12,
         end_point_max_tasks: 12,
         end_point_stack_size: ReadableSize::mb(12),
-        import_concurrency: 123,
+        import_concurrency: 12,
     };
     value.metric = MetricConfig {
         interval: ReadableDuration::secs(12),

--- a/tests/config/test-custom.toml
+++ b/tests/config/test-custom.toml
@@ -13,6 +13,7 @@ grpc-stream-initial-window-size = 12345
 end-point-concurrency = 12
 end-point-max-tasks = 12
 end-point-stack-size = "12MB"
+import-concurrency = 12
 
 [server.labels]
 a = "b"

--- a/tests/raftstore/node.rs
+++ b/tests/raftstore/node.rs
@@ -178,6 +178,9 @@ impl Simulator for NodeCluster {
             (snap_mgr.clone(), None)
         };
 
+        let upload_path = TempDir::new("test_upload").unwrap();
+        let upload_dir = Arc::new(UploadDir::new(upload_path.path()).unwrap());
+
         node.start(
             event_loop,
             engines.clone(),
@@ -185,6 +188,7 @@ impl Simulator for NodeCluster {
             snap_mgr.clone(),
             snap_status_receiver,
             pd_worker,
+            upload_dir.clone(),
         ).unwrap();
         assert!(
             engines

--- a/tests/raftstore/server.rs
+++ b/tests/raftstore/server.rs
@@ -133,9 +133,9 @@ impl Simulator for ServerCluster {
             sim_router.clone(),
             resolver,
             snap_mgr.clone(),
-            upload_dir.clone(),
             pd_worker.scheduler(),
             Some(engines.clone()),
+            upload_dir.clone(),
         ).unwrap();
         let addr = server.listening_addr();
         cfg.server.addr = format!("{}", addr);

--- a/tests/raftstore/server.rs
+++ b/tests/raftstore/server.rs
@@ -131,6 +131,7 @@ impl Simulator for ServerCluster {
             snap_mgr.clone(),
             pd_worker.scheduler(),
             Some(engines.clone()),
+            None,
         ).unwrap();
         let addr = server.listening_addr();
         cfg.server.addr = format!("{}", addr);

--- a/tests/raftstore/server.rs
+++ b/tests/raftstore/server.rs
@@ -156,6 +156,7 @@ impl Simulator for ServerCluster {
             snap_mgr.clone(),
             snap_status_receiver,
             pd_worker,
+            upload_dir.clone(),
         ).unwrap();
         assert!(node_id == 0 || node_id == node.id());
         let node_id = node.id();

--- a/tests/raftstore/server.rs
+++ b/tests/raftstore/server.rs
@@ -119,8 +119,8 @@ impl Simulator for ServerCluster {
         self.storages.insert(node_id, store.get_engine());
 
         // Create upload dir.
-        let upload_path = TempDir::new("upload").unwrap();
-        let upload_dir = Arc::new(UploadDir::new(upload_path.path()).unwrap());
+        let upload_path = TempDir::new("upload").unwrap().into_path();
+        let upload_dir = Arc::new(UploadDir::new(upload_path).unwrap());
 
         // Create pd client, snapshot manager, server.
         let (worker, resolver) = resolve::new_resolver(self.pd_client.clone()).unwrap();

--- a/tests/raftstore/test_bootstrap.rs
+++ b/tests/raftstore/test_bootstrap.rs
@@ -14,7 +14,7 @@
 use std::sync::{mpsc, Arc};
 use std::path::Path;
 use tikv::raftstore::store::{bootstrap_store, create_event_loop, keys, Engines, Peekable,
-                             SnapManager};
+                             SnapManager, UploadDir};
 use tikv::server::Node;
 use tikv::storage::{ALL_CFS, CF_RAFT};
 use tikv::util::rocksdb;
@@ -61,6 +61,8 @@ fn test_node_bootstrap_with_prepared_data() {
     );
     let engines = Engines::new(engine.clone(), raft_engine.clone());
     let tmp_mgr = TempDir::new("test_cluster").unwrap();
+    let upload_path = TempDir::new("test_upload").unwrap().into_path();
+    let upload_dir = Arc::new(UploadDir::new(upload_path).unwrap());
 
     let mut node = Node::new(
         &mut event_loop,
@@ -102,6 +104,7 @@ fn test_node_bootstrap_with_prepared_data() {
         snap_mgr,
         snapshot_status_receiver,
         pd_worker,
+        upload_dir,
     ).unwrap();
     assert!(
         engine

--- a/tests/raftstore/test_service.rs
+++ b/tests/raftstore/test_service.rs
@@ -852,7 +852,7 @@ fn test_ingest_sst() {
 
     // Different CFs in sst handle
     let mut handle = sst_handles[0].clone();
-    handle.set_cfname("testcf".to_owned());
+    handle.set_cf_name("testcf".to_owned());
     let mut ingest = IngestSSTRequest::new();
     ingest.set_context(ctx.clone());
     ingest.mut_handles().push(handle);
@@ -901,7 +901,7 @@ fn make_sst_handle() -> SSTHandle {
 fn make_sst_handle_from_ctx(ctx: &Context) -> SSTHandle {
     let mut h = SSTHandle::new();
     h.set_uuid(Uuid::new_v4().as_bytes().to_vec());
-    h.set_cfname("default".to_owned());
+    h.set_cf_name("default".to_owned());
     h.set_region_id(ctx.get_region_id());
     h.set_region_epoch(ctx.get_region_epoch().clone());
     h

--- a/tests/raftstore/test_service.rs
+++ b/tests/raftstore/test_service.rs
@@ -875,7 +875,7 @@ fn test_ingest_sst() {
         let resp = kv.raw_get(m).unwrap();
         assert!(resp.get_error().is_empty());
         assert!(!resp.has_region_error());
-        assert!(resp.get_value().cmp(&v) == Ordering::Equal);
+        assert_eq!(resp.get_value().cmp(&v), Ordering::Equal);
     }
 }
 

--- a/tests/raftstore/test_service.rs
+++ b/tests/raftstore/test_service.rs
@@ -814,7 +814,7 @@ fn make_sst_handle() -> SSTHandle {
     let mut h = SSTHandle::new();
     let uuid = Uuid::new_v4();
     h.set_uuid(uuid.as_bytes().to_vec());
-    h.set_cfname("default".to_owned());
+    h.set_cf_name("default".to_owned());
     h.set_region_id(1);
     h.mut_region_epoch().set_conf_ver(2);
     h.mut_region_epoch().set_version(3);

--- a/tests/raftstore/test_service.rs
+++ b/tests/raftstore/test_service.rs
@@ -24,9 +24,13 @@ use kvproto::coprocessor::*;
 use kvproto::{debugpb, eraftpb, metapb, raft_serverpb};
 use kvproto::tikvpb_grpc::TikvClient;
 use kvproto::debugpb_grpc::DebugClient;
+use kvproto::importpb::*;
+use kvproto::importpb_grpc::*;
 use rocksdb::Writable;
-use futures::{future, Future, Sink, Stream};
-use grpc::{ChannelBuilder, Environment, Error, RpcStatusCode};
+use futures::{future, stream, Future, Sink, Stream};
+use grpc::{ChannelBuilder, Environment, Error, Result, RpcStatusCode, WriteFlags};
+use crc::crc32::{self, Hasher32};
+use uuid::Uuid;
 
 use super::server::*;
 use super::cluster::Cluster;
@@ -54,6 +58,17 @@ fn must_new_cluster_and_kv_client() -> (Cluster<ServerCluster>, TikvClient, Cont
     let env = Arc::new(Environment::new(1));
     let channel = ChannelBuilder::new(env).connect(&format!("{}", addr));
     let client = TikvClient::new(channel);
+
+    (cluster, client, ctx)
+}
+
+fn must_new_cluster_and_import_client() -> (Cluster<ServerCluster>, ImportClient, Context) {
+    let (cluster, leader, ctx) = must_new_cluster();
+
+    let addr = cluster.sim.rl().get_addr(leader.get_store_id());
+    let env = Arc::new(Environment::new(1));
+    let channel = ChannelBuilder::new(env).connect(&format!("{}", addr));
+    let client = ImportClient::new(channel);
 
     (cluster, client, ctx)
 }
@@ -763,4 +778,51 @@ fn test_debug_scan_mvcc() {
     let keys = future.wait().unwrap();
     assert_eq!(keys.len(), 1);
     assert_eq!(keys[0], keys::data_key(b"meta_lock_1"));
+}
+
+fn make_sst_meta(len: usize, crc32: u32) -> SSTMeta {
+    let mut m = SSTMeta::new();
+    m.set_len(len as u64);
+    m.set_crc32(crc32);
+    m.set_handle(make_sst_handle());
+    m
+}
+
+fn make_sst_handle() -> SSTHandle {
+    let mut h = SSTHandle::new();
+    let uuid = Uuid::new_v4();
+    h.set_uuid(uuid.as_bytes().to_vec());
+    h.set_cfname("default".to_owned());
+    h.set_region_id(1);
+    h.mut_region_epoch().set_conf_ver(2);
+    h.mut_region_epoch().set_version(3);
+    h
+}
+
+fn test_upload_sst(client: &ImportClient, m: UploadSSTRequest) -> Result<UploadSSTResponse> {
+    let (tx, rx) = client.upload_sst();
+    let stream = stream::once({ Ok((m, WriteFlags::default().buffer_hint(true))) });
+    stream.forward(tx).and_then(|_| rx).wait()
+}
+
+#[test]
+fn test_import_service() {
+    let (_cluster, client, _) = must_new_cluster_and_import_client();
+
+    let data = vec![1; 1024];
+    let mut hash = crc32::Digest::new(crc32::IEEE);
+    hash.write(&data);
+    let crc32 = hash.sum32();
+
+    let mut m = UploadSSTRequest::new();
+    m.set_data(data.clone());
+
+    let meta = make_sst_meta(data.len(), crc32);
+    m.set_meta(meta.clone());
+    test_upload_sst(&client, m.clone()).unwrap();
+
+    // Mismatch checksum
+    let meta = make_sst_meta(data.len(), 0);
+    m.set_meta(meta.clone());
+    assert!(test_upload_sst(&client, m.clone()).is_err());
 }

--- a/tests/raftstore/test_service.rs
+++ b/tests/raftstore/test_service.rs
@@ -11,6 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::Ordering;
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
 use std::sync::Arc;
 
 use tikv::util::HandyRwLock;
@@ -26,11 +30,13 @@ use kvproto::tikvpb_grpc::TikvClient;
 use kvproto::debugpb_grpc::DebugClient;
 use kvproto::importpb::*;
 use kvproto::importpb_grpc::*;
-use rocksdb::Writable;
+use rocksdb::{ColumnFamilyOptions, EnvOptions, SstFileWriter, Writable};
 use futures::{future, stream, Future, Sink, Stream};
 use grpc::{ChannelBuilder, Environment, Error, Result, RpcStatusCode, WriteFlags};
 use crc::crc32::{self, Hasher32};
 use uuid::Uuid;
+use tempdir::TempDir;
+use protobuf::RepeatedField;
 
 use super::server::*;
 use super::cluster::Cluster;
@@ -62,15 +68,19 @@ fn must_new_cluster_and_kv_client() -> (Cluster<ServerCluster>, TikvClient, Cont
     (cluster, client, ctx)
 }
 
-fn must_new_cluster_and_import_client() -> (Cluster<ServerCluster>, ImportClient, Context) {
+fn must_new_cluster_and_kv_and_import_client()
+    -> (Cluster<ServerCluster>, TikvClient, ImportClient, Context)
+{
     let (cluster, leader, ctx) = must_new_cluster();
 
     let addr = cluster.sim.rl().get_addr(leader.get_store_id());
     let env = Arc::new(Environment::new(1));
-    let channel = ChannelBuilder::new(env).connect(&format!("{}", addr));
-    let client = ImportClient::new(channel);
+    let ch = ChannelBuilder::new(env.clone()).connect(&format!("{}", addr));
+    let kv = TikvClient::new(ch);
+    let ch = ChannelBuilder::new(env.clone()).connect(&format!("{}", addr));
+    let import = ImportClient::new(ch);
 
-    (cluster, client, ctx)
+    (cluster, kv, import, ctx)
 }
 
 #[test]
@@ -782,7 +792,7 @@ fn test_debug_scan_mvcc() {
 
 #[test]
 fn test_upload_sst() {
-    let (_cluster, client, _) = must_new_cluster_and_import_client();
+    let (_cluster, _, client, _) = must_new_cluster_and_kv_and_import_client();
 
     let data = vec![1; 1024];
     let mut hash = crc32::Digest::new(crc32::IEEE);
@@ -802,6 +812,73 @@ fn test_upload_sst() {
     send_upload_sst(&client, upload.clone()).unwrap();
 }
 
+#[test]
+fn test_ingest_sst() {
+    let (_cluster, kv, import, ctx) = must_new_cluster_and_kv_and_import_client();
+
+    let temp_dir = TempDir::new("test_ingest_sst").unwrap();
+    let num_files = 3;
+    let num_keys_per_file = 10;
+    let mut sst_handles = vec![];
+    for i in 0..num_files {
+        let path = temp_dir.path().join(format!("{}.sst", i));
+        let start = i * num_keys_per_file;
+        let end = (i + 1) * num_keys_per_file;
+        make_sst_file(&path, start, end);
+        let handle = send_sst_file(&import, &ctx, &path);
+        sst_handles.push(handle);
+    }
+
+    let epoch = ctx.get_region_epoch();
+    let mut stale_epoch = epoch.clone();
+    stale_epoch.set_version(epoch.get_version() - 1);
+
+    // Stale epoch in context
+    let mut stale_ctx = ctx.clone();
+    stale_ctx.set_region_epoch(stale_epoch.clone());
+    let mut ingest = IngestSSTRequest::new();
+    ingest.set_context(stale_ctx);
+    let resp = import.ingest_sst(ingest).unwrap();
+    assert!(resp.get_error().has_stale_epoch());
+
+    // Stale epoch in sst handle
+    let mut handle = sst_handles[0].clone();
+    handle.set_region_epoch(stale_epoch.clone());
+    let mut ingest = IngestSSTRequest::new();
+    ingest.set_context(ctx.clone());
+    ingest.mut_handles().push(handle);
+    let resp = import.ingest_sst(ingest).unwrap();
+    assert!(resp.has_error());
+
+    // Different CFs in sst handle
+    let mut handle = sst_handles[0].clone();
+    handle.set_cfname("testcf".to_owned());
+    let mut ingest = IngestSSTRequest::new();
+    ingest.set_context(ctx.clone());
+    ingest.mut_handles().push(handle);
+    let resp = import.ingest_sst(ingest).unwrap();
+    assert!(resp.has_error());
+
+    let mut ingest = IngestSSTRequest::new();
+    ingest.set_context(ctx.clone());
+    ingest.set_handles(RepeatedField::from_vec(sst_handles));
+    let resp = import.ingest_sst(ingest).unwrap();
+    assert!(!resp.has_error());
+
+    // Check ingested sst files
+    let num_keys = num_files * num_keys_per_file;
+    for i in 0..num_keys {
+        let (k, v) = make_kv(i, i);
+        let mut m = RawGetRequest::new();
+        m.set_context(ctx.clone());
+        m.set_key(k);
+        let resp = kv.raw_get(m).unwrap();
+        assert!(resp.get_error().is_empty());
+        assert!(!resp.has_region_error());
+        assert!(resp.get_value().cmp(&v) == Ordering::Equal);
+    }
+}
+
 fn make_sst_meta(len: usize, crc32: u32) -> SSTMeta {
     let mut m = SSTMeta::new();
     m.set_len(len as u64);
@@ -819,6 +896,56 @@ fn make_sst_handle() -> SSTHandle {
     h.mut_region_epoch().set_conf_ver(2);
     h.mut_region_epoch().set_version(3);
     h
+}
+
+fn make_sst_handle_from_ctx(ctx: &Context) -> SSTHandle {
+    let mut h = SSTHandle::new();
+    h.set_uuid(Uuid::new_v4().as_bytes().to_vec());
+    h.set_cfname("default".to_owned());
+    h.set_region_id(ctx.get_region_id());
+    h.set_region_epoch(ctx.get_region_epoch().clone());
+    h
+}
+
+fn make_kv(k: u64, v: u64) -> (Vec<u8>, Vec<u8>) {
+    let k = format!("k-{:08}", k);
+    let v = format!("v-{:08}", v);
+    (k.into_bytes(), v.into_bytes())
+}
+
+fn make_sst_file<P: AsRef<Path>>(path: P, start: u64, end: u64) {
+    let env_opt = EnvOptions::new();
+    let cf_opt = ColumnFamilyOptions::new();
+    let mut sst = SstFileWriter::new(env_opt, cf_opt);
+
+    sst.open(path.as_ref().to_str().unwrap()).unwrap();
+    for i in start..end {
+        let (k, v) = make_kv(i, i);
+        let k = keys::data_key(&k);
+        sst.put(&k, &v).unwrap();
+    }
+    sst.finish().unwrap();
+}
+
+fn send_sst_file<P: AsRef<Path>>(client: &ImportClient, ctx: &Context, path: P) -> SSTHandle {
+    let mut data = vec![];
+    File::open(path).unwrap().read_to_end(&mut data).unwrap();
+
+    let mut hash = crc32::Digest::new(crc32::IEEE);
+    hash.write(&data);
+
+    let handle = make_sst_handle_from_ctx(ctx);
+    let mut meta = SSTMeta::new();
+    meta.set_len(data.len() as u64);
+    meta.set_crc32(hash.sum32());
+    meta.set_handle(handle.clone());
+
+    let mut m = UploadSSTRequest::new();
+    m.set_meta(meta);
+    m.set_data(data);
+    send_upload_sst(client, m).unwrap();
+
+    handle
 }
 
 fn send_upload_sst(client: &ImportClient, m: UploadSSTRequest) -> Result<UploadSSTResponse> {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -42,6 +42,8 @@ extern crate grpcio as grpc;
 extern crate futures;
 extern crate futures_cpupool;
 extern crate toml;
+extern crate crc;
+extern crate uuid;
 
 mod raft;
 mod raftstore;


### PR DESCRIPTION
Allow a client to upload SST files to TiKV, and then ingest them to RocksDB.

This PR follows https://github.com/pingcap/tikv/pull/2420, and will be rebased later.
Put it here for now for easy review.