### PR TITLE
Ingest SST with `move_files` option

### DIFF
--- a/src/util/file.rs
+++ b/src/util/file.rs
@@ -38,8 +38,18 @@ pub fn delete_file_if_exist(file: &PathBuf) {
 }
 
 pub fn copy_and_sync<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<u64> {
-    let res = fs::copy(&from, &to)?;
-    File::open(&to)?.sync_all()?;
+    if !from.as_ref().is_file() {
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            "the source path is not an existing regular file",
+        ));
+    }
+
+    let mut reader = File::open(from)?;
+    let mut writer = File::create(to)?;
+
+    let res = io::copy(&mut reader, &mut writer)?;
+    writer.sync_all()?;
     Ok(res)
 }
 

--- a/src/util/file.rs
+++ b/src/util/file.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 use std::io::{self, ErrorKind, Read};
-use std::fs::{self, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
 
 use crc::crc32::{self, Digest, Hasher32};
@@ -35,6 +35,12 @@ pub fn delete_file_if_exist(file: &PathBuf) {
             warn!("failed to delete file {}: {:?}", file.display(), e);
         }
     }
+}
+
+pub fn copy_and_sync<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<u64> {
+    let res = fs::copy(&from, &to)?;
+    File::open(&to)?.sync_all()?;
+    Ok(res)
 }
 
 const DIGEST_BUFFER_SIZE: usize = 10240;

--- a/src/util/rocksdb/mod.rs
+++ b/src/util/rocksdb/mod.rs
@@ -411,7 +411,7 @@ pub fn prepare_sst_for_ingestion<P: AsRef<Path>>(
 ) -> Result<(), String> {
     let path = path.as_ref().to_str().unwrap();
     let clone = clone.as_ref().to_str().unwrap();
-    if Path::new(clone).exists() {
+    if !Path::new(clone).exists() {
         fs::copy(path, clone)
             .map(|_| ())
             .map_err(|e| format!("copy from {} to {}: {:?}", path, clone, e))
@@ -509,7 +509,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_os = "linux")]
     fn test_prepare_sst_for_ingestion() {
         let path = TempDir::new("_util_rocksdb_test_prepare_sst_for_ingestion").expect("");
         let path_str = path.path().to_str().unwrap();

--- a/src/util/rocksdb/mod.rs
+++ b/src/util/rocksdb/mod.rs
@@ -391,12 +391,10 @@ pub fn prepare_sst_for_ingestion<P: AsRef<Path>, Q: AsRef<Path>>(
         // RocksDB must not have this file, we can make a hard link.
         fs::hard_link(path, clone)
             .map_err(|e| format!("link from {} to {}: {:?}", path, clone, e))?;
-        info!("link from {} to {}", path, clone);
     } else {
         // RocksDB may have this file, we should make a copy.
         copy_and_sync(path, clone)
             .map_err(|e| format!("copy from {} to {}: {:?}", path, clone, e))?;
-        info!("copy from {} to {}", path, clone);
     }
 
     Ok(())
@@ -412,7 +410,6 @@ pub fn prepare_sst_for_ingestion<P: AsRef<Path>, Q: AsRef<Path>>(
     if !Path::new(clone).exists() {
         copy_and_sync(path, clone)
             .map_err(|e| format!("copy from {} to {}: {:?}", path, clone, e))?;
-        info!("copy from {} to {}", path, clone);
     }
     Ok(())
 }

--- a/src/util/rocksdb/mod.rs
+++ b/src/util/rocksdb/mod.rs
@@ -391,10 +391,12 @@ pub fn prepare_sst_for_ingestion<P: AsRef<Path>, Q: AsRef<Path>>(
         // RocksDB must not have this file, we can make a hard link.
         fs::hard_link(path, clone)
             .map_err(|e| format!("link from {} to {}: {:?}", path, clone, e))?;
+        info!("link from {} to {}", path, clone);
     } else {
         // RocksDB may have this file, we should make a copy.
         copy_and_sync(path, clone)
             .map_err(|e| format!("copy from {} to {}: {:?}", path, clone, e))?;
+        info!("copy from {} to {}", path, clone);
     }
 
     Ok(())
@@ -409,11 +411,10 @@ pub fn prepare_sst_for_ingestion<P: AsRef<Path>, Q: AsRef<Path>>(
     let clone = clone.as_ref().to_str().unwrap();
     if !Path::new(clone).exists() {
         copy_and_sync(path, clone)
-            .map(|_| ())
-            .map_err(|e| format!("copy from {} to {}: {:?}", path, clone, e))
-    } else {
-        Ok(())
+            .map_err(|e| format!("copy from {} to {}: {:?}", path, clone, e))?;
+        info!("copy from {} to {}", path, clone);
     }
+    Ok(())
 }
 
 pub fn validate_sst_for_ingestion<P: AsRef<Path>>(

--- a/src/util/rocksdb/mod.rs
+++ b/src/util/rocksdb/mod.rs
@@ -32,6 +32,7 @@ use rocksdb::set_external_sst_file_global_seq_no;
 use util::rocksdb::engine_metrics::{ROCKSDB_COMPRESSION_RATIO_AT_LEVEL,
                                     ROCKSDB_CUR_SIZE_ALL_MEM_TABLES, ROCKSDB_TOTAL_SST_FILES_SIZE};
 use util::rocksdb;
+use util::file::copy_and_sync;
 
 pub use rocksdb::CFHandle;
 
@@ -394,7 +395,7 @@ pub fn prepare_sst_for_ingestion<P: AsRef<Path>>(
             .map_err(|e| format!("link from {} to {}: {:?}", path, clone, e))?;
     } else {
         // RocksDB may have this file, we should make a copy.
-        fs::copy(path, clone)
+        copy_and_sync(path, clone)
             .map_err(|e| format!("copy from {} to {}: {:?}", path, clone, e))?;
     }
 
@@ -412,7 +413,7 @@ pub fn prepare_sst_for_ingestion<P: AsRef<Path>>(
     let path = path.as_ref().to_str().unwrap();
     let clone = clone.as_ref().to_str().unwrap();
     if !Path::new(clone).exists() {
-        fs::copy(path, clone)
+        copy_and_sync(path, clone)
             .map(|_| ())
             .map_err(|e| format!("copy from {} to {}: {:?}", path, clone, e))
     } else {


### PR DESCRIPTION
Add a function to prepare a SST file for ingestion.
The purpose is to make the ingestion retryable when using the `move_files`
option. Things we need to consider here:
1. We need to access the original file on retry, so we should make a clone
   before ingestion.
2. `RocksDB` will modified the global seqno of the ingested file, so we need
   to modified the global seqno back to 0 so that we can pass the checksum
   validation.
3. If the file has been ingested to `RocksDB`, we should not modified the
   global seqno directly, because that may corrupt RocksDB's data.