### PR TITLE
*: change version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "tikv"
-version = "1.0.1"
+version = "1.1.0-dev"
 dependencies = [
  "backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tikv"
-version = "1.0.1"
+version = "1.1.0-dev"
 keywords = ["KV", "distributed-systems", "raft"]
 build = "build.rs"
 


### PR DESCRIPTION
So when using master version of TiKV, the output won't be 1.0.1 anymore, which is very confusing.

Also, I propose to change the version very time a new major/minor version is released. For example, if we are going to release 1.1.0 from master, then we need to

1. checkout release-1.1 branch;
2. release new version on release-1.1 branch;
3. update master version to 1.2.0-dev.