### PR TITLE
util: Rmove BatchRunnable and use Runnable instead.

### DIFF
--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -27,7 +27,7 @@ use kvproto::errorpb::{self, ServerIsBusy};
 use kvproto::kvrpcpb::{CommandPri, IsolationLevel};
 
 use util::time::{duration_to_sec, Instant};
-use util::worker::{BatchRunnable, FutureScheduler, Scheduler};
+use util::worker::{FutureScheduler, Runnable, Scheduler};
 use util::collections::HashMap;
 use util::threadpool::{Context, ContextFactory, ThreadPool, ThreadPoolBuilder};
 use server::{Config, OnResponse};
@@ -444,8 +444,12 @@ impl Display for RequestTask {
     }
 }
 
-impl BatchRunnable<Task> for Host {
+impl Runnable<Task> for Host {
     // TODO: limit pending reqs
+    fn run(&mut self, _: Task) {
+        panic!("Shouldn't call Host::run directly");
+    }
+
     #[allow(for_kv_map)]
     fn run_batch(&mut self, tasks: &mut Vec<Task>) {
         let mut grouped_reqs = map![];


### PR DESCRIPTION
The design of `BatchRunnable` contains this code:
```rust
impl<T> BatchRunnable<T> for Runnable<T> {
    fn run_batch(&mut self, _: &mut Vec<T>) {}
}
```
But it's confict with
```rust
struct RunnerProxy<T: Display, R: BatchRunnable>(runner: R);
impl<T: Display, R: BatchRunnable<T>> BatchRunnable<T> for RunnerProxy<T, R> {
    fn run_batch(&mut self, _: &mut Vec<T>) {}
}
```
I think it's a compiler bug. We can avoid that bug by removing `BatchRunnable` directly.