### PR TITLE
Add get_region_info for pd client

### DIFF
--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -26,7 +26,7 @@ use util::{Either, HandyRwLock};
 use util::security::SecurityManager;
 use util::time::duration_to_sec;
 use pd::{Config, PdFuture};
-use super::{Error, PdClient, RegionLeader, RegionStat, Result, REQUEST_TIMEOUT};
+use super::{Error, PdClient, RegionInfo, RegionStat, Result, REQUEST_TIMEOUT};
 use super::util::{check_resp_header, sync_request, validate_endpoints, Inner, LeaderClient};
 use super::metrics::*;
 
@@ -204,7 +204,7 @@ impl PdClient for RpcClient {
         Ok(resp.take_region())
     }
 
-    fn get_region_leader(&self, key: &[u8]) -> Result<RegionLeader> {
+    fn get_region_info(&self, key: &[u8]) -> Result<RegionInfo> {
         let _timer = PD_REQUEST_HISTOGRAM_VEC
             .with_label_values(&["get_region"])
             .start_coarse_timer();
@@ -229,7 +229,7 @@ impl PdClient for RpcClient {
         } else {
             None
         };
-        Ok(RegionLeader::new(region, leader))
+        Ok(RegionInfo::new(region, leader))
     }
 
     fn get_region_by_id(&self, region_id: u64) -> PdFuture<Option<metapb::Region>> {

--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -26,7 +26,7 @@ use util::{Either, HandyRwLock};
 use util::security::SecurityManager;
 use util::time::duration_to_sec;
 use pd::{Config, PdFuture};
-use super::{Error, PdClient, RegionStat, Result, REQUEST_TIMEOUT};
+use super::{Error, PdClient, RegionLeader, RegionStat, Result, REQUEST_TIMEOUT};
 use super::util::{check_resp_header, sync_request, validate_endpoints, Inner, LeaderClient};
 use super::metrics::*;
 
@@ -202,6 +202,34 @@ impl PdClient for RpcClient {
         check_resp_header(resp.get_header())?;
 
         Ok(resp.take_region())
+    }
+
+    fn get_region_leader(&self, key: &[u8]) -> Result<RegionLeader> {
+        let _timer = PD_REQUEST_HISTOGRAM_VEC
+            .with_label_values(&["get_region"])
+            .start_coarse_timer();
+
+        let mut req = pdpb::GetRegionRequest::new();
+        req.set_header(self.header());
+        req.set_region_key(key.to_vec());
+
+        let mut resp = sync_request(&self.leader_client, LEADER_CHANGE_RETRY, |client| {
+            let option = CallOption::default().timeout(Duration::from_secs(REQUEST_TIMEOUT));
+            client.get_region_opt(req.clone(), option)
+        })?;
+        check_resp_header(resp.get_header())?;
+
+        let region = if resp.has_region() {
+            resp.take_region()
+        } else {
+            return Err(Error::RegionNotFound);
+        };
+        let leader = if resp.has_leader() {
+            Some(resp.take_leader())
+        } else {
+            None
+        };
+        Ok(RegionLeader::new(region, leader))
     }
 
     fn get_region_by_id(&self, region_id: u64) -> PdFuture<Option<metapb::Region>> {

--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -222,7 +222,7 @@ impl PdClient for RpcClient {
         let region = if resp.has_region() {
             resp.take_region()
         } else {
-            return Err(Error::RegionNotFound);
+            return Err(Error::RegionNotFound(key.to_owned()));
         };
         let leader = if resp.has_leader() {
             Some(resp.take_leader())

--- a/src/pd/errors.rs
+++ b/src/pd/errors.rs
@@ -41,7 +41,10 @@ quick_error!{
             description(err.description())
             display("unknown error {:?}", err)
         }
-        RegionNotFound {}
+        RegionNotFound(key: Vec<u8>) {
+            description("region is not found")
+            display("region is not found for key {:?}", key)
+        }
     }
 }
 

--- a/src/pd/errors.rs
+++ b/src/pd/errors.rs
@@ -41,6 +41,7 @@ quick_error!{
             description(err.description())
             display("unknown error {:?}", err)
         }
+        RegionNotFound {}
     }
 }
 

--- a/src/pd/mod.rs
+++ b/src/pd/mod.rs
@@ -69,21 +69,21 @@ impl RegionStat {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct RegionLeader {
+pub struct RegionInfo {
     pub region: metapb::Region,
     pub leader: Option<metapb::Peer>,
 }
 
-impl RegionLeader {
-    pub fn new(region: metapb::Region, leader: Option<metapb::Peer>) -> RegionLeader {
-        RegionLeader {
+impl RegionInfo {
+    pub fn new(region: metapb::Region, leader: Option<metapb::Peer>) -> RegionInfo {
+        RegionInfo {
             region: region,
             leader: leader,
         }
     }
 }
 
-impl Deref for RegionLeader {
+impl Deref for RegionInfo {
     type Target = metapb::Region;
 
     fn deref(&self) -> &Self::Target {
@@ -91,15 +91,15 @@ impl Deref for RegionLeader {
     }
 }
 
-impl DerefMut for RegionLeader {
+impl DerefMut for RegionInfo {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.region
     }
 }
 
-impl From<metapb::Region> for RegionLeader {
-    fn from(region: metapb::Region) -> RegionLeader {
-        RegionLeader::new(region, None)
+impl From<metapb::Region> for RegionInfo {
+    fn from(region: metapb::Region) -> RegionInfo {
+        RegionInfo::new(region, None)
     }
 }
 
@@ -158,10 +158,10 @@ pub trait PdClient: Send + Sync {
     // Get region which the key belong to.
     fn get_region(&self, key: &[u8]) -> Result<metapb::Region>;
 
-    // Get region and leader which the key belong to.
+    // Get region info which the key belong to.
     // We can return leader in `get_region` too, but that will break a lot of code.
     // In most cases we just need the region, so just leave it for convenience.
-    fn get_region_leader(&self, key: &[u8]) -> Result<RegionLeader> {
+    fn get_region_info(&self, key: &[u8]) -> Result<RegionInfo> {
         self.get_region(key).map(|region| region.into())
     }
 

--- a/src/pd/mod.rs
+++ b/src/pd/mod.rs
@@ -26,8 +26,6 @@ pub use self::pd::{Runner as PdRunner, Task as PdTask};
 pub use self::util::RECONNECT_INTERVAL_SEC;
 pub use self::config::Config;
 
-use std::ops::{Deref, DerefMut};
-
 use kvproto::metapb;
 use kvproto::pdpb;
 use futures::Future;
@@ -80,26 +78,6 @@ impl RegionInfo {
             region: region,
             leader: leader,
         }
-    }
-}
-
-impl Deref for RegionInfo {
-    type Target = metapb::Region;
-
-    fn deref(&self) -> &Self::Target {
-        &self.region
-    }
-}
-
-impl DerefMut for RegionInfo {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.region
-    }
-}
-
-impl From<metapb::Region> for RegionInfo {
-    fn from(region: metapb::Region) -> RegionInfo {
-        RegionInfo::new(region, None)
     }
 }
 
@@ -159,10 +137,9 @@ pub trait PdClient: Send + Sync {
     fn get_region(&self, key: &[u8]) -> Result<metapb::Region>;
 
     // Get region info which the key belong to.
-    // We can return leader in `get_region` too, but that will break a lot of code.
-    // In most cases we just need the region, so just leave it for convenience.
     fn get_region_info(&self, key: &[u8]) -> Result<RegionInfo> {
-        self.get_region(key).map(|region| region.into())
+        self.get_region(key)
+            .map(|region| RegionInfo::new(region, None))
     }
 
     // Get region by region id.

--- a/src/pd/mod.rs
+++ b/src/pd/mod.rs
@@ -26,6 +26,8 @@ pub use self::pd::{Runner as PdRunner, Task as PdTask};
 pub use self::util::RECONNECT_INTERVAL_SEC;
 pub use self::config::Config;
 
+use std::ops::Deref;
+
 use kvproto::metapb;
 use kvproto::pdpb;
 use futures::Future;
@@ -78,6 +80,14 @@ impl RegionInfo {
             region: region,
             leader: leader,
         }
+    }
+}
+
+impl Deref for RegionInfo {
+    type Target = metapb::Region;
+
+    fn deref(&self) -> &Self::Target {
+        &self.region
     }
 }
 


### PR DESCRIPTION
We need to know a region's leader when calling some kv RPCs, but the original `get_region` method doesn't return the leader in the response. We can return a region's leader in `get_region`, but it will break a lot of code. Since in most cases, we just need to get the region, I keep the `get_region` method and add another `get_region_info` method for those who need to know the region's leader.