### PR TITLE
set raftstore thread priority

### DIFF
--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -44,6 +44,7 @@ use util::worker::{FutureWorker, Scheduler, Stopped, Worker};
 use util::transport::SendCh;
 use util::RingQueue;
 use util::collections::{HashMap, HashSet};
+use util::sys as util_sys;
 use storage::{CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
 use raftstore::coprocessor::CoprocessorHost;
 use raftstore::coprocessor::split_observer::SplitObserver;
@@ -541,6 +542,8 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         let apply_runner = ApplyRunner::new(self, tx, self.cfg.sync_log);
         self.apply_res_receiver = Some(rx);
         box_try!(self.apply_worker.start(apply_runner));
+
+        util_sys::adjust_priority(util_sys::AdjustPriType::Incr);
 
         event_loop.run(self)?;
         Ok(())

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -543,7 +543,9 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         self.apply_res_receiver = Some(rx);
         box_try!(self.apply_worker.start(apply_runner));
 
-        util_sys::adjust_priority(util_sys::AdjustPriType::Incr);
+        if let Err(e) = util_sys::pri::set_priority(util_sys::HIGH_PRI) {
+            warn!("set priority for raftstore failed, error: {:?}", e);
+        }
 
         event_loop.run(self)?;
         Ok(())

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -44,6 +44,7 @@ pub mod collections;
 pub mod time;
 pub mod io_limiter;
 pub mod security;
+pub mod sys;
 
 pub use self::rocksdb::properties;
 

--- a/src/util/sys/mod.rs
+++ b/src/util/sys/mod.rs
@@ -8,8 +8,8 @@ pub mod pri {
 
     pub fn set_priority(pri: i32) -> Result<(), Error> {
         unsafe {
-            let pid = libc::syscall(libc::SYS_gettid);
-            if libc::setpriority(libc::PRIO_PROCESS as u32, pid as u32, pri) != 0 {
+            let tid = libc::syscall(libc::SYS_gettid);
+            if libc::setpriority(libc::PRIO_PROCESS as u32, tid as u32, pri) != 0 {
                 let e = Error::last_os_error();
                 return Err(e);
             }
@@ -19,10 +19,10 @@ pub mod pri {
 
     pub fn get_priority() -> Result<i32, Error> {
         unsafe {
-            let pid = libc::syscall(libc::SYS_gettid);
+            let tid = libc::syscall(libc::SYS_gettid);
             // clean previous error
             let _ = Error::last_os_error();
-            let ret = libc::getpriority(libc::PRIO_PROCESS as u32, pid as u32);
+            let ret = libc::getpriority(libc::PRIO_PROCESS as u32, tid as u32);
             if ret == -1 {
                 let e = Error::last_os_error();
                 if let Some(errno) = e.raw_os_error() {

--- a/src/util/sys/mod.rs
+++ b/src/util/sys/mod.rs
@@ -37,7 +37,6 @@ pub mod pri {
         use std::io::ErrorKind;
 
         #[test]
-        #[cfg(target_os = "linux")]
         fn test_set_priority() {
             // priority is a value in range -20 to 19, the default priority
             // is 0, lower priorities cause more favorable scheduling.

--- a/src/util/sys/mod.rs
+++ b/src/util/sys/mod.rs
@@ -4,7 +4,7 @@ pub const HIGH_PRI: i32 = -1;
 #[cfg(target_os = "linux")]
 pub mod pri {
     use libc;
-    use std::io::{Error, ErrorKind};
+    use std::io::Error;
 
     pub fn set_priority(pri: i32) -> Result<(), Error> {
         unsafe {

--- a/src/util/sys/mod.rs
+++ b/src/util/sys/mod.rs
@@ -41,8 +41,8 @@ pub mod pri {
         fn test_set_priority() {
             // priority is a value in range -20 to 19, the default priority
             // is 0, lower priorities cause more favorable scheduling.
-            assert_eq!(get_priority(), Ok(0));
-            assert!(set_priority(10).is_ok());
+            assert_eq!(get_priority().unwrap(), 0);
+            set_priority(10).unwrap();
             assert_eq!(get_priority().unwrap(), 10);
 
             // only users which have `SYS_NICE_CAP` capability can priority.

--- a/src/util/sys/mod.rs
+++ b/src/util/sys/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(target_os = "linux")]
 use libc;
 
 pub enum AdjustPriType {
@@ -6,16 +7,18 @@ pub enum AdjustPriType {
     Desc,
 }
 
+#[cfg(target_os = "linux")]
 pub fn adjust_priority(t: AdjustPriType) {
-    if cfg!(target_os = "unix") {
-        unsafe {
-            let pid = libc::pthread_self();
-            let pri = match t {
-                AdjustPriType::Incr => -1,
-                AdjustPriType::Normal => 0,
-                AdjustPriType::Desc => 1,
-            };
-            libc::setpriority(libc::PRIO_PROCESS as u32, pid as u32, pri);
-        }
+    unsafe {
+        let pid = libc::pthread_self();
+        let pri = match t {
+            AdjustPriType::Incr => -1,
+            AdjustPriType::Normal => 0,
+            AdjustPriType::Desc => 1,
+        };
+        libc::setpriority(libc::PRIO_PROCESS as u32, pid as u32, pri);
     }
 }
+
+#[cfg(not(target_os = "linux"))]
+pub fn adjust_priority(_: AdjustPriType) {}

--- a/src/util/sys/mod.rs
+++ b/src/util/sys/mod.rs
@@ -1,32 +1,71 @@
-#[cfg(target_os = "linux")]
-use libc;
-#[cfg(target_os = "linux")]
-use std::io::Error;
 
-pub enum AdjustPriType {
-    Incr,
-    Normal,
-    Desc,
-}
+pub const HIGH_PRI: i32 = -1;
 
 #[cfg(target_os = "linux")]
-pub fn adjust_priority(t: AdjustPriType) {
-    unsafe {
-        let pid = libc::pthread_self();
-        let pri = match t {
-            AdjustPriType::Incr => -1,
-            AdjustPriType::Normal => 0,
-            AdjustPriType::Desc => 1,
-        };
-        if libc::setpriority(libc::PRIO_PROCESS as u32, pid as u32, pri) != 0 {
-            warn!(
-                "set thread priority to {} failed, error {:?}",
-                pri,
-                Error::last_os_error()
-            );
+pub mod pri {
+    use libc;
+    use std::io::{Error, ErrorKind};
+
+    pub fn set_priority(pri: i32) -> Result<(), Error> {
+        unsafe {
+            let pid = libc::getpid();
+            if libc::setpriority(libc::PRIO_PROCESS as u32, pid as u32, pri) != 0 {
+                let e = Error::last_os_error();
+                return Err(e);
+            }
+            Ok(())
+        }
+    }
+
+    pub fn get_priority() -> Result<i32, Error> {
+        unsafe {
+            let pid = libc::getpid();
+            let ret = libc::getpriority(libc::PRIO_PROCESS as u32, pid as u32);
+            if ret == -1 {
+                let e = Error::last_os_error();
+                if e.kind() != ErrorKind::Other {
+                    return Err(e);
+                }
+            }
+            Ok(ret)
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::io::ErrorKind;
+
+        #[test]
+        #[cfg(target_os = "linux")]
+        fn test_set_priority() {
+            // priority is a value in range -20 to 19, the default priority
+            // is 0, lower priorities cause more favorable scheduling.
+            assert_eq!(get_priority(), Ok(0));
+            assert!(set_proitiry(10).is_ok());
+
+            assert_eq!(get_priority(), Ok(10));
+
+            // only users which have `SYS_NICE_CAP` capability can priority.
+            let ret = set_proitiry(-10);
+            if let ret = Err(e) {
+                assert_eq!(e.kind(), ErrorKind::PermissionDenied);
+            } else {
+                assert_eq!(get_priority(), Ok(-10));
+            }
         }
     }
 }
 
 #[cfg(not(target_os = "linux"))]
-pub fn adjust_priority(_: AdjustPriType) {}
+pub mod pri {
+    use std::io::Error;
+
+    pub fn set_priority(_: i32) -> Result<(), Error> {
+        Ok(())
+    }
+
+    pub fn get_priority() -> Result<i32, Error> {
+        Ok(0)
+    }
+}

--- a/src/util/sys/mod.rs
+++ b/src/util/sys/mod.rs
@@ -11,11 +11,11 @@ pub fn adjust_priority(t: AdjustPriType) {
         unsafe {
             let pid = libc::pthread_self();
             let pri = match t {
-                Incr => -1,
-                Normal => 0,
-                Desc => 1,
+                AdjustPriType::Incr => -1,
+                AdjustPriType::Normal => 0,
+                AdjustPriType::Desc => 1,
             };
-            libc::setpriority(libc::PRIO_PROCESS, pid, pri);
+            libc::setpriority(libc::PRIO_PROCESS as u32, pid as u32, pri);
         }
     }
 }

--- a/src/util/sys/mod.rs
+++ b/src/util/sys/mod.rs
@@ -20,11 +20,15 @@ pub mod pri {
     pub fn get_priority() -> Result<i32, Error> {
         unsafe {
             let pid = libc::getpid();
+            // clean previous error
+            let _ = Error::last_os_error();
             let ret = libc::getpriority(libc::PRIO_PROCESS as u32, pid as u32);
             if ret == -1 {
                 let e = Error::last_os_error();
-                if e.kind() != ErrorKind::Other {
-                    return Err(e);
+                if let Some(errno) = e.raw_os_error() {
+                    if errno != 0 {
+                        return Err(e);
+                    }
                 }
             }
             Ok(ret)

--- a/src/util/sys/mod.rs
+++ b/src/util/sys/mod.rs
@@ -49,7 +49,7 @@ pub mod pri {
             set_priority(10).unwrap();
             assert_eq!(get_priority().unwrap(), 10);
 
-            // only users which have `SYS_NICE_CAP` capability can increase priority.
+            // only users who have `SYS_NICE_CAP` capability can increase priority.
             let ret = set_priority(HIGH_PRI);
             if let Err(e) = ret {
                 assert_eq!(e.kind(), ErrorKind::PermissionDenied);

--- a/src/util/sys/mod.rs
+++ b/src/util/sys/mod.rs
@@ -34,6 +34,7 @@ pub mod pri {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use super::super::HIGH_PRI;
         use std::io::ErrorKind;
 
         #[test]

--- a/src/util/sys/mod.rs
+++ b/src/util/sys/mod.rs
@@ -22,7 +22,7 @@ pub fn adjust_priority(t: AdjustPriType) {
             warn!(
                 "set thread priority to {} failed, error {:?}",
                 pri,
-                Error::last_os_err()
+                Error::last_os_error()
             );
         }
     }

--- a/src/util/sys/mod.rs
+++ b/src/util/sys/mod.rs
@@ -42,16 +42,15 @@ pub mod pri {
             // priority is a value in range -20 to 19, the default priority
             // is 0, lower priorities cause more favorable scheduling.
             assert_eq!(get_priority(), Ok(0));
-            assert!(set_proitiry(10).is_ok());
-
-            assert_eq!(get_priority(), Ok(10));
+            assert!(set_priority(10).is_ok());
+            assert_eq!(get_priority().unwrap(), 10);
 
             // only users which have `SYS_NICE_CAP` capability can priority.
-            let ret = set_proitiry(-10);
-            if let ret = Err(e) {
+            let ret = set_priority(-10);
+            if let Err(e) = ret {
                 assert_eq!(e.kind(), ErrorKind::PermissionDenied);
             } else {
-                assert_eq!(get_priority(), Ok(-10));
+                assert_eq!(get_priority().unwrap(), -10);
             }
         }
     }

--- a/src/util/sys/mod.rs
+++ b/src/util/sys/mod.rs
@@ -44,12 +44,12 @@ pub mod pri {
             set_priority(10).unwrap();
             assert_eq!(get_priority().unwrap(), 10);
 
-            // only users which have `SYS_NICE_CAP` capability can priority.
-            let ret = set_priority(-10);
+            // only users which have `SYS_NICE_CAP` capability can increase priority.
+            let ret = set_priority(HIGH_PRI);
             if let Err(e) = ret {
                 assert_eq!(e.kind(), ErrorKind::PermissionDenied);
             } else {
-                assert_eq!(get_priority().unwrap(), -10);
+                assert_eq!(get_priority().unwrap(), HIGH_PRI);
             }
         }
     }

--- a/src/util/sys/mod.rs
+++ b/src/util/sys/mod.rs
@@ -1,0 +1,21 @@
+use libc;
+
+pub enum AdjustPriType {
+    Incr,
+    Normal,
+    Desc,
+}
+
+pub fn adjust_priority(t: AdjustPriType) {
+    if cfg!(target_os = "unix") {
+        unsafe {
+            let pid = libc::pthread_self();
+            let pri = match t {
+                Incr => -1,
+                Normal => 0,
+                Desc => 1,
+            };
+            libc::setpriority(libc::PRIO_PROCESS, pid, pri);
+        }
+    }
+}

--- a/src/util/sys/mod.rs
+++ b/src/util/sys/mod.rs
@@ -1,5 +1,7 @@
 #[cfg(target_os = "linux")]
 use libc;
+#[cfg(target_os = "linux")]
+use std::io::Error;
 
 pub enum AdjustPriType {
     Incr,
@@ -16,7 +18,13 @@ pub fn adjust_priority(t: AdjustPriType) {
             AdjustPriType::Normal => 0,
             AdjustPriType::Desc => 1,
         };
-        libc::setpriority(libc::PRIO_PROCESS as u32, pid as u32, pri);
+        if libc::setpriority(libc::PRIO_PROCESS as u32, pid as u32, pri) != 0 {
+            warn!(
+                "set thread priority to {} failed, error {:?}",
+                pri,
+                Error::last_os_err()
+            );
+        }
     }
 }
 

--- a/src/util/sys/mod.rs
+++ b/src/util/sys/mod.rs
@@ -8,7 +8,7 @@ pub mod pri {
 
     pub fn set_priority(pri: i32) -> Result<(), Error> {
         unsafe {
-            let pid = libc::getpid();
+            let pid = libc::syscall(libc::SYS_gettid);
             if libc::setpriority(libc::PRIO_PROCESS as u32, pid as u32, pri) != 0 {
                 let e = Error::last_os_error();
                 return Err(e);
@@ -19,7 +19,7 @@ pub mod pri {
 
     pub fn get_priority() -> Result<i32, Error> {
         unsafe {
-            let pid = libc::getpid();
+            let pid = libc::syscall(libc::SYS_gettid);
             // clean previous error
             let _ = Error::last_os_error();
             let ret = libc::getpriority(libc::PRIO_PROCESS as u32, pid as u32);


### PR DESCRIPTION
Two requirement:
1) user needs `CAP_SYS_NICE` capability.
2) only support linux platform.
or, nothing will happen.

In order to add `CAP_SYS_NICE` for user tidb, please add following two lines to /etc/security/limits.conf:
tidb        soft        nice          -1
tidb        hard        nice          -1