### PR TITLE
cleanup mustconsumevec

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -38,7 +38,7 @@ use raftstore::store::worker::apply::ExecResult;
 
 use util::worker::{FutureWorker, Scheduler};
 use raftstore::store::worker::{Apply, ApplyRes, ApplyTask};
-use util::Either;
+use util::{Either, MustConsumeVec};
 use util::time::monotonic_raw_now;
 use util::collections::{FlatMap, FlatMapValues as Values, HashSet};
 
@@ -59,7 +59,7 @@ const DEFAULT_APPEND_WB_SIZE: usize = 4 * 1024;
 
 struct ReadIndexRequest {
     id: u64,
-    cmds: Vec<(RaftCmdRequest, Callback)>,
+    cmds: MustConsumeVec<(RaftCmdRequest, Callback)>,
     renew_lease_time: Timespec,
 }
 
@@ -68,14 +68,6 @@ impl ReadIndexRequest {
         unsafe {
             let id = &self.id as *const u64 as *const u8;
             slice::from_raw_parts(id, 8)
-        }
-    }
-}
-
-impl Drop for ReadIndexRequest {
-    fn drop(&mut self) {
-        if !self.cmds.is_empty() {
-            panic!("callback of index read at {} is leak.", self.id);
         }
     }
 }
@@ -1347,9 +1339,11 @@ impl Peer {
             return false;
         }
 
+        let mut v = MustConsumeVec::with_capacity("callback of index read", 1);
+        v.push((req, cb));
         self.pending_reads.reads.push_back(ReadIndexRequest {
             id: id,
-            cmds: vec![(req, cb)],
+            cmds: v,
             renew_lease_time: renew_lease_time,
         });
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -449,10 +449,16 @@ pub struct MustConsumeVec<T> {
 }
 
 impl<T> MustConsumeVec<T> {
+    #[inline]
     pub fn new(tag: &'static str) -> MustConsumeVec<T> {
+        MustConsumeVec::with_capacity(tag, 0)
+    }
+
+    #[inline]
+    pub fn with_capacity(tag: &'static str, cap: usize) -> MustConsumeVec<T> {
         MustConsumeVec {
             tag: tag,
-            v: vec![],
+            v: Vec::with_capacity(cap),
         }
     }
 }
@@ -656,7 +662,7 @@ mod tests {
 
     #[test]
     fn test_resource_leak() {
-        let res = panic::catch_unwind(|| {
+        let res = recover_safe!(|| {
             let mut v = MustConsumeVec::new("test");
             v.push(2);
         });


### PR DESCRIPTION
Use `recover_safe!` to hide the panic stacktrace and replace more code.