### PR TITLE
*: tiny cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ default: release
 
 all: format build test
 
-dev:
-	@env ENABLE_FEATURES=dev FAIL_POINT=1 make all
+dev: format
+	@env ENABLE_FEATURES=dev FAIL_POINT=1 make test
 
 build:
 	cargo build --features "${ENABLE_FEATURES}"

--- a/src/raftstore/store/worker/apply.rs
+++ b/src/raftstore/store/worker/apply.rs
@@ -167,15 +167,15 @@ pub enum ExecResult {
     DeleteRange { ranges: Vec<Range> },
 }
 
-struct ApplyCallBack {
+struct ApplyCallback {
     region: Region,
     cbs: Vec<(Option<Callback>, RaftCmdResponse)>,
 }
 
-impl ApplyCallBack {
-    fn new(region: Region) -> ApplyCallBack {
+impl ApplyCallback {
+    fn new(region: Region) -> ApplyCallback {
         let cbs = vec![];
-        ApplyCallBack { region, cbs }
+        ApplyCallback { region, cbs }
     }
 
     fn invoke_all(self, host: &CoprocessorHost) {
@@ -193,7 +193,7 @@ impl ApplyCallBack {
 struct ApplyContext<'a> {
     host: &'a CoprocessorHost,
     wb: WriteBatch,
-    cbs: MustConsumeVec<ApplyCallBack>,
+    cbs: MustConsumeVec<ApplyCallback>,
     wb_last_bytes: u64,
     wb_last_keys: u64,
     sync_log: bool,
@@ -214,7 +214,7 @@ impl<'a> ApplyContext<'a> {
     }
 
     fn prepare_for(&mut self, delegate: &ApplyDelegate) {
-        self.cbs.push(ApplyCallBack::new(delegate.region.clone()));
+        self.cbs.push(ApplyCallback::new(delegate.region.clone()));
     }
 
     pub fn mark_last_bytes_and_keys(&mut self) {


### PR DESCRIPTION
- change dev target to skip build target, so it can run faster.
- fix typos