### PR TITLE
endpoint: add recursion limit check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,13 +669,13 @@ dependencies = [
 [[package]]
 name = "protobuf"
 version = "1.4.1"
-source = "git+https://github.com/busyjay/rust-protobuf.git?branch=set-recurse-limit#35fb1a67f231b3f62f4750e81ec6d8ae829139af"
+source = "git+https://github.com/stepancheg/rust-protobuf.git#51f50fb4d9c937e37f0eaf61866738a254da4d0e"
 
 [[package]]
 name = "protobuf"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-replace = "protobuf 1.4.1 (git+https://github.com/busyjay/rust-protobuf.git?branch=set-recurse-limit)"
+replace = "protobuf 1.4.1 (git+https://github.com/stepancheg/rust-protobuf.git)"
 
 [[package]]
 name = "pulldown-cmark"
@@ -1155,7 +1155,7 @@ dependencies = [
 "checksum pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8cee804ecc7eaf201a4a207241472cc870e825206f6c031e3ee2a72fa425f2fa"
 "checksum procinfo 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f42e8578852a3306838981aedad8c5642ba794929aa12af0c9eb6c072b77af6c"
 "checksum prometheus 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "276b782a9f116c6dc1e9dc63611e9e944b9dba5b29bb4bd24b55013af9c3fc00"
-"checksum protobuf 1.4.1 (git+https://github.com/busyjay/rust-protobuf.git?branch=set-recurse-limit)" = "<none>"
+"checksum protobuf 1.4.1 (git+https://github.com/stepancheg/rust-protobuf.git)" = "<none>"
 "checksum protobuf 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "568a15e4d572d9a5e63ae3a55f84328c984842887db179b40b4cc6a608bac6a4"
 "checksum pulldown-cmark 0.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "378e941dbd392c101f2cb88097fa4d7167bc421d4b88de3ff7dbee503bc3233b"
 "checksum quick-error 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7ac990ab4e038dd8481a5e3fd00641067fcfc674ad663f3222752ed5284e05d4"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,13 @@ dependencies = [
 [[package]]
 name = "protobuf"
 version = "1.4.1"
+source = "git+https://github.com/busyjay/rust-protobuf.git?branch=set-recurse-limit#35fb1a67f231b3f62f4750e81ec6d8ae829139af"
+
+[[package]]
+name = "protobuf"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+replace = "protobuf 1.4.1 (git+https://github.com/busyjay/rust-protobuf.git?branch=set-recurse-limit)"
 
 [[package]]
 name = "pulldown-cmark"
@@ -1149,6 +1155,7 @@ dependencies = [
 "checksum pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8cee804ecc7eaf201a4a207241472cc870e825206f6c031e3ee2a72fa425f2fa"
 "checksum procinfo 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f42e8578852a3306838981aedad8c5642ba794929aa12af0c9eb6c072b77af6c"
 "checksum prometheus 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "276b782a9f116c6dc1e9dc63611e9e944b9dba5b29bb4bd24b55013af9c3fc00"
+"checksum protobuf 1.4.1 (git+https://github.com/busyjay/rust-protobuf.git?branch=set-recurse-limit)" = "<none>"
 "checksum protobuf 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "568a15e4d572d9a5e63ae3a55f84328c984842887db179b40b4cc6a608bac6a4"
 "checksum pulldown-cmark 0.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "378e941dbd392c101f2cb88097fa4d7167bc421d4b88de3ff7dbee503bc3233b"
 "checksum quick-error 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7ac990ab4e038dd8481a5e3fd00641067fcfc674ad663f3222752ed5284e05d4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,9 @@ optional = true
 [dependencies.fail]
 git = "https://github.com/pingcap/fail-rs.git"
 
+[replace]
+"protobuf:1.4.1" = { git = "https://github.com/busyjay/rust-protobuf.git", branch = "set-recurse-limit" }
+
 [profile.dev]
 opt-level = 0  # Controls the --opt-level the compiler builds with
 debug = true   # Controls whether the compiler passes `-g`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ optional = true
 git = "https://github.com/pingcap/fail-rs.git"
 
 [replace]
-"protobuf:1.4.1" = { git = "https://github.com/busyjay/rust-protobuf.git", branch = "set-recurse-limit" }
+"protobuf:1.4.1" = { git = "https://github.com/stepancheg/rust-protobuf.git" }
 
 [profile.dev]
 opt-level = 0  # Controls the --opt-level the compiler builds with

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -37,6 +37,8 @@
 
 # stack size of endpoint, complicated tasks may involve very deep recursion.
 # end-point-stack-size = "10MB"
+# max recursion level allowed when decoding dag expression
+# end-point-recursion-limit = 1000
 
 # set attributes about this server, e.g. { zone = "us-west-1", disk = "ssd" }.
 # labels = {}

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -21,7 +21,7 @@ use tipb::select::{self, Chunk, DAGRequest, SelectRequest};
 use tipb::analyze::{AnalyzeReq, AnalyzeType};
 use tipb::executor::ExecType;
 use tipb::schema::ColumnInfo;
-use protobuf::Message as PbMsg;
+use protobuf::{CodedInputStream, Message as PbMsg};
 use kvproto::coprocessor::{KeyRange, Request, Response};
 use kvproto::errorpb::{self, ServerIsBusy};
 use kvproto::kvrpcpb::{CommandPri, IsolationLevel};
@@ -304,7 +304,7 @@ pub struct RequestTask {
 }
 
 impl RequestTask {
-    pub fn new(req: Request, on_resp: OnResponse) -> RequestTask {
+    pub fn new(req: Request, on_resp: OnResponse, recursion_limit: isize) -> RequestTask {
         let timer = Instant::now_coarse();
         let deadline = timer + Duration::from_secs(REQUEST_MAX_HANDLE_SECS);
         let mut start_ts = None;
@@ -315,8 +315,10 @@ impl RequestTask {
                 if tp == REQ_TYPE_SELECT {
                     table_scan = true;
                 }
+                let mut is = CodedInputStream::from_bytes(req.get_data());
+                is.set_recursion_limit(recursion_limit);
                 let mut sel = SelectRequest::new();
-                if let Err(e) = sel.merge_from_bytes(req.get_data()) {
+                if let Err(e) = sel.merge_from(&mut is) {
                     Err(box_err!(e))
                 } else {
                     start_ts = Some(sel.get_start_ts());
@@ -324,8 +326,10 @@ impl RequestTask {
                 }
             }
             REQ_TYPE_DAG => {
+                let mut is = CodedInputStream::from_bytes(req.get_data());
+                is.set_recursion_limit(recursion_limit);
                 let mut dag = DAGRequest::new();
-                if let Err(e) = dag.merge_from_bytes(req.get_data()) {
+                if let Err(e) = dag.merge_from(&mut is) {
                     Err(box_err!(e))
                 } else {
                     start_ts = Some(dag.get_start_ts());
@@ -338,8 +342,10 @@ impl RequestTask {
                 }
             }
             REQ_TYPE_ANALYZE => {
+                let mut is = CodedInputStream::from_bytes(req.get_data());
+                is.set_recursion_limit(recursion_limit);
                 let mut analyze = AnalyzeReq::new();
-                if let Err(e) = analyze.merge_from_bytes(req.get_data()) {
+                if let Err(e) = analyze.merge_from(&mut is) {
                     Err(box_err!(e))
                 } else {
                     start_ts = Some(analyze.get_start_ts());
@@ -749,6 +755,9 @@ mod tests {
     use std::time::Duration;
 
     use kvproto::coprocessor::Request;
+    use tipb::select::DAGRequest;
+    use tipb::expression::Expr;
+    use tipb::executor::Executor;
 
     use util::worker::{FutureWorker, Worker};
     use util::time::Instant;
@@ -776,7 +785,11 @@ mod tests {
         let end_point = Host::new(engine, worker.scheduler(), &cfg, pd_worker.scheduler());
         worker.start_batch(end_point, 30).unwrap();
         let (tx, rx) = mpsc::channel();
-        let mut task = RequestTask::new(Request::new(), box move |msg| { tx.send(msg).unwrap(); });
+        let mut task = RequestTask::new(
+            Request::new(),
+            box move |msg| { tx.send(msg).unwrap(); },
+            1000,
+        );
         task.ctx.deadline -= Duration::from_secs(super::REQUEST_MAX_HANDLE_SECS);
         worker.schedule(Task::Request(task)).unwrap();
         let resp = rx.recv_timeout(Duration::from_secs(3)).unwrap();
@@ -805,10 +818,14 @@ mod tests {
             } else {
                 req.mut_context().set_priority(CommandPri::High);
             }
-            let task = RequestTask::new(req, box move |msg| {
-                thread::sleep(Duration::from_millis(100));
-                let _ = tx.send(msg);
-            });
+            let task = RequestTask::new(
+                req,
+                box move |msg| {
+                    thread::sleep(Duration::from_millis(100));
+                    let _ = tx.send(msg);
+                },
+                1000,
+            );
             worker.schedule(Task::Request(task)).unwrap();
         }
         for _ in 0..120 {
@@ -820,5 +837,35 @@ mod tests {
             return;
         }
         panic!("suppose to get ServerIsBusy error.");
+    }
+
+    #[test]
+    fn test_stack_guard() {
+        let mut expr = Expr::new();
+        for _ in 0..10 {
+            let mut e = Expr::new();
+            e.mut_children().push(expr);
+            expr = e;
+        }
+        let mut e = Executor::new();
+        e.mut_selection().mut_conditions().push(expr);
+        let mut dag = DAGRequest::new();
+        dag.mut_executors().push(e);
+        let mut req = Request::new();
+        req.set_tp(REQ_TYPE_DAG);
+        req.set_data(dag.write_to_bytes().unwrap());
+        RequestTask::new(req.clone(), box move |_| unreachable!(), 100);
+        RequestTask::new(
+            req,
+            box move |res| {
+                let s = format!("{:?}", res);
+                assert!(
+                    s.contains("Recursion"),
+                    "parse should fail due to recursion limit {}",
+                    s
+                );
+            },
+            5,
+        );
     }
 }

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -304,7 +304,7 @@ pub struct RequestTask {
 }
 
 impl RequestTask {
-    pub fn new(req: Request, on_resp: OnResponse, recursion_limit: isize) -> RequestTask {
+    pub fn new(req: Request, on_resp: OnResponse, recursion_limit: u32) -> RequestTask {
         let timer = Instant::now_coarse();
         let deadline = timer + Duration::from_secs(REQUEST_MAX_HANDLE_SECS);
         let mut start_ts = None;

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -64,7 +64,7 @@ pub struct Config {
     pub end_point_concurrency: usize,
     pub end_point_max_tasks: usize,
     pub end_point_stack_size: ReadableSize,
-    pub end_point_recursion_limit: isize,
+    pub end_point_recursion_limit: u32,
     // Server labels to specify some attributes about this server.
     #[serde(with = "config::order_map_serde")]
     pub labels: HashMap<String, String>,

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -80,6 +80,7 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver + 'static> Server<T, S> {
             end_point_worker.scheduler(),
             raft_router.clone(),
             snap_worker.scheduler(),
+            cfg.end_point_recursion_limit,
         );
         let addr = SocketAddr::from_str(&cfg.addr)?;
         info!("listening on {}", addr);

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -53,7 +53,7 @@ pub struct Service<T: RaftStoreRouter + 'static> {
     // For handling snapshot.
     snap_scheduler: Scheduler<SnapTask>,
     token: Arc<AtomicUsize>, // TODO: remove it.
-    recursion_limit: isize,
+    recursion_limit: u32,
 }
 
 impl<T: RaftStoreRouter + 'static> Service<T> {
@@ -62,7 +62,7 @@ impl<T: RaftStoreRouter + 'static> Service<T> {
         end_point_scheduler: Scheduler<EndPointTask>,
         ch: T,
         snap_scheduler: Scheduler<SnapTask>,
-        recursion_limit: isize,
+        recursion_limit: u32,
     ) -> Service<T> {
         Service {
             storage: storage,

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -53,6 +53,7 @@ pub struct Service<T: RaftStoreRouter + 'static> {
     // For handling snapshot.
     snap_scheduler: Scheduler<SnapTask>,
     token: Arc<AtomicUsize>, // TODO: remove it.
+    recursion_limit: isize,
 }
 
 impl<T: RaftStoreRouter + 'static> Service<T> {
@@ -61,6 +62,7 @@ impl<T: RaftStoreRouter + 'static> Service<T> {
         end_point_scheduler: Scheduler<EndPointTask>,
         ch: T,
         snap_scheduler: Scheduler<SnapTask>,
+        recursion_limit: isize,
     ) -> Service<T> {
         Service {
             storage: storage,
@@ -68,6 +70,7 @@ impl<T: RaftStoreRouter + 'static> Service<T> {
             ch: ch,
             snap_scheduler: snap_scheduler,
             token: Arc::new(AtomicUsize::new(1)),
+            recursion_limit: recursion_limit,
         }
     }
 
@@ -748,8 +751,9 @@ impl<T: RaftStoreRouter + 'static> tikvpb_grpc::Tikv for Service<T> {
             .start_coarse_timer();
 
         let (cb, future) = make_callback();
-        let res = self.end_point_scheduler
-            .schedule(EndPointTask::Request(RequestTask::new(req, cb)));
+        let res = self.end_point_scheduler.schedule(EndPointTask::Request(
+            RequestTask::new(req, cb, self.recursion_limit),
+        ));
         if let Err(e) = res {
             self.send_fail_status(ctx, sink, Error::from(e), RpcStatusCode::ResourceExhausted);
             return;

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -64,6 +64,7 @@ fn test_serde_custom_tikv_config() {
         end_point_concurrency: 12,
         end_point_max_tasks: 12,
         end_point_stack_size: ReadableSize::mb(12),
+        end_point_recursion_limit: 100,
     };
     value.metric = MetricConfig {
         interval: ReadableDuration::secs(12),

--- a/tests/config/test-custom.toml
+++ b/tests/config/test-custom.toml
@@ -13,6 +13,7 @@ grpc-stream-initial-window-size = 12345
 end-point-concurrency = 12
 end-point-max-tasks = 12
 end-point-stack-size = "12MB"
+end-point-recursion-limit = 100
 
 [server.labels]
 a = "b"

--- a/tests/coprocessor/test_select.rs
+++ b/tests/coprocessor/test_select.rs
@@ -1661,7 +1661,7 @@ fn test_reverse() {
 
 pub fn handle_request(end_point: &Worker<EndPointTask>, req: Request) -> Response {
     let (tx, rx) = mpsc::channel();
-    let req = RequestTask::new(req, box move |r| tx.send(r).unwrap());
+    let req = RequestTask::new(req, box move |r| tx.send(r).unwrap(), 100);
     end_point.schedule(EndPointTask::Request(req)).unwrap();
     rx.recv().unwrap()
 }
@@ -2427,7 +2427,7 @@ fn test_handle_truncate() {
             .where_expr(cond.clone())
             .build();
         let (tx, rx) = mpsc::channel();
-        let req = RequestTask::new(req, box move |r| tx.send(r).unwrap());
+        let req = RequestTask::new(req, box move |r| tx.send(r).unwrap(), 100);
         end_point.schedule(EndPointTask::Request(req)).unwrap();
         let resp = rx.recv().unwrap();
         assert!(!resp.get_other_error().is_empty());
@@ -2535,7 +2535,7 @@ fn test_handle_truncate_for_dag() {
             .where_expr(cond.clone())
             .build();
         let (tx, rx) = mpsc::channel();
-        let req = RequestTask::new(req, box move |r| tx.send(r).unwrap());
+        let req = RequestTask::new(req, box move |r| tx.send(r).unwrap(), 100);
         end_point.schedule(EndPointTask::Request(req)).unwrap();
         let resp = rx.recv().unwrap();
         assert!(!resp.get_other_error().is_empty());


### PR DESCRIPTION
This is a rewrite of pr #2424. Instead of checking it in executors, check it at the very beginning of deserialization.

Because pr stepancheg/rust-protobuf#248 is not merged (and released) yet, so use a branch for now.