### PR TITLE
pd: fix a dead lock

### DIFF
--- a/src/pd/mod.rs
+++ b/src/pd/mod.rs
@@ -22,6 +22,7 @@ pub use self::errors::{Error, Result};
 pub use self::client::RpcClient;
 pub use self::util::validate_endpoints;
 pub use self::pd::{Runner as PdRunner, Task as PdTask};
+pub use self::util::RECONNECT_INTERVAL_SEC;
 
 use kvproto::metapb;
 use kvproto::pdpb;

--- a/src/pd/util.rs
+++ b/src/pd/util.rs
@@ -285,7 +285,9 @@ where
     F: Fn(&PdClient) -> GrpcResult<R>,
 {
     for _ in 0..retry {
-        match func(&client.inner.rl().client).map_err(Error::Grpc) {
+        // DO NOT put any lock operation in match statement, or it will cause dead lock!
+        let ret = { func(&client.inner.rl().client).map_err(Error::Grpc) };
+        match ret {
             Ok(r) => {
                 return Ok(r);
             }

--- a/src/pd/util.rs
+++ b/src/pd/util.rs
@@ -180,7 +180,7 @@ impl LeaderClient {
     }
 }
 
-const RECONNECT_INTERVAL_SEC: u64 = 1; // 1s
+pub const RECONNECT_INTERVAL_SEC: u64 = 1; // 1s
 
 /// The context of sending requets.
 pub struct Request<Req, Resp, F> {

--- a/tests/pd/mock/mocker/retry.rs
+++ b/tests/pd/mock/mocker/retry.rs
@@ -36,7 +36,7 @@ impl Retry {
         }
     }
 
-    fn ok_or_error(&self) -> bool {
+    fn is_ok(&self) -> bool {
         let count = self.count.fetch_add(1, Ordering::SeqCst);
         if count != 0 && count % self.retry == 0 {
             // it's ok.
@@ -50,7 +50,7 @@ impl Retry {
 
 impl PdMocker for Retry {
     fn get_region_by_id(&self, _: &GetRegionByIDRequest) -> Option<Result<GetRegionResponse>> {
-        if self.ok_or_error() {
+        if self.is_ok() {
             info!("[Retry] get_region_by_id returns Ok(_)");
             Some(Ok(GetRegionResponse::new()))
         } else {
@@ -60,7 +60,7 @@ impl PdMocker for Retry {
     }
 
     fn get_store(&self, _: &GetStoreRequest) -> Option<Result<GetStoreResponse>> {
-        if self.ok_or_error() {
+        if self.is_ok() {
             info!("[Retry] get_store returns Ok(_)");
             Some(Ok(GetStoreResponse::new()))
         } else {


### PR DESCRIPTION
Read lock won't be dropped inside of the `match` block.