### PR TITLE
Specifying gRPC event engine

### DIFF
--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -333,7 +333,7 @@ fn overwrite_config_with_cmd_args(config: &mut TiKvConfig, matches: &ArgMatches)
 // Set gRPC event engine to epollsig.
 // See more: https://github.com/grpc/grpc/blob/486761d04e03a9183d8013eddd86c3134d52d459\
 //           /src/core/lib/iomgr/ev_posix.cc#L149
-fn specify_grpc_event_engine() {
+fn configure_grpc_event_engine() {
     const GRPC_POLL_STRATEGY: &str = "GRPC_POLL_STRATEGY";
     const DEFAULT_ENGINE: &str = "epollsig";
     if env::var(GRPC_POLL_STRATEGY).is_err() {
@@ -506,7 +506,7 @@ fn main() {
     // Before any startup, check system configuration.
     check_system_config(&config);
 
-    specify_grpc_event_engine();
+    configure_grpc_event_engine();
 
     let security_mgr = Arc::new(
         SecurityManager::new(&config.security)

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -335,12 +335,11 @@ fn overwrite_config_with_cmd_args(config: &mut TiKvConfig, matches: &ArgMatches)
 //           /src/core/lib/iomgr/ev_posix.cc#L149
 fn specify_grpc_event_engine() {
     const GRPC_POLL_STRATEGY: &str = "GRPC_POLL_STRATEGY";
-    let mut engines = "epollsig".to_owned();
-    if let Ok(env_engines) = env::var(GRPC_POLL_STRATEGY) {
-        engines.push(',');
-        engines.push_str(&env_engines);
+    const DEFAULT_ENGINE: &str = "epollsig";
+    if env::var(GRPC_POLL_STRATEGY).is_err() {
+        // Set to epollsig if it is not specified.
+        env::set_var(GRPC_POLL_STRATEGY, DEFAULT_ENGINE);
     }
-    env::set_var(GRPC_POLL_STRATEGY, engines);
 }
 
 fn main() {

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -333,7 +333,7 @@ fn overwrite_config_with_cmd_args(config: &mut TiKvConfig, matches: &ArgMatches)
 // Set gRPC event engine to epollsig.
 // See more: https://github.com/grpc/grpc/blob/486761d04e03a9183d8013eddd86c3134d52d459\
 //           /src/core/lib/iomgr/ev_posix.cc#L149
-fn configure_grpc_event_engine() {
+fn configure_grpc_poll_strategy() {
     const GRPC_POLL_STRATEGY: &str = "GRPC_POLL_STRATEGY";
     const DEFAULT_ENGINE: &str = "epollsig";
     if env::var(GRPC_POLL_STRATEGY).is_err() {
@@ -506,7 +506,7 @@ fn main() {
     // Before any startup, check system configuration.
     check_system_config(&config);
 
-    configure_grpc_event_engine();
+    configure_grpc_poll_strategy();
 
     let security_mgr = Arc::new(
         SecurityManager::new(&config.security)

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -494,6 +494,11 @@ fn main() {
     // Before any startup, check system configuration.
     check_system_config(&config);
 
+    // Set gRPC event engine to epollsig.
+    // See more: https://github.com/grpc/grpc/blob/486761d04e03a9183d8013eddd86c3134d52d459\
+    //           /src/core/lib/iomgr/ev_posix.cc#L149
+    env::set_var("GRPC_POLL_STRATEGY", "epollsig");
+
     let security_mgr = Arc::new(
         SecurityManager::new(&config.security)
             .unwrap_or_else(|e| fatal!("failed to create security manager: {:?}", e)),


### PR DESCRIPTION
Set gRPC event engine to the epollsig.

![screenshot from 2018-01-09 14-32-51](https://user-images.githubusercontent.com/2150711/34710949-4807ff9c-f558-11e7-9e42-bca0f1470022.png)
