### PR TITLE
Optimize write type parsing for mvcc properties collector

### DIFF
--- a/src/storage/mvcc/write.rs
+++ b/src/storage/mvcc/write.rs
@@ -117,6 +117,10 @@ impl Write {
         }
         Ok(Write::new(write_type, start_ts, Some(b.to_vec())))
     }
+
+    pub fn parse_type(mut b: &[u8]) -> Result<WriteType> {
+        WriteType::from_u8(b.read_u8()?).ok_or(Error::BadFormatWrite)
+    }
 }
 
 #[cfg(test)]
@@ -179,6 +183,7 @@ mod tests {
             let v = write.to_bytes();
             let w = Write::parse(&v[..]).unwrap_or_else(|e| panic!("#{} parse() err: {:?}", i, e));
             assert_eq!(w, write, "#{} expect {:?}, but got {:?}", i, write, w);
+            assert_eq!(Write::parse_type(&v).unwrap(), w.write_type);
         }
 
         // Test `Write::parse()` handles incorrect input.
@@ -187,5 +192,6 @@ mod tests {
         let lock = Write::new(WriteType::Lock, 1, Some(b"short_value".to_vec()));
         let v = lock.to_bytes();
         assert!(Write::parse(&v[..1]).is_err());
+        assert_eq!(Write::parse_type(&v).unwrap(), lock.write_type);
     }
 }

--- a/src/util/rocksdb/properties.rs
+++ b/src/util/rocksdb/properties.rs
@@ -150,7 +150,7 @@ impl TablePropertiesCollector for MvccPropertiesCollector {
             self.props.max_row_versions = self.row_versions;
         }
 
-        let v = match Write::parse(value) {
+        let write_type = match Write::parse_type(value) {
             Ok(v) => v,
             Err(_) => {
                 self.num_errors += 1;
@@ -158,7 +158,7 @@ impl TablePropertiesCollector for MvccPropertiesCollector {
             }
         };
 
-        if v.write_type == WriteType::Put {
+        if write_type == WriteType::Put {
             self.props.num_puts += 1;
         }
 


### PR DESCRIPTION
We only need the `WriteType` of the value in the collector, so add a method to parse the `WriteType` instead of the whole value to reduce CPU usage.