### PR TITLE
coprocessor: Fix return type for builtin aggregation fuction 'AVG' and 'SUM'

### DIFF
--- a/src/coprocessor/dag/executor/aggregation.rs
+++ b/src/coprocessor/dag/executor/aggregation.rs
@@ -286,7 +286,6 @@ mod test {
                 Datum::Dec(8.into()),
                 Datum::F64(3.0),
                 Datum::F64(3.0),
-
             ],
             vec![
                 Datum::I64(4),

--- a/src/coprocessor/dag/executor/aggregation.rs
+++ b/src/coprocessor/dag/executor/aggregation.rs
@@ -338,7 +338,7 @@ mod test {
             (ExprType::Avg, 0),
             (ExprType::Count, 2),
             (ExprType::Sum, 3),
-            (ExprType::Avg, 4)
+            (ExprType::Avg, 4),
         ];
         let aggr_funcs = build_aggr_func(&aggr_funcs);
         aggregation.set_agg_func(RepeatedField::from_vec(aggr_funcs));

--- a/src/coprocessor/dag/executor/aggregation.rs
+++ b/src/coprocessor/dag/executor/aggregation.rs
@@ -334,7 +334,12 @@ mod test {
         let group_by_cols = vec![1, 2];
         let group_by = build_group_by(&group_by_cols);
         aggregation.set_group_by(RepeatedField::from_vec(group_by));
-        let aggr_funcs = vec![(ExprType::Avg, 0), (ExprType::Count, 2), (ExprType::Sum, 3), (ExprType::Avg, 4)];
+        let aggr_funcs = vec![
+            (ExprType::Avg, 0),
+            (ExprType::Count, 2),
+            (ExprType::Sum, 3),
+            (ExprType::Avg, 4)
+        ];
         let aggr_funcs = build_aggr_func(&aggr_funcs);
         aggregation.set_agg_func(RepeatedField::from_vec(aggr_funcs));
         // init Aggregation Executor

--- a/src/coprocessor/dag/executor/aggregation.rs
+++ b/src/coprocessor/dag/executor/aggregation.rs
@@ -253,42 +253,59 @@ mod test {
             new_col_info(1, types::LONG_LONG),
             new_col_info(2, types::VARCHAR),
             new_col_info(3, types::NEW_DECIMAL),
+            new_col_info(4, types::FLOAT),
+            new_col_info(5, types::DOUBLE),
         ];
         let raw_data = vec![
             vec![
                 Datum::I64(1),
                 Datum::Bytes(b"a".to_vec()),
                 Datum::Dec(7.into()),
+                Datum::F64(1.0),
+                Datum::F64(1.0),
             ],
             vec![
                 Datum::I64(2),
                 Datum::Bytes(b"a".to_vec()),
                 Datum::Dec(7.into()),
+                Datum::F64(2.0),
+                Datum::F64(2.0),
             ],
             vec![
                 Datum::I64(3),
                 Datum::Bytes(b"b".to_vec()),
                 Datum::Dec(8.into()),
+                Datum::F64(3.0),
+                Datum::F64(3.0),
+
             ],
             vec![
                 Datum::I64(4),
                 Datum::Bytes(b"a".to_vec()),
                 Datum::Dec(7.into()),
+                Datum::F64(4.0),
+                Datum::F64(4.0),
             ],
             vec![
                 Datum::I64(5),
                 Datum::Bytes(b"f".to_vec()),
                 Datum::Dec(5.into()),
+                Datum::F64(5.0),
+                Datum::F64(5.0),
             ],
             vec![
                 Datum::I64(6),
                 Datum::Bytes(b"b".to_vec()),
                 Datum::Dec(8.into()),
+                Datum::F64(6.0),
+                Datum::F64(6.0),
             ],
             vec![
                 Datum::I64(7),
                 Datum::Bytes(b"f".to_vec()),
                 Datum::Dec(6.into()),
+                Datum::F64(7.0),
+                Datum::F64(7.0),
             ],
         ];
         let table_data = gen_table_data(tid, &cis, &raw_data);
@@ -308,7 +325,7 @@ mod test {
         let group_by_cols = vec![1, 2];
         let group_by = build_group_by(&group_by_cols);
         aggregation.set_group_by(RepeatedField::from_vec(group_by));
-        let aggr_funcs = vec![(ExprType::Avg, 0), (ExprType::Count, 2)];
+        let aggr_funcs = vec![(ExprType::Avg, 0), (ExprType::Count, 2), (ExprType::Sum, 3), (ExprType::Avg, 4)];
         let aggr_funcs = build_aggr_func(&aggr_funcs);
         aggregation.set_agg_func(RepeatedField::from_vec(aggr_funcs));
         // init Aggregation Executor
@@ -329,6 +346,9 @@ mod test {
                 3 as u64,
                 Decimal::from(7),
                 3 as u64,
+                7.0 as f64,
+                3 as u64,
+                7.0 as f64,
                 b"a".as_ref(),
                 Decimal::from(7),
             ),
@@ -336,6 +356,9 @@ mod test {
                 2 as u64,
                 Decimal::from(9),
                 2 as u64,
+                9.0 as f64,
+                2 as u64,
+                9.0 as f64,
                 b"b".as_ref(),
                 Decimal::from(8),
             ),
@@ -343,6 +366,9 @@ mod test {
                 1 as u64,
                 Decimal::from(5),
                 1 as u64,
+                5.0 as f64,
+                1 as u64,
+                5.0 as f64,
                 b"f".as_ref(),
                 Decimal::from(5),
             ),
@@ -350,11 +376,14 @@ mod test {
                 1 as u64,
                 Decimal::from(7),
                 1 as u64,
+                7.0 as f64,
+                1 as u64,
+                7.0 as f64,
                 b"f".as_ref(),
                 Decimal::from(6),
             ),
         ];
-        let expect_col_cnt = 5;
+        let expect_col_cnt = 8;
         for (row, expect_cols) in row_data.into_iter().zip(expect_row_data) {
             let ds = row.value.as_slice().decode().unwrap();
             assert_eq!(ds.len(), expect_col_cnt);

--- a/src/coprocessor/select/aggregate.rs
+++ b/src/coprocessor/select/aggregate.rs
@@ -130,7 +130,7 @@ impl AggrFunc for Sum {
         }
         let is_float = match res {
             Datum::F64(_) => true,
-            _ => false
+            _ => false,
         };
         if is_float {
             collector.push(Datum::F64(res.f64()));

--- a/src/coprocessor/select/aggregate.rs
+++ b/src/coprocessor/select/aggregate.rs
@@ -124,19 +124,12 @@ impl AggrFunc for Sum {
 
     fn calc(&mut self, collector: &mut Vec<Datum>) -> Result<()> {
         let res = self.res.take().unwrap_or(Datum::Null);
-        if res == Datum::Null {
-            collector.push(res);
-            return Ok(());
-        }
-        let is_float = match res {
-            Datum::F64(_) => true,
-            _ => false,
-        };
-        if is_float {
-            collector.push(Datum::F64(res.f64()));
-        } else {
-            let d = box_try!(res.into_dec());
-            collector.push(Datum::Dec(d));
+        match res {
+            Datum::Null | Datum::F64(_) => collector.push(res),
+            _ => {
+                let d = box_try!(res.into_dec());
+                collector.push(Datum::Dec(d));
+            },
         }
         Ok(())
     }

--- a/src/coprocessor/select/aggregate.rs
+++ b/src/coprocessor/select/aggregate.rs
@@ -129,7 +129,7 @@ impl AggrFunc for Sum {
             _ => {
                 let d = box_try!(res.into_dec());
                 collector.push(Datum::Dec(d));
-            },
+            }
         }
         Ok(())
     }

--- a/src/coprocessor/select/aggregate.rs
+++ b/src/coprocessor/select/aggregate.rs
@@ -128,8 +128,16 @@ impl AggrFunc for Sum {
             collector.push(res);
             return Ok(());
         }
-        let d = box_try!(res.into_dec());
-        collector.push(Datum::Dec(d));
+        let is_float = match res {
+            Datum::F64(_) => true,
+            _ => false
+        };
+        if is_float {
+            collector.push(Datum::F64(res.f64()));
+        } else {
+            let d = box_try!(res.into_dec());
+            collector.push(Datum::Dec(d));
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
corresponding modification for https://github.com/pingcap/tidb/pull/5292