### PR TITLE
Upgrade fail to 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,8 +214,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fail"
-version = "0.1.0"
-source = "git+https://github.com/pingcap/fail-rs.git#6a92d26dc04dc82359bbb73320caba9c5e9c3024"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -948,7 +948,7 @@ dependencies = [
  "clap 2.23.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.150 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fail 0.1.0 (git+https://github.com/pingcap/fail-rs.git)",
+ "fail 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flat_map 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1199,7 +1199,7 @@ dependencies = [
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
 "checksum either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18785c1ba806c258137c937e44ada9ee7e69a37e3c72077542cd2f069d78562a"
-"checksum fail 0.1.0 (git+https://github.com/pingcap/fail-rs.git)" = "<none>"
+"checksum fail 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd2e1a22c616c8c8c96b6e07c243014551f3ba77291d24c22e0bfea6830c0b4e"
 "checksum flat_map 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "fc16c081affe2ded9d62cd239a9ef1b4801fa98037b59523014f661c7bee182c"
 "checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
 "checksum fs2 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "237b7991317b8d94391c0a4813b1f74fd81c11352440cd598d2b763ed288bfc1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ murmur3 = "0.4.0"
 futures-cpupool = "0.1"
 zipf = "0.2.0"
 bitflags = "1.0.1"
+fail = "0.2"
 
 [target.'cfg(unix)'.dependencies]
 signal = "0.4"
@@ -92,9 +93,6 @@ git = "https://github.com/busyjay/jemallocator.git"
 branch = "dev"
 features = ["profiling"]
 optional = true
-
-[dependencies.fail]
-git = "https://github.com/pingcap/fail-rs.git"
 
 [replace]
 "protobuf:1.4.1" = { git = "https://github.com/stepancheg/rust-protobuf.git" }

--- a/src/raftstore/store/worker/region.rs
+++ b/src/raftstore/store/worker/region.rs
@@ -111,7 +111,7 @@ impl SnapContext {
         ));
         // Only enable the fail point when the region id is equal to 1, which is
         // the id of bootstrapped region in tests.
-        fail_point!("handle_gen", region_id == 1, |_| Ok(()));
+        fail_point!("region_handle_gen", region_id == 1, |_| Ok(()));
         if let Err(e) = notifier.try_send(snap) {
             info!(
                 "[region {}] failed to notify snap result, maybe leadership has changed, \
@@ -143,7 +143,7 @@ impl SnapContext {
 
     fn apply_snap(&self, region_id: u64, abort: Arc<AtomicUsize>) -> Result<()> {
         info!("[region {}] begin apply snap data", region_id);
-        fail_point!("apply_snap");
+        fail_point!("region_apply_snap");
         check_abort(&abort)?;
         let region_key = keys::region_state_key(region_id);
         let mut region_state: RegionLocalState =

--- a/src/raftstore/store/worker/region.rs
+++ b/src/raftstore/store/worker/region.rs
@@ -111,7 +111,7 @@ impl SnapContext {
         ));
         // Only enable the fail point when the region id is equal to 1, which is
         // the id of bootstrapped region in tests.
-        fail_point!("region_handle_gen", region_id == 1, |_| Ok(()));
+        fail_point!("region_gen_snap", region_id == 1, |_| Ok(()));
         if let Err(e) = notifier.try_send(snap) {
             info!(
                 "[region {}] failed to notify snap result, maybe leadership has changed, \

--- a/tests/failpoints_cases/test_pending_peers.rs
+++ b/tests/failpoints_cases/test_pending_peers.rs
@@ -28,7 +28,7 @@ fn test_pending_peers() {
     let mut cluster = new_node_cluster(0, 3);
     cluster.cfg.raft_store.pd_heartbeat_tick_interval = ReadableDuration::millis(100);
 
-    let region_worker_fp = "tikv::raftstore::store::worker::region::apply_snap";
+    let region_worker_fp = "region_apply_snap";
 
     let pd_client = cluster.pd_client.clone();
     // Disable default max peer count check.

--- a/tests/failpoints_cases/test_snap.rs
+++ b/tests/failpoints_cases/test_snap.rs
@@ -29,7 +29,7 @@ fn test_overlap_cleanup() {
     // Disable raft log gc in this test case.
     cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::secs(60);
 
-    let gen_snapshot_fp = "region_handle_gen";
+    let gen_snapshot_fp = "region_gen_snap";
 
     let pd_client = cluster.pd_client.clone();
     // Disable default max peer count check.

--- a/tests/failpoints_cases/test_snap.rs
+++ b/tests/failpoints_cases/test_snap.rs
@@ -29,7 +29,7 @@ fn test_overlap_cleanup() {
     // Disable raft log gc in this test case.
     cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::secs(60);
 
-    let gen_snapshot_fp = "tikv::raftstore::store::worker::region::handle_gen";
+    let gen_snapshot_fp = "region_handle_gen";
 
     let pd_client = cluster.pd_client.clone();
     // Disable default max peer count check.

--- a/tests/failpoints_cases/test_storage.rs
+++ b/tests/failpoints_cases/test_storage.rs
@@ -26,8 +26,8 @@ use storage::util::new_raft_engine;
 #[test]
 fn test_storage_1gc() {
     let _guard = ::setup();
-    let snapshot_fp = "tikv::storage::engine::raftkv::raftkv_async_snapshot_finish";
-    let batch_snapshot_fp = "tikv::storage::engine::raftkv::raftkv_async_batch_snapshot_finish";
+    let snapshot_fp = "raftkv_async_snapshot_finish";
+    let batch_snapshot_fp = "raftkv_async_batch_snapshot_finish";
     let (_cluster, engine, ctx) = new_raft_engine(3, "");
     let config = Config::default();
     let mut storage = Storage::from_engine(engine.clone(), &config).unwrap();


### PR DESCRIPTION
This PR upgrade fail to 0.2, all failpoints names are changed. 

Our internal stability tests need to a update too. CC @cwen0  