### PR TITLE
Fix make dev compile error on Mac

### DIFF
--- a/src/util/rocksdb/mod.rs
+++ b/src/util/rocksdb/mod.rs
@@ -532,7 +532,7 @@ mod tests {
     }
 
     #[cfg(not(target_os = "linux"))]
-    fn check_hard_link<P: AsRef<Path>>(path: P, nlink: u64) {
+    fn check_hard_link<P: AsRef<Path>>(_: P, _: u64) {
         // Just do nothing
     }
 

--- a/src/util/rocksdb/mod.rs
+++ b/src/util/rocksdb/mod.rs
@@ -533,8 +533,7 @@ mod tests {
 
     #[cfg(not(target_os = "linux"))]
     fn check_hard_link<P: AsRef<Path>>(path: P, nlink: u64) {
-        use std::os::unix::fs::MetadataExt;
-        assert_eq!(fs::metadata(path).unwrap().nlink(), nlink);
+        // Just do nothing
     }
 
     fn gen_sst_with_kvs(db: &DB, cf: &CFHandle, path: &str, kvs: &[(&str, &str)]) {

--- a/src/util/rocksdb/mod.rs
+++ b/src/util/rocksdb/mod.rs
@@ -525,11 +525,16 @@ mod tests {
         assert!(get_engine_compression_ratio_at_level(&db, cf, 0).is_some());
     }
 
+    #[cfg(target_os = "linux")]
     fn check_hard_link<P: AsRef<Path>>(path: P, nlink: u64) {
-        if cfg!(target_os = "linux") {
-            use std::os::linux::fs::MetadataExt;
-            assert_eq!(fs::metadata(path).unwrap().st_nlink(), nlink);
-        }
+        use std::os::linux::fs::MetadataExt;
+        assert_eq!(fs::metadata(path).unwrap().st_nlink(), nlink);
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn check_hard_link<P: AsRef<Path>>(path: P, nlink: u64) {
+        use std::os::unix::fs::MetadataExt;
+        assert_eq!(fs::metadata(path).unwrap().nlink(), nlink);
     }
 
     fn gen_sst_with_kvs(db: &DB, cf: &CFHandle, path: &str, kvs: &[(&str, &str)]) {


### PR DESCRIPTION
Execute make dev on MacOS will got compile error message: 

```
error[E0432]: unresolved import `std::os::linux`
   --> src/util/rocksdb/mod.rs:530:26
    |
530 |             use std::os::linux::fs::MetadataExt;
    |                          ^^^^^ Could not find `linux` in `os`

error[E0599]: no method named `st_nlink` found for type `std::fs::Metadata` in the current scope
   --> src/util/rocksdb/mod.rs:531:52
    |
531 |             assert_eq!(fs::metadata(path).unwrap().st_nlink(), nlink);
    |                                                    ^^^^^^^^
    |
    = help: items from traits can only be used if the trait is in scope
    = note: the following trait is implemented but not in scope, perhaps add a `use` for it:
            candidate #1: `use std::os::macos::fs::MetadataExt;`


error: aborting due to 2 previous errors

error: Could not compile `tikv`.
```