### PR TITLE
tikv-fail: change addr arg to required

### DIFF
--- a/src/bin/tikv-fail.rs
+++ b/src/bin/tikv-fail.rs
@@ -49,6 +49,7 @@ fn main() {
         .about("A tool for injecting failures to TiKV and recovery")
         .arg(
             Arg::with_name("addr")
+                .required(true)
                 .short("a")
                 .takes_value(true)
                 .help("set tikv ip:port"),


### PR DESCRIPTION
addr arg is required now,or it will just show a unwrap error msg