### PR TITLE
import: Add ImportSST/UploadSST API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/huachaohuang/kvproto.git?branch=import-sst#77985b6bbfc8f6c04f6f17c403462f09f875b2eb"
+source = "git+https://github.com/pingcap/kvproto.git#7b013aefd7210f4f4dbfca3330b462ddce5dd496"
 dependencies = [
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1011,7 +1011,7 @@ dependencies = [
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)",
- "kvproto 0.0.1 (git+https://github.com/huachaohuang/kvproto.git?branch=import-sst)",
+ "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1300,7 +1300,7 @@ dependencies = [
 "checksum jemalloc-sys 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum kvproto 0.0.1 (git+https://github.com/huachaohuang/kvproto.git?branch=import-sst)" = "<none>"
+"checksum kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)" = "<none>"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,15 +255,15 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "futures-cpupool"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -287,7 +287,7 @@ name = "grpcio"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -403,9 +403,9 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git#2d2218933e0014d29af8da914b65687b1a7d239b"
+source = "git+https://github.com/huachaohuang/kvproto.git?branch=import-sst#77985b6bbfc8f6c04f6f17c403462f09f875b2eb"
 dependencies = [
- "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -835,6 +835,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -1002,11 +1007,11 @@ dependencies = [
  "flat_map 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-cpupool 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)",
- "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto 0.0.1 (git+https://github.com/huachaohuang/kvproto.git?branch=import-sst)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1034,6 +1039,7 @@ dependencies = [
  "toml 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "utime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zipf 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1062,7 +1068,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1077,7 +1083,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1086,7 +1092,7 @@ name = "tokio-timer"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1183,6 +1189,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,8 +1282,8 @@ dependencies = [
 "checksum flat_map 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "fc16c081affe2ded9d62cd239a9ef1b4801fa98037b59523014f661c7bee182c"
 "checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
 "checksum fs2 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "237b7991317b8d94391c0a4813b1f74fd81c11352440cd598d2b763ed288bfc1"
-"checksum futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "05a23db7bd162d4e8265968602930c476f688f0c180b44bdaf55e0cb2c687558"
-"checksum futures-cpupool 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a283c84501e92cade5ea673a2a7ca44f71f209ccdd302a3e0896f50083d2c5ff"
+"checksum futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "118b49cac82e04121117cbd3121ede3147e885627d82c4546b87c702debb90c1"
+"checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum gcc 0.3.53 (registry+https://github.com/rust-lang/crates.io-index)" = "e8310f7e9c890398b0e80e301c4f474e9918d2b27fca8f48486ca775fa9ffc5a"
 "checksum getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9047cfbd08a437050b363d35ef160452c5fe8ea5187ae0a624708c91581d685"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
@@ -1285,7 +1300,7 @@ dependencies = [
 "checksum jemalloc-sys 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)" = "<none>"
+"checksum kvproto 0.0.1 (git+https://github.com/huachaohuang/kvproto.git?branch=import-sst)" = "<none>"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
@@ -1340,6 +1355,7 @@ dependencies = [
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 "checksum semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+"checksum serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"
 "checksum serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c2f530d36fb84ec48fb7146936881f026cdbf4892028835fd9398475f82c1bb4"
 "checksum serde_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "10552fad5500771f3902d0c5ba187c5881942b811b7ba0d8fbbfbf84d80806d3"
 "checksum serde_derive_internals 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37aee4e0da52d801acfbc0cc219eb1eda7142112339726e427926a6f6ee65d3a"
@@ -1378,6 +1394,7 @@ dependencies = [
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum utime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4a9c0ddf7a5a39cd0c316dac124303d71fa197f8607027546c3be3e1c6f7bd9b"
+"checksum uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7cfec50b0842181ba6e713151b72f4ec84a6a7e2c9c8a8a3ffc37bb1cd16b231"
 "checksum vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9e0a7d8bed3178a8fb112199d466eeca9ed09a14ba8ad67718179b4fd5487d0b"
 "checksum vec_map 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8cdc8b93bd0198ed872357fb2e667f7125646b1762f16d60b2c96350d361897"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,8 +78,7 @@ signal = "0.4"
 git = "https://github.com/pingcap/rust-rocksdb.git"
 
 [dependencies.kvproto]
-git = "https://github.com/huachaohuang/kvproto.git"
-branch = "import-sst"
+git = "https://github.com/pingcap/kvproto.git"
 
 [dependencies.tipb]
 git = "https://github.com/pingcap/tipb.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ futures-cpupool = "0.1"
 zipf = "0.2.0"
 bitflags = "1.0.1"
 fail = "0.2"
+uuid = { version = "0.4", features = [ "serde", "v4" ] }
 
 [target.'cfg(unix)'.dependencies]
 signal = "0.4"
@@ -77,7 +78,8 @@ signal = "0.4"
 git = "https://github.com/pingcap/rust-rocksdb.git"
 
 [dependencies.kvproto]
-git = "https://github.com/pingcap/kvproto.git"
+git = "https://github.com/huachaohuang/kvproto.git"
+branch = "import-sst"
 
 [dependencies.tipb]
 git = "https://github.com/pingcap/tipb.git"

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -421,3 +421,9 @@
 # ca-path = ""
 # cert-path = ""
 # key-path = ""
+
+[import]
+# number of threads to handle RPC requests.
+# num-threads = 4
+# stream channel buffer size, stream will be blocked on channel full.
+# stream-channel-size = 128

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -424,6 +424,6 @@
 
 [import]
 # number of threads to handle RPC requests.
-# num-threads = 4
-# stream channel buffer size, stream will be blocked on channel full.
-# stream-channel-size = 128
+# num-threads = 8
+# stream channel window size, stream will be blocked on channel full.
+# stream-channel-window = 128

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -213,7 +213,7 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
 
     let importer = Arc::new(SSTImporter::new(import_path).unwrap());
     let import_service =
-        ImportSSTService::new(cfg.import.clone(), storage.clone(), importer.clone());
+        ImportSSTService::new(cfg.import.clone(), storage.clone(), Arc::clone(&importer));
 
     let server_cfg = Arc::new(cfg.server.clone());
     // Create server

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -74,6 +74,7 @@ use tikv::raftstore::coprocessor::CoprocessorHost;
 use tikv::pd::{PdClient, RpcClient};
 use tikv::util::time::Monitor;
 use tikv::util::rocksdb::metrics_flusher::{MetricsFlusher, DEFAULT_FLUSHER_INTERVAL};
+use tikv::import::{ImportSSTService, SSTImporter};
 
 const RESERVED_OPEN_FDS: u64 = 1000;
 
@@ -152,6 +153,7 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
     let db_path = store_path.join(Path::new(DEFAULT_ROCKSDB_SUB_DIR));
     let snap_path = store_path.join(Path::new("snap"));
     let raft_db_path = Path::new(&cfg.raft_store.raftdb_path);
+    let import_path = store_path.join("import");
 
     let f = File::create(lock_path.as_path())
         .unwrap_or_else(|e| fatal!("failed to create lock at {}: {:?}", lock_path.display(), e));
@@ -209,6 +211,10 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
         limiter,
     );
 
+    let importer = Arc::new(SSTImporter::new(import_path).unwrap());
+    let import_service =
+        ImportSSTService::new(cfg.import.clone(), storage.clone(), importer.clone());
+
     let server_cfg = Arc::new(cfg.server.clone());
     // Create server
     let mut server = Server::new(
@@ -221,6 +227,7 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
         snap_mgr.clone(),
         pd_worker.scheduler(),
         Some(engines.clone()),
+        Some(import_service),
     ).unwrap_or_else(|e| fatal!("failed to create server: {:?}", e));
     let trans = server.transport();
 

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -212,8 +212,7 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
     );
 
     let importer = Arc::new(SSTImporter::new(import_path).unwrap());
-    let import_service =
-        ImportSSTService::new(cfg.import.clone(), storage.clone(), Arc::clone(&importer));
+    let import_service = ImportSSTService::new(cfg.import.clone(), storage.clone(), importer);
 
     let server_cfg = Arc::new(cfg.server.clone());
     // Create server

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,7 @@ use rocksdb::{BlockBasedOptions, ColumnFamilyOptions, CompactionPriority, DBComp
               DBOptions, DBRecoveryMode};
 use sys_info;
 
+use import::Config as ImportConfig;
 use server::Config as ServerConfig;
 use pd::Config as PdConfig;
 use raftstore::coprocessor::Config as CopConfig;
@@ -656,6 +657,7 @@ pub struct TiKvConfig {
     pub rocksdb: DbConfig,
     pub raftdb: RaftDbConfig,
     pub security: SecurityConfig,
+    pub import: ImportConfig,
 }
 
 impl Default for TiKvConfig {
@@ -672,6 +674,7 @@ impl Default for TiKvConfig {
             raftdb: RaftDbConfig::default(),
             storage: StorageConfig::default(),
             security: SecurityConfig::default(),
+            import: ImportConfig::default(),
         }
     }
 }
@@ -706,6 +709,7 @@ impl TiKvConfig {
         self.pd.validate()?;
         self.coprocessor.validate()?;
         self.security.validate()?;
+        self.import.validate()?;
         Ok(())
     }
 

--- a/src/import/config.rs
+++ b/src/import/config.rs
@@ -19,14 +19,14 @@ use std::result::Result;
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
     pub num_threads: usize,
-    pub stream_channel_size: usize,
+    pub stream_channel_window: usize,
 }
 
 impl Default for Config {
     fn default() -> Config {
         Config {
-            num_threads: 4,
-            stream_channel_size: 128,
+            num_threads: 8,
+            stream_channel_window: 128,
         }
     }
 }
@@ -36,8 +36,8 @@ impl Config {
         if self.num_threads == 0 {
             return Err("import.num_threads can not be 0".into());
         }
-        if self.stream_channel_size == 0 {
-            return Err("import.stream_channel_size can not be 0".into());
+        if self.stream_channel_window == 0 {
+            return Err("import.stream_channel_window can not be 0".into());
         }
         Ok(())
     }

--- a/src/import/config.rs
+++ b/src/import/config.rs
@@ -1,0 +1,44 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::result::Result;
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+#[serde(default)]
+#[serde(rename_all = "kebab-case")]
+pub struct Config {
+    pub num_threads: usize,
+    pub stream_channel_size: usize,
+}
+
+impl Default for Config {
+    fn default() -> Config {
+        Config {
+            num_threads: 4,
+            stream_channel_size: 128,
+        }
+    }
+}
+
+impl Config {
+    pub fn validate(&self) -> Result<(), Box<Error>> {
+        if self.num_threads == 0 {
+            return Err("import.num_threads can not be 0".into());
+        }
+        if self.stream_channel_size == 0 {
+            return Err("import.stream_channel_size can not be 0".into());
+        }
+        Ok(())
+    }
+}

--- a/src/import/errors.rs
+++ b/src/import/errors.rs
@@ -11,30 +11,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::io;
-use std::result;
+use std::io::Error as IoError;
 use std::path::PathBuf;
+use std::result;
 
-use grpc;
+use grpc::Error as GrpcError;
 use uuid::ParseError;
 use futures::sync::oneshot::Canceled;
 
-use util::codec;
+use util::codec::Error as CodecError;
 
 quick_error! {
     #[derive(Debug)]
     pub enum Error {
-        Io(err: io::Error) {
+        Io(err: IoError) {
             from()
             cause(err)
             description(err.description())
         }
-        Grpc(err: grpc::Error) {
+        Grpc(err: GrpcError) {
             from()
             cause(err)
             description(err.description())
         }
         Uuid(err: ParseError) {
+            from()
+            cause(err)
+            description(err.description())
+        }
+        Codec(err: CodecError) {
             from()
             cause(err)
             description(err.description())
@@ -46,11 +51,6 @@ quick_error! {
         RocksDB(msg: String) {
             from()
             display("RocksDB {}", msg)
-        }
-        Codec(err: codec::Error) {
-            from()
-            cause(err)
-            description(err.description())
         }
         FileExists(path: PathBuf) {
             display("File {:?} exists", path)

--- a/src/import/errors.rs
+++ b/src/import/errors.rs
@@ -1,0 +1,79 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io;
+use std::result;
+use std::path::PathBuf;
+use std::num::ParseIntError;
+
+use grpc;
+use uuid::ParseError;
+use futures::sync::oneshot::Canceled;
+
+use util::codec;
+
+quick_error! {
+    #[derive(Debug)]
+    pub enum Error {
+        Io(err: io::Error) {
+            from()
+            cause(err)
+            description(err.description())
+        }
+        Grpc(err: grpc::Error) {
+            from()
+            cause(err)
+            description(err.description())
+        }
+        Uuid(err: ParseError) {
+            from()
+            cause(err)
+            description(err.description())
+        }
+        Future(err: Canceled) {
+            from()
+            cause(err)
+        }
+        RocksDB(msg: String) {
+            from()
+            display("RocksDB {}", msg)
+        }
+        Codec(err: codec::Error) {
+            from()
+            cause(err)
+            description(err.description())
+        }
+        ParseIntError(err: ParseIntError) {
+            from()
+            cause(err)
+            description(err.description())
+        }
+        FileExists(path: PathBuf) {
+            display("File {} exists", path.to_str().unwrap())
+        }
+        FileCorrupted(path: PathBuf) {
+            display("File {} corrupted", path.to_str().unwrap())
+        }
+        FileNotExists(path: PathBuf) {
+            display("File {} not exists", path.to_str().unwrap())
+        }
+        InvalidSSTPath(path: PathBuf) {
+            display("Invalid SST path {}", path.to_str().unwrap())
+        }
+        TokenNotFound(token: usize) {
+            display("Token {} not found", token)
+        }
+    }
+}
+
+pub type Result<T> = result::Result<T, Error>;

--- a/src/import/errors.rs
+++ b/src/import/errors.rs
@@ -59,16 +59,16 @@ quick_error! {
             description(err.description())
         }
         FileExists(path: PathBuf) {
-            display("File {} exists", path.to_str().unwrap())
+            display("File {:?} exists", path)
         }
         FileCorrupted(path: PathBuf) {
-            display("File {} corrupted", path.to_str().unwrap())
+            display("File {:?} corrupted", path)
         }
         FileNotExists(path: PathBuf) {
-            display("File {} not exists", path.to_str().unwrap())
+            display("File {:?} not exists", path)
         }
         InvalidSSTPath(path: PathBuf) {
-            display("Invalid SST path {}", path.to_str().unwrap())
+            display("Invalid SST path {:?}", path)
         }
         TokenNotFound(token: usize) {
             display("Token {} not found", token)

--- a/src/import/errors.rs
+++ b/src/import/errors.rs
@@ -14,7 +14,6 @@
 use std::io;
 use std::result;
 use std::path::PathBuf;
-use std::num::ParseIntError;
 
 use grpc;
 use uuid::ParseError;
@@ -53,22 +52,17 @@ quick_error! {
             cause(err)
             description(err.description())
         }
-        ParseIntError(err: ParseIntError) {
-            from()
-            cause(err)
-            description(err.description())
-        }
         FileExists(path: PathBuf) {
             display("File {:?} exists", path)
-        }
-        FileCorrupted(path: PathBuf) {
-            display("File {:?} corrupted", path)
         }
         FileNotExists(path: PathBuf) {
             display("File {:?} not exists", path)
         }
-        InvalidSSTPath(path: PathBuf) {
-            display("Invalid SST path {:?}", path)
+        FileCorrupted(path: PathBuf, reason: String) {
+            display("File {:?} corrupted: {}", path, reason)
+        }
+        TokenExists(token: usize) {
+            display("Token {} exists", token)
         }
         TokenNotFound(token: usize) {
             display("Token {} not found", token)

--- a/src/import/errors.rs
+++ b/src/import/errors.rs
@@ -15,9 +15,9 @@ use std::io::Error as IoError;
 use std::path::PathBuf;
 use std::result;
 
+use futures::sync::oneshot::Canceled;
 use grpc::Error as GrpcError;
 use uuid::ParseError;
-use futures::sync::oneshot::Canceled;
 
 use util::codec::Error as CodecError;
 

--- a/src/import/metrics.rs
+++ b/src/import/metrics.rs
@@ -22,10 +22,10 @@ lazy_static! {
             exponential_buckets(0.001, 2.0, 30).unwrap()
         ).unwrap();
 
-    pub static ref IMPORT_UPLOAD_CHUNK_SIZE: Histogram =
+    pub static ref IMPORT_UPLOAD_CHUNK_BYTES: Histogram =
         register_histogram!(
-            "tikv_import_upload_chunk_size",
-            "Bucketed histogram of import upload chunk size",
+            "tikv_import_upload_chunk_bytes",
+            "Bucketed histogram of import upload chunk bytes",
             exponential_buckets(1024.0, 2.0, 20).unwrap()
         ).unwrap();
 

--- a/src/import/metrics.rs
+++ b/src/import/metrics.rs
@@ -14,11 +14,25 @@
 use prometheus::*;
 
 lazy_static! {
-    pub static ref IMPORT_RPC_DURATION_VEC: HistogramVec =
+    pub static ref IMPORT_RPC_DURATION: HistogramVec =
         register_histogram_vec!(
-            "tikv_import_rpc_duration_seconds",
+            "tikv_import_rpc_duration",
             "Bucketed histogram of import rpc duration",
-            &["req", "result"],
+            &["request", "result"],
             exponential_buckets(0.001, 2.0, 30).unwrap()
+        ).unwrap();
+
+    pub static ref IMPORT_UPLOAD_CHUNK_SIZE: Histogram =
+        register_histogram!(
+            "tikv_import_upload_chunk_size",
+            "Bucketed histogram of import upload chunk size",
+            exponential_buckets(1024.0, 2.0, 20).unwrap()
+        ).unwrap();
+
+    pub static ref IMPORT_UPLOAD_CHUNK_DURATION: Histogram =
+        register_histogram!(
+            "tikv_import_upload_chunk_duration",
+            "Bucketed histogram of import upload chunk duration",
+            exponential_buckets(0.001, 2.0, 20).unwrap()
         ).unwrap();
 }

--- a/src/import/metrics.rs
+++ b/src/import/metrics.rs
@@ -1,0 +1,24 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use prometheus::*;
+
+lazy_static! {
+    pub static ref IMPORT_RPC_DURATION_VEC: HistogramVec =
+        register_histogram_vec!(
+            "tikv_import_rpc_duration_seconds",
+            "Bucketed histogram of import rpc duration",
+            &["req", "result"],
+            exponential_buckets(0.001, 2.0, 30).unwrap()
+        ).unwrap();
+}

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -11,9 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(test)]
-pub mod tests;
-
 mod config;
 mod errors;
 mod metrics;
@@ -21,6 +18,8 @@ mod metrics;
 mod service;
 mod sst_service;
 mod sst_importer;
+
+pub mod tests;
 
 pub use self::errors::{Error, Result};
 pub use self::config::Config;

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(test)]
+pub mod tests;
+
 mod config;
 mod errors;
 mod metrics;

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -21,7 +21,7 @@ mod sst_importer;
 
 pub mod test_helpers;
 
-pub use self::errors::{Error, Result};
 pub use self::config::Config;
-pub use self::sst_importer::SSTImporter;
+pub use self::errors::{Error, Result};
 pub use self::sst_service::ImportSSTService;
+pub use self::sst_importer::SSTImporter;

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -1,0 +1,25 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod config;
+mod errors;
+mod metrics;
+#[macro_use]
+mod service;
+mod sst_service;
+mod sst_importer;
+
+pub use self::errors::{Error, Result};
+pub use self::config::Config;
+pub use self::sst_importer::SSTImporter;
+pub use self::sst_service::ImportSSTService;

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -19,7 +19,7 @@ mod service;
 mod sst_service;
 mod sst_importer;
 
-pub mod tests;
+pub mod test_helpers;
 
 pub use self::errors::{Error, Result};
 pub use self::config::Config;

--- a/src/import/service.rs
+++ b/src/import/service.rs
@@ -1,0 +1,42 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+use grpc::{RpcStatus, RpcStatusCode};
+
+use super::Error;
+
+pub fn make_rpc_error(err: Error) -> RpcStatus {
+    RpcStatus::new(RpcStatusCode::Unknown, Some(format!("{:?}", err)))
+}
+
+macro_rules! send_rpc_response {
+    ($res:ident, $sink: ident, $label:ident, $timer:ident) => ({
+        let duration = duration_to_sec($timer.elapsed());
+        let res = match $res {
+            Ok(resp) => {
+                IMPORT_RPC_DURATION_VEC
+                    .with_label_values(&[$label, "ok"])
+                    .observe(duration);
+                $sink.success(resp)
+            }
+            Err(e) => {
+                IMPORT_RPC_DURATION_VEC
+                    .with_label_values(&[$label, "error"])
+                    .observe(duration);
+                $sink.fail(make_rpc_error(e))
+            }
+        };
+        res.map_err(|e| warn!("send rpc response: {:?}", e))
+    })
+}

--- a/src/import/service.rs
+++ b/src/import/service.rs
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use grpc::{RpcStatus, RpcStatusCode};
 
 use super::Error;

--- a/src/import/service.rs
+++ b/src/import/service.rs
@@ -22,18 +22,17 @@ pub fn make_rpc_error(err: Error) -> RpcStatus {
 
 macro_rules! send_rpc_response {
     ($res:ident, $sink: ident, $label:ident, $timer:ident) => ({
-        let duration = duration_to_sec($timer.elapsed());
         let res = match $res {
             Ok(resp) => {
-                IMPORT_RPC_DURATION_VEC
+                IMPORT_RPC_DURATION
                     .with_label_values(&[$label, "ok"])
-                    .observe(duration);
+                    .observe($timer.elapsed_secs());
                 $sink.success(resp)
             }
             Err(e) => {
-                IMPORT_RPC_DURATION_VEC
+                IMPORT_RPC_DURATION
                     .with_label_values(&[$label, "error"])
-                    .observe(duration);
+                    .observe($timer.elapsed_secs());
                 $sink.fail(make_rpc_error(e))
             }
         };

--- a/src/import/sst_importer.rs
+++ b/src/import/sst_importer.rs
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
 use std::fmt;
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
@@ -24,6 +23,7 @@ use uuid::Uuid;
 use kvproto::importpb::*;
 use rocksdb::{IngestExternalFileOptions, DB};
 
+use util::collections::HashMap;
 use util::rocksdb::{get_cf_handle, prepare_sst_for_ingestion, validate_sst_for_ingestion};
 
 use super::{Error, Result};
@@ -41,7 +41,7 @@ impl SSTImporter {
         Ok(SSTImporter {
             dir: ImportDir::new(root)?,
             token: AtomicUsize::new(1),
-            files: Mutex::new(HashMap::new()),
+            files: Mutex::new(HashMap::default()),
         })
     }
 

--- a/src/import/sst_importer.rs
+++ b/src/import/sst_importer.rs
@@ -1,0 +1,432 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crc::crc32::{self, Hasher32};
+use uuid::Uuid;
+use rocksdb::{IngestExternalFileOptions, DB};
+
+use kvproto::importpb::*;
+
+use util::rocksdb::{get_cf_handle, prepare_sst_for_ingestion, validate_sst_for_ingestion};
+
+use super::{Error, Result};
+
+pub type Token = usize;
+
+pub struct SSTImporter {
+    dir: ImportDir,
+    token: AtomicUsize,
+    files: Mutex<HashMap<Token, ImportFile>>,
+}
+
+impl SSTImporter {
+    pub fn new<P: AsRef<Path>>(root: P) -> Result<SSTImporter> {
+        Ok(SSTImporter {
+            dir: ImportDir::new(root)?,
+            token: AtomicUsize::new(1),
+            files: Mutex::new(HashMap::new()),
+        })
+    }
+
+    pub fn token(&self) -> Token {
+        self.token.fetch_add(1, Ordering::SeqCst)
+    }
+
+    fn insert(&self, token: Token, file: ImportFile) {
+        let mut files = self.files.lock().unwrap();
+        assert!(files.insert(token, file).is_none());
+    }
+
+    pub fn remove(&self, token: Token) -> Option<ImportFile> {
+        let mut files = self.files.lock().unwrap();
+        files.remove(&token)
+    }
+
+    pub fn create(&self, token: Token, meta: &SSTMeta) -> Result<()> {
+        match self.dir.create(meta) {
+            Ok(f) => {
+                info!("create {}", f);
+                self.insert(token, f);
+                Ok(())
+            }
+            Err(e) => {
+                error!("create {:?}: {:?}", meta, e);
+                Err(e)
+            }
+        }
+    }
+
+    pub fn append(&self, token: Token, data: &[u8]) -> Result<()> {
+        match self.remove(token) {
+            Some(mut f) => match f.append(data) {
+                Ok(_) => {
+                    self.insert(token, f);
+                    Ok(())
+                }
+                Err(e) => {
+                    error!("append {}: {:?}", f, e);
+                    Err(e)
+                }
+            },
+            None => Err(Error::TokenNotFound(token)),
+        }
+    }
+
+    pub fn finish(&self, token: Token) -> Result<()> {
+        match self.remove(token) {
+            Some(mut f) => match f.finish() {
+                Ok(_) => {
+                    info!("finish {}", f);
+                    Ok(())
+                }
+                Err(e) => {
+                    error!("finish {}: {:?}", f, e);
+                    Err(e)
+                }
+            },
+            None => Err(Error::TokenNotFound(token)),
+        }
+    }
+
+    pub fn ingest(&self, meta: &SSTMeta, db: &DB) -> Result<()> {
+        match self.dir.ingest(meta, db) {
+            Ok(_) => {
+                info!("ingest {:?}", meta);
+                Ok(())
+            }
+            Err(e) => {
+                error!("ingest {:?}: {:?}", meta, e);
+                Err(e)
+            }
+        }
+    }
+}
+
+// TODO: Add size and rate limit.
+pub struct ImportDir {
+    root_dir: PathBuf,
+    temp_dir: PathBuf,
+    clone_dir: PathBuf,
+}
+
+impl ImportDir {
+    const TEMP_DIR: &'static str = ".temp";
+    const CLONE_DIR: &'static str = ".clone";
+
+    fn new<P: AsRef<Path>>(root: P) -> Result<ImportDir> {
+        let root_dir = root.as_ref().to_owned();
+        let temp_dir = root_dir.join(Self::TEMP_DIR);
+        let clone_dir = root_dir.join(Self::CLONE_DIR);
+        if temp_dir.exists() {
+            fs::remove_dir_all(&temp_dir)?;
+        }
+        if clone_dir.exists() {
+            fs::remove_dir_all(&clone_dir)?;
+        }
+        fs::create_dir_all(&temp_dir)?;
+        fs::create_dir_all(&clone_dir)?;
+        Ok(ImportDir {
+            root_dir: root_dir,
+            temp_dir: temp_dir,
+            clone_dir: clone_dir,
+        })
+    }
+
+    fn join(&self, meta: &SSTMeta) -> Result<ImportPath> {
+        let file_name = sst_meta_to_path(meta)?;
+        let save_path = self.root_dir.join(&file_name);
+        let temp_path = self.temp_dir.join(&file_name);
+        let clone_path = self.clone_dir.join(&file_name);
+        Ok(ImportPath {
+            save: save_path,
+            temp: temp_path,
+            clone: clone_path,
+        })
+    }
+
+    fn create(&self, meta: &SSTMeta) -> Result<ImportFile> {
+        let path = self.join(meta)?;
+        if path.save.exists() {
+            return Err(Error::FileExists(path.save));
+        }
+        ImportFile::create(meta.clone(), path)
+    }
+
+    fn ingest(&self, meta: &SSTMeta, db: &DB) -> Result<()> {
+        let path = self.join(meta)?;
+        let cf = meta.get_cf_name();
+        prepare_sst_for_ingestion(&path.save, &path.clone)?;
+        validate_sst_for_ingestion(db, cf, &path.clone, meta.get_length(), meta.get_crc32())?;
+
+        let handle = get_cf_handle(db, cf)?;
+        let mut opts = IngestExternalFileOptions::new();
+        opts.move_files(true);
+        db.ingest_external_file_cf(handle, &opts, &[path.clone.to_str().unwrap()])?;
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct ImportPath {
+    // The path of the file that has been uploaded.
+    save: PathBuf,
+    // The path of the file that is being uploaded.
+    temp: PathBuf,
+    // The path of the file that is going to be ingested.
+    clone: PathBuf,
+}
+
+impl fmt::Display for ImportPath {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "ImportPath {{save: {}, temp: {}, clone: {}}}",
+            self.save.to_str().unwrap(),
+            self.temp.to_str().unwrap(),
+            self.clone.to_str().unwrap(),
+        )
+    }
+}
+
+pub struct ImportFile {
+    meta: SSTMeta,
+    path: ImportPath,
+    file: Option<File>,
+    digest: crc32::Digest,
+}
+
+impl ImportFile {
+    fn create(meta: SSTMeta, path: ImportPath) -> Result<ImportFile> {
+        let file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path.temp)?;
+        Ok(ImportFile {
+            meta: meta,
+            path: path,
+            file: Some(file),
+            digest: crc32::Digest::new(crc32::IEEE),
+        })
+    }
+
+    fn append(&mut self, data: &[u8]) -> Result<()> {
+        self.file.as_mut().unwrap().write_all(data)?;
+        self.digest.write(data);
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<()> {
+        self.validate()?;
+        self.file.take().unwrap().sync_all()?;
+        if self.path.save.exists() {
+            return Err(Error::FileExists(self.path.save.clone()));
+        }
+        fs::rename(&self.path.temp, &self.path.save)?;
+        Ok(())
+    }
+
+    fn cleanup(&mut self) -> Result<()> {
+        self.file.take();
+        if self.path.temp.exists() {
+            fs::remove_file(&self.path.temp)?;
+        }
+        Ok(())
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.digest.sum32() != self.meta.get_crc32() {
+            return Err(Error::FileCorrupted(self.path.temp.clone()));
+        }
+        let f = self.file.as_ref().unwrap();
+        if f.metadata()?.len() != self.meta.get_length() {
+            return Err(Error::FileCorrupted(self.path.temp.clone()));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for ImportFile {
+    fn drop(&mut self) {
+        if let Err(e) = self.cleanup() {
+            warn!("cleanup {}: {:?}", self, e);
+        }
+    }
+}
+
+impl fmt::Display for ImportFile {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "ImportFile {{meta: {{{:?}}}, path: {}}}",
+            self.meta,
+            self.path,
+        )
+    }
+}
+
+const SST_SUFFIX: &'static str = ".sst";
+
+fn sst_meta_to_path(meta: &SSTMeta) -> Result<PathBuf> {
+    Ok(PathBuf::from(format!(
+        "{}_{}_{}_{}{}",
+        Uuid::from_bytes(meta.get_uuid())?,
+        meta.get_region_id(),
+        meta.get_region_epoch().get_conf_ver(),
+        meta.get_region_epoch().get_version(),
+        SST_SUFFIX,
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+    use tempdir::TempDir;
+    use rocksdb::{CFHandle, EnvOptions, SstFileWriter};
+    use util::rocksdb::new_engine;
+
+    #[test]
+    fn test_import_dir() {
+        let temp_dir = TempDir::new("test_import_import_dir").unwrap();
+        let dir = ImportDir::new(temp_dir.path()).unwrap();
+
+        let db_path = temp_dir.path().join("db");
+        let cf_name = "default";
+        let db = new_engine(db_path.to_str().unwrap(), &[cf_name], None).unwrap();
+        let cf = db.cf_handle(cf_name).unwrap();
+
+        let cases = vec![
+            [("k1", "v1"), ("k2", "v2"), ("k3", "v3")],
+            [("k3", "v3"), ("k4", "v4"), ("k5", "v5")],
+        ];
+
+        for (i, case) in cases.iter().enumerate() {
+            let sst_path = temp_dir.path().join(format!("{}.sst", i));
+
+            // Generate a valid SST file.
+            gen_sst_with_kvs(&db, cf, sst_path.to_str().unwrap(), case);
+            let mut data = Vec::new();
+            File::open(&sst_path)
+                .unwrap()
+                .read_to_end(&mut data)
+                .unwrap();
+            let crc32 = get_data_crc32(&data);
+
+            // Make a valid SSTMeta.
+            let mut meta = SSTMeta::new();
+            let uuid = Uuid::new_v4();
+            meta.set_uuid(uuid.as_bytes().to_vec());
+            meta.set_crc32(crc32);
+            meta.set_length(data.len() as u64);
+            meta.set_cf_name(cf_name.to_owned());
+
+            // Write the SST file to the dir.
+            let mut f = dir.create(&meta).unwrap();
+            f.append(&data).unwrap();
+            f.finish().unwrap();
+
+            dir.ingest(&meta, &db).unwrap();
+            check_db_with_kvs(&db, cf, case);
+        }
+    }
+
+    #[test]
+    fn test_import_file() {
+        let temp_dir = TempDir::new("tikv_test_import_file").unwrap();
+
+        let path = ImportPath {
+            save: temp_dir.path().join("save"),
+            temp: temp_dir.path().join("temp"),
+            clone: temp_dir.path().join("clone"),
+        };
+
+        let data = b"import_file";
+        let crc32 = get_data_crc32(data);
+
+        let mut meta = SSTMeta::new();
+
+        {
+            let mut f = ImportFile::create(meta.clone(), path.clone()).unwrap();
+            // Create the same file again will fail because the file exists.
+            assert!(ImportFile::create(meta.clone(), path.clone()).is_err());
+            f.append(data).unwrap();
+            // Validate will fail because the meta crc32 and length are 0.
+            assert!(f.finish().is_err());
+            assert!(path.temp.exists());
+            assert!(!path.save.exists());
+        }
+
+        meta.set_crc32(crc32);
+
+        {
+            let mut f = ImportFile::create(meta.clone(), path.clone()).unwrap();
+            f.append(data).unwrap();
+            // Validate will fail because the meta length is 0.
+            assert!(f.finish().is_err());
+        }
+
+        meta.set_length(data.len() as u64);
+
+        {
+            let mut f = ImportFile::create(meta.clone(), path.clone()).unwrap();
+            f.append(data).unwrap();
+            f.finish().unwrap();
+            assert!(!path.temp.exists());
+            assert!(path.save.exists());
+        }
+    }
+
+    #[test]
+    fn test_sst_meta_to_path() {
+        let mut meta = SSTMeta::new();
+        let uuid = Uuid::new_v4();
+        meta.set_uuid(uuid.as_bytes().to_vec());
+        meta.set_region_id(1);
+        meta.mut_region_epoch().set_conf_ver(2);
+        meta.mut_region_epoch().set_version(3);
+
+        let path = sst_meta_to_path(&meta).unwrap();
+        let expected_path = format!("{}_1_2_3.sst", uuid);
+        assert_eq!(path.to_str().unwrap(), &expected_path);
+    }
+
+    fn get_data_crc32(data: &[u8]) -> u32 {
+        let mut digest = crc32::Digest::new(crc32::IEEE);
+        digest.write(data);
+        digest.sum32()
+    }
+
+    fn gen_sst_with_kvs(db: &DB, cf: &CFHandle, path: &str, kvs: &[(&str, &str)]) {
+        let opts = db.get_options_cf(cf).clone();
+        let mut writer = SstFileWriter::new(EnvOptions::new(), opts);
+        writer.open(path).unwrap();
+        for &(k, v) in kvs {
+            writer.put(k.as_bytes(), v.as_bytes()).unwrap();
+        }
+        writer.finish().unwrap();
+    }
+
+    fn check_db_with_kvs(db: &DB, cf: &CFHandle, kvs: &[(&str, &str)]) {
+        for &(k, v) in kvs {
+            assert_eq!(db.get_cf(cf, k.as_bytes()).unwrap().unwrap(), v.as_bytes());
+        }
+    }
+}

--- a/src/import/sst_importer.rs
+++ b/src/import/sst_importer.rs
@@ -63,7 +63,7 @@ impl SSTImporter {
     pub fn create(&self, token: Token, meta: &SSTMeta) -> Result<()> {
         match self.dir.create(meta) {
             Ok(f) => {
-                info!("create {}", f);
+                info!("create {:?}", f);
                 self.insert(token, f);
                 Ok(())
             }
@@ -82,7 +82,7 @@ impl SSTImporter {
                     Ok(())
                 }
                 Err(e) => {
-                    error!("append {}: {:?}", f, e);
+                    error!("append {:?}: {:?}", f, e);
                     Err(e)
                 }
             },
@@ -94,11 +94,11 @@ impl SSTImporter {
         match self.remove(token) {
             Some(mut f) => match f.finish() {
                 Ok(_) => {
-                    info!("finish {}", f);
+                    info!("finish {:?}", f);
                     Ok(())
                 }
                 Err(e) => {
-                    error!("finish {}: {:?}", f, e);
+                    error!("finish {:?}: {:?}", f, e);
                     Err(e)
                 }
             },
@@ -194,15 +194,13 @@ pub struct ImportPath {
     clone: PathBuf,
 }
 
-impl fmt::Display for ImportPath {
+impl fmt::Debug for ImportPath {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "ImportPath {{save: {}, temp: {}, clone: {}}}",
-            self.save.to_str().unwrap(),
-            self.temp.to_str().unwrap(),
-            self.clone.to_str().unwrap(),
-        )
+        f.debug_struct("ImportPath")
+            .field("save", &self.save)
+            .field("temp", &self.temp)
+            .field("clone", &self.clone)
+            .finish()
     }
 }
 
@@ -266,19 +264,17 @@ impl ImportFile {
 impl Drop for ImportFile {
     fn drop(&mut self) {
         if let Err(e) = self.cleanup() {
-            warn!("cleanup {}: {:?}", self, e);
+            warn!("cleanup {:?}: {:?}", self, e);
         }
     }
 }
 
-impl fmt::Display for ImportFile {
+impl fmt::Debug for ImportFile {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "ImportFile {{meta: {{{:?}}}, path: {}}}",
-            self.meta,
-            self.path,
-        )
+        f.debug_struct("ImportFile")
+            .field("meta", &self.meta)
+            .field("path", &self.path)
+            .finish()
     }
 }
 

--- a/src/import/sst_importer.rs
+++ b/src/import/sst_importer.rs
@@ -295,7 +295,6 @@ fn sst_meta_to_path(meta: &SSTMeta) -> Result<PathBuf> {
 mod tests {
     use super::*;
     use import::tests::*;
-    use std::io::Read;
     use tempdir::TempDir;
     use util::rocksdb::new_engine;
 
@@ -309,13 +308,11 @@ mod tests {
 
         let cases = vec![(0, 10), (5, 15), (10, 20), (0, 100)];
 
-        for (i, &(start, end)) in cases.iter().enumerate() {
+        for (i, &range) in cases.iter().enumerate() {
             let path = temp_dir.path().join(format!("{}.sst", i));
 
             // Generate a valid SST file.
-            let meta = gen_sst_file(&path, start, end);
-            let mut data = Vec::new();
-            File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+            let (meta, data) = gen_sst_file(&path, range);
 
             // Write the SST file to the dir.
             let mut f = dir.create(&meta).unwrap();
@@ -323,7 +320,7 @@ mod tests {
             f.finish().unwrap();
 
             dir.ingest(&meta, &db).unwrap();
-            check_db_range(&db, start, end);
+            check_db_range(&db, range);
         }
     }
 

--- a/src/import/sst_importer.rs
+++ b/src/import/sst_importer.rs
@@ -21,9 +21,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crc::crc32::{self, Hasher32};
 use uuid::Uuid;
-use rocksdb::{IngestExternalFileOptions, DB};
-
 use kvproto::importpb::*;
+use rocksdb::{IngestExternalFileOptions, DB};
 
 use util::rocksdb::{get_cf_handle, prepare_sst_for_ingestion, validate_sst_for_ingestion};
 
@@ -290,7 +289,7 @@ impl fmt::Debug for ImportFile {
     }
 }
 
-const SST_SUFFIX: &'static str = ".sst";
+const SST_SUFFIX: &str = ".sst";
 
 fn sst_meta_to_path(meta: &SSTMeta) -> Result<PathBuf> {
     Ok(PathBuf::from(format!(

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 use std::sync::Arc;
-use std::time::Instant;
 
 use grpc::{ClientStreamingSink, RequestStream, RpcContext, UnarySink};
 use futures::{Future, Stream};
@@ -23,7 +22,7 @@ use kvproto::importpb::*;
 use kvproto::importpb_grpc::*;
 
 use storage::Storage;
-use util::time::duration_to_sec;
+use util::time::{duration_to_sec, Instant};
 
 use super::service::*;
 use super::metrics::*;
@@ -60,7 +59,7 @@ impl ImportSst for ImportSSTService {
         sink: ClientStreamingSink<UploadResponse>,
     ) {
         let label = "upload";
-        let timer = Instant::now();
+        let timer = Instant::now_coarse();
 
         let token = self.importer.token();
         let import1 = self.importer.clone();
@@ -83,7 +82,7 @@ impl ImportSst for ImportSSTService {
                     Ok(_) => import2.finish(token),
                     Err(e) => {
                         if let Some(f) = import2.remove(token) {
-                            error!("remove {}: {:?}", f, e);
+                            error!("remove {:?}: {:?}", f, e);
                         }
                         Err(e)
                     }

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -1,0 +1,99 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use grpc::{ClientStreamingSink, RequestStream, RpcContext, UnarySink};
+use futures::{Future, Stream};
+use futures::sync::mpsc;
+use futures_cpupool::{Builder, CpuPool};
+
+use kvproto::importpb::*;
+use kvproto::importpb_grpc::*;
+
+use storage::Storage;
+use util::time::duration_to_sec;
+
+use super::service::*;
+use super::metrics::*;
+use super::{Config, Error, SSTImporter};
+
+#[derive(Clone)]
+pub struct ImportSSTService {
+    cfg: Config,
+    pool: CpuPool,
+    storage: Storage,
+    importer: Arc<SSTImporter>,
+}
+
+impl ImportSSTService {
+    pub fn new(cfg: Config, storage: Storage, importer: Arc<SSTImporter>) -> ImportSSTService {
+        let pool = Builder::new()
+            .name_prefix("import-sst")
+            .pool_size(cfg.num_threads)
+            .create();
+        ImportSSTService {
+            cfg: cfg,
+            pool: pool,
+            storage: storage,
+            importer: importer,
+        }
+    }
+}
+
+impl ImportSst for ImportSSTService {
+    fn upload(
+        &self,
+        ctx: RpcContext,
+        stream: RequestStream<UploadRequest>,
+        sink: ClientStreamingSink<UploadResponse>,
+    ) {
+        let label = "upload";
+        let timer = Instant::now();
+
+        let token = self.importer.token();
+        let import1 = self.importer.clone();
+        let import2 = self.importer.clone();
+        let bounded_stream = mpsc::spawn(stream, &self.pool, self.cfg.stream_channel_size);
+
+        ctx.spawn(
+            bounded_stream
+                .map_err(Error::from)
+                .for_each(move |chunk| {
+                    if chunk.has_meta() {
+                        import1.create(token, chunk.get_meta())?;
+                    }
+                    if !chunk.get_data().is_empty() {
+                        import1.append(token, chunk.get_data())?;
+                    }
+                    Ok(())
+                })
+                .then(move |res| match res {
+                    Ok(_) => import2.finish(token),
+                    Err(e) => {
+                        if let Some(f) = import2.remove(token) {
+                            error!("remove {}: {:?}", f, e);
+                        }
+                        Err(e)
+                    }
+                })
+                .map(|_| UploadResponse::new())
+                .then(move |res| send_rpc_response!(res, sink, label, timer)),
+        )
+    }
+
+    fn ingest(&self, _: RpcContext, _: IngestRequest, _: UnarySink<IngestResponse>) {
+        unimplemented!();
+    }
+}

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -65,7 +65,7 @@ impl ImportSst for ImportSSTService {
         let thread2 = self.threads.clone();
         let import1 = Arc::clone(&self.importer);
         let import2 = Arc::clone(&self.importer);
-        let bounded_stream = mpsc::spawn(stream, &self.threads, self.cfg.stream_channel_size);
+        let bounded_stream = mpsc::spawn(stream, &self.threads, self.cfg.stream_channel_window);
 
         ctx.spawn(
             bounded_stream

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -80,7 +80,7 @@ impl ImportSst for ImportSSTService {
                         if !chunk.get_data().is_empty() {
                             let data = chunk.get_data();
                             import1.append(token, data)?;
-                            IMPORT_UPLOAD_CHUNK_SIZE.observe(data.len() as f64);
+                            IMPORT_UPLOAD_CHUNK_BYTES.observe(data.len() as f64);
                         }
                         IMPORT_UPLOAD_CHUNK_DURATION.observe(start.elapsed_secs());
                         Ok(())

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -39,7 +39,7 @@ pub struct ImportSSTService {
 impl ImportSSTService {
     pub fn new(cfg: Config, storage: Storage, importer: Arc<SSTImporter>) -> ImportSSTService {
         let threads = Builder::new()
-            .name_prefix("import-sst")
+            .name_prefix("sst-importer")
             .pool_size(cfg.num_threads)
             .create();
         ImportSSTService {

--- a/src/import/test_helpers.rs
+++ b/src/import/test_helpers.rs
@@ -22,7 +22,7 @@ use kvproto::importpb::*;
 
 use raftstore::store::keys;
 
-pub fn get_data_crc32(data: &[u8]) -> u32 {
+pub fn calc_data_crc32(data: &[u8]) -> u32 {
     let mut digest = crc32::Digest::new(crc32::IEEE);
     digest.write(data);
     digest.sum32()
@@ -53,7 +53,7 @@ pub fn gen_sst_file<P: AsRef<Path>>(path: P, range: (u8, u8)) -> (SSTMeta, Vec<u
 pub fn read_sst_file<P: AsRef<Path>>(path: P, range: (u8, u8)) -> (SSTMeta, Vec<u8>) {
     let mut data = Vec::new();
     File::open(path).unwrap().read_to_end(&mut data).unwrap();
-    let crc32 = get_data_crc32(&data);
+    let crc32 = calc_data_crc32(&data);
 
     let mut meta = SSTMeta::new();
     meta.set_uuid(Uuid::new_v4().as_bytes().to_vec());

--- a/src/import/tests.rs
+++ b/src/import/tests.rs
@@ -1,0 +1,70 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Read;
+use std::fs::File;
+use std::path::Path;
+
+use crc::crc32::{self, Hasher32};
+use uuid::Uuid;
+use rocksdb::{ColumnFamilyOptions, EnvOptions, SstFileWriter, DB};
+use kvproto::importpb::*;
+
+use raftstore::store::keys;
+
+pub fn get_data_crc32(data: &[u8]) -> u32 {
+    let mut digest = crc32::Digest::new(crc32::IEEE);
+    digest.write(data);
+    digest.sum32()
+}
+
+pub fn check_db_range(db: &DB, start: u8, end: u8) {
+    for i in start..end {
+        let k = keys::data_key(&[i]);
+        assert_eq!(db.get(&k).unwrap().unwrap(), &[i]);
+    }
+}
+
+pub fn gen_sst_meta<P: AsRef<Path>>(path: P, start: u8, end: u8) -> SSTMeta {
+    let mut data = Vec::new();
+    File::open(path).unwrap().read_to_end(&mut data).unwrap();
+    let crc32 = get_data_crc32(&data);
+    let length = data.len() as u64;
+
+    let mut range = Range::new();
+    range.set_start(vec![start]);
+    range.set_end(vec![end]);
+
+    let mut m = SSTMeta::new();
+    m.set_uuid(Uuid::new_v4().as_bytes().to_vec());
+    m.set_range(range);
+    m.set_crc32(crc32);
+    m.set_length(length);
+    m.set_cf_name("default".to_owned());
+    m
+}
+
+pub fn gen_sst_file<P: AsRef<Path>>(path: P, start: u8, end: u8) -> SSTMeta {
+    let env_opt = EnvOptions::new();
+    let cf_opt = ColumnFamilyOptions::new();
+    let mut w = SstFileWriter::new(env_opt, cf_opt);
+
+    w.open(path.as_ref().to_str().unwrap()).unwrap();
+    for i in start..end {
+        let k = keys::data_key(&[i]);
+        w.put(&k, &[i]).unwrap();
+    }
+    w.finish().unwrap();
+
+    gen_sst_meta(path, start, end)
+}

--- a/src/import/tests.rs
+++ b/src/import/tests.rs
@@ -28,43 +28,40 @@ pub fn get_data_crc32(data: &[u8]) -> u32 {
     digest.sum32()
 }
 
-pub fn check_db_range(db: &DB, start: u8, end: u8) {
-    for i in start..end {
+pub fn check_db_range(db: &DB, range: (u8, u8)) {
+    for i in range.0..range.1 {
         let k = keys::data_key(&[i]);
         assert_eq!(db.get(&k).unwrap().unwrap(), &[i]);
     }
 }
 
-pub fn gen_sst_meta<P: AsRef<Path>>(path: P, start: u8, end: u8) -> SSTMeta {
-    let mut data = Vec::new();
-    File::open(path).unwrap().read_to_end(&mut data).unwrap();
-    let crc32 = get_data_crc32(&data);
-    let length = data.len() as u64;
-
-    let mut range = Range::new();
-    range.set_start(vec![start]);
-    range.set_end(vec![end]);
-
-    let mut m = SSTMeta::new();
-    m.set_uuid(Uuid::new_v4().as_bytes().to_vec());
-    m.set_range(range);
-    m.set_crc32(crc32);
-    m.set_length(length);
-    m.set_cf_name("default".to_owned());
-    m
-}
-
-pub fn gen_sst_file<P: AsRef<Path>>(path: P, start: u8, end: u8) -> SSTMeta {
+pub fn gen_sst_file<P: AsRef<Path>>(path: P, range: (u8, u8)) -> (SSTMeta, Vec<u8>) {
     let env_opt = EnvOptions::new();
     let cf_opt = ColumnFamilyOptions::new();
     let mut w = SstFileWriter::new(env_opt, cf_opt);
 
     w.open(path.as_ref().to_str().unwrap()).unwrap();
-    for i in start..end {
+    for i in range.0..range.1 {
         let k = keys::data_key(&[i]);
         w.put(&k, &[i]).unwrap();
     }
     w.finish().unwrap();
 
-    gen_sst_meta(path, start, end)
+    read_sst_file(path, range)
+}
+
+pub fn read_sst_file<P: AsRef<Path>>(path: P, range: (u8, u8)) -> (SSTMeta, Vec<u8>) {
+    let mut data = Vec::new();
+    File::open(path).unwrap().read_to_end(&mut data).unwrap();
+    let crc32 = get_data_crc32(&data);
+
+    let mut meta = SSTMeta::new();
+    meta.set_uuid(Uuid::new_v4().as_bytes().to_vec());
+    meta.mut_range().set_start(vec![range.0]);
+    meta.mut_range().set_end(vec![range.1]);
+    meta.set_crc32(crc32);
+    meta.set_length(data.len() as u64);
+    meta.set_cf_name("default".to_owned());
+
+    (meta, data)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,8 +82,8 @@ extern crate toml;
 extern crate url;
 #[cfg(test)]
 extern crate utime;
-extern crate zipf;
 extern crate uuid;
+extern crate zipf;
 
 #[macro_use]
 pub mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,9 @@ extern crate url;
 #[cfg(test)]
 extern crate utime;
 extern crate zipf;
+#[macro_use]
+extern crate fail;
+extern crate uuid;
 
 #[macro_use]
 pub mod util;
@@ -93,5 +96,6 @@ pub mod raftstore;
 pub mod pd;
 pub mod server;
 pub mod coprocessor;
+pub mod import;
 
 pub use storage::Storage;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,8 +83,6 @@ extern crate url;
 #[cfg(test)]
 extern crate utime;
 extern crate zipf;
-#[macro_use]
-extern crate fail;
 extern crate uuid;
 
 #[macro_use]

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -18,7 +18,9 @@ use std::str::FromStr;
 use grpc::{ChannelBuilder, EnvBuilder, Environment, Server as GrpcServer, ServerBuilder};
 use kvproto::tikvpb_grpc::*;
 use kvproto::debugpb_grpc::create_debug;
+use kvproto::importpb_grpc::create_import_sst;
 
+use import::ImportSSTService;
 use util::worker::{Builder as WorkerBuilder, FutureScheduler, Worker};
 use util::security::SecurityManager;
 use storage::Storage;
@@ -66,6 +68,7 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver + 'static> Server<T, S> {
         snap_mgr: SnapManager,
         pd_scheduler: FutureScheduler<PdTask>,
         debug_engines: Option<Engines>,
+        import_service: Option<ImportSSTService>,
     ) -> Result<Server<T, S>> {
         let env = Arc::new(
             EnvBuilder::new()
@@ -106,6 +109,9 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver + 'static> Server<T, S> {
             sb = security_mgr.bind(sb, &ip, addr.port());
             if let Some(engines) = debug_engines {
                 sb = sb.register_service(create_debug(DebugService::new(engines)));
+            }
+            if let Some(service) = import_service {
+                sb = sb.register_service(create_import_sst(service));
             }
             sb.build()?
         };
@@ -283,6 +289,7 @@ mod tests {
             },
             SnapManager::new("", None, None),
             pd_worker.scheduler(),
+            None,
             None,
         ).unwrap();
 

--- a/src/util/time.rs
+++ b/src/util/time.rs
@@ -249,6 +249,10 @@ impl Instant {
         }
     }
 
+    pub fn elapsed_secs(&self) -> f64 {
+        duration_to_sec(self.elapsed())
+    }
+
     pub fn duration_since(&self, earlier: Instant) -> Duration {
         match (*self, earlier) {
             (Instant::Monotonic(later), Instant::Monotonic(earlier)) => {

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -359,7 +359,7 @@ fn test_serde_custom_tikv_config() {
     };
     value.import = ImportConfig {
         num_threads: 123,
-        stream_channel_size: 123,
+        stream_channel_window: 123,
     };
 
     let custom = read_file_in_project_dir("tests/config/test-custom.toml");

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -23,6 +23,7 @@ use tikv::raftstore::store::Config as RaftstoreConfig;
 use tikv::raftstore::coprocessor::Config as CopConfig;
 use tikv::config::*;
 use tikv::storage::Config as StorageConfig;
+use tikv::import::Config as ImportConfig;
 use tikv::util::config::{ReadableDuration, ReadableSize};
 use tikv::util::security::SecurityConfig;
 
@@ -355,6 +356,10 @@ fn test_serde_custom_tikv_config() {
         cert_path: "invalid path".to_owned(),
         key_path: "invalid path".to_owned(),
         override_ssl_target: "".to_owned(),
+    };
+    value.import = ImportConfig {
+        num_threads: 123,
+        stream_channel_size: 123,
     };
 
     let custom = read_file_in_project_dir("tests/config/test-custom.toml");

--- a/tests/config/test-custom.toml
+++ b/tests/config/test-custom.toml
@@ -305,4 +305,4 @@ key-path = "invalid path"
 
 [import]
 num-threads = 123
-stream-channel-size = 123
+stream-channel-window = 123

--- a/tests/config/test-custom.toml
+++ b/tests/config/test-custom.toml
@@ -302,3 +302,7 @@ max-bytes-for-level-multiplier = 8
 ca-path = "invalid path"
 cert-path = "invalid path"
 key-path = "invalid path"
+
+[import]
+num-threads = 123
+stream-channel-size = 123

--- a/tests/import/mod.rs
+++ b/tests/import/mod.rs
@@ -1,0 +1,14 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod sst_service;

--- a/tests/import/sst_service.rs
+++ b/tests/import/sst_service.rs
@@ -70,19 +70,19 @@ fn test_upload_sst() {
     // Mismatch crc32
     let meta = new_sst_meta(0, length);
     upload.set_meta(meta);
-    assert!(send_upload_sst(&import, upload.clone()).is_err());
+    assert!(send_upload_sst(&import, &upload).is_err());
 
     // Mismatch length
     let meta = new_sst_meta(crc32, 0);
     upload.set_meta(meta);
-    assert!(send_upload_sst(&import, upload.clone()).is_err());
+    assert!(send_upload_sst(&import, &upload).is_err());
 
     let meta = new_sst_meta(crc32, length);
     upload.set_meta(meta);
-    send_upload_sst(&import, upload.clone()).unwrap();
+    send_upload_sst(&import, &upload).unwrap();
 
     // Can't upload the same uuid file again.
-    assert!(send_upload_sst(&import, upload.clone()).is_err());
+    assert!(send_upload_sst(&import, &upload).is_err());
 }
 
 fn new_sst_meta(crc32: u32, length: u64) -> SSTMeta {
@@ -93,8 +93,8 @@ fn new_sst_meta(crc32: u32, length: u64) -> SSTMeta {
     m
 }
 
-fn send_upload_sst(client: &ImportSstClient, m: UploadRequest) -> Result<UploadResponse> {
+fn send_upload_sst(client: &ImportSstClient, m: &UploadRequest) -> Result<UploadResponse> {
     let (tx, rx) = client.upload().unwrap();
-    let stream = stream::once({ Ok((m, WriteFlags::default().buffer_hint(true))) });
+    let stream = stream::once({ Ok((m.clone(), WriteFlags::default().buffer_hint(true))) });
     stream.forward(tx).and_then(|_| rx).wait()
 }

--- a/tests/import/sst_service.rs
+++ b/tests/import/sst_service.rs
@@ -11,7 +11,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use import::tests::*;
+use std::sync::Arc;
+
+use uuid::Uuid;
+use futures::{stream, Future, Stream};
+
+use kvproto::kvrpcpb::*;
+use kvproto::importpb::*;
+use kvproto::importpb_grpc::*;
+use grpc::{ChannelBuilder, Environment, Result, WriteFlags};
+
+use tikv::util::HandyRwLock;
+use tikv::import::tests::*;
+
+use raftstore::server::*;
+use raftstore::cluster::Cluster;
 
 fn new_cluster() -> (Cluster<ServerCluster>, Context) {
     let count = 1;
@@ -29,38 +43,41 @@ fn new_cluster() -> (Cluster<ServerCluster>, Context) {
     (cluster, ctx)
 }
 
-fn new_cluster_and_import_client() -> (Cluster<ServerCluster>, ImportClient) {
-    let (cluster, ctx) = must_new_cluster();
+fn new_cluster_and_import_client() -> (Cluster<ServerCluster>, ImportSstClient) {
+    let (cluster, ctx) = new_cluster();
 
-    let env = Arc::new(Environment::new(1));
-    let addr = cluster.sim.rl().get_addr(ctx.get_peer().get_store_id());
-    let ch = ChannelBuilder::new(env).connect(&format!("{}", addr));
-    let import = ImportClient::new(ch);
+    let ch = {
+        let env = Arc::new(Environment::new(1));
+        let node = ctx.get_peer().get_store_id();
+        ChannelBuilder::new(env).connect(cluster.sim.rl().get_addr(node))
+    };
+    let import = ImportSstClient::new(ch);
 
     (cluster, import)
 }
 
 #[test]
 fn test_upload_sst() {
-    let (_, import) = must_new_cluster_and_import_client();
+    let (_cluster, import) = new_cluster_and_import_client();
 
     let data = vec![1; 1024];
     let crc32 = get_data_crc32(&data);
+    let length = data.len() as u64;
 
-    let mut upload = UploadSSTRequest::new();
+    let mut upload = UploadRequest::new();
     upload.set_data(data.clone());
 
+    // Mismatch crc32
+    let meta = new_sst_meta(0, length);
+    upload.set_meta(meta);
+    assert!(send_upload_sst(&import, upload.clone()).is_err());
+
     // Mismatch length
-    let meta = make_sst_meta(0, crc32);
+    let meta = new_sst_meta(crc32, 0);
     upload.set_meta(meta);
     assert!(send_upload_sst(&import, upload.clone()).is_err());
 
-    // Mismatch checksum
-    let meta = make_sst_meta(data.len(), 0);
-    upload.set_meta(meta);
-    assert!(send_upload_sst(&import, upload.clone()).is_err());
-
-    let meta = make_sst_meta(data.len(), crc32);
+    let meta = new_sst_meta(crc32, length);
     upload.set_meta(meta);
     send_upload_sst(&import, upload.clone()).unwrap();
 
@@ -70,13 +87,14 @@ fn test_upload_sst() {
 
 fn new_sst_meta(crc32: u32, length: u64) -> SSTMeta {
     let mut m = SSTMeta::new();
+    m.set_uuid(Uuid::new_v4().as_bytes().to_vec());
     m.set_crc32(crc32);
     m.set_length(length);
     m
 }
 
-fn send_upload_sst(client: &ImportClient, m: UploadSSTRequest) -> Result<UploadSSTResponse> {
-    let (tx, rx) = client.upload_sst();
+fn send_upload_sst(client: &ImportSstClient, m: UploadRequest) -> Result<UploadResponse> {
+    let (tx, rx) = client.upload().unwrap();
     let stream = stream::once({ Ok((m, WriteFlags::default().buffer_hint(true))) });
     stream.forward(tx).and_then(|_| rx).wait()
 }

--- a/tests/import/sst_service.rs
+++ b/tests/import/sst_service.rs
@@ -1,0 +1,94 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fn must_new_cluster() -> (Cluster<ServerCluster>, Context) {
+    let count = 1;
+    let mut cluster = new_server_cluster(0, count);
+    cluster.run();
+
+    let region_id = 1;
+    let leader = cluster.leader_of_region(region_id).unwrap();
+    let epoch = cluster.get_region_epoch(region_id);
+    let mut ctx = Context::new();
+    ctx.set_region_id(region_id);
+    ctx.set_peer(leader.clone());
+    ctx.set_region_epoch(epoch);
+
+    (cluster, ctx)
+}
+
+fn must_new_cluster_and_import_client() -> (Cluster<ServerCluster>, ImportClient, Context) {
+    let (cluster, ctx) = must_new_cluster();
+
+    let env = Arc::new(Environment::new(1));
+    let addr = cluster.sim.rl().get_addr(ctx.get_peer().get_store_id());
+    let channel = ChannelBuilder::new(env).connect(&format!("{}", addr));
+    let client = ImportClient::new(channel);
+
+    (cluster, client, ctx)
+}
+
+#[test]
+fn test_upload_sst() {
+    let (_, client, _) = must_new_cluster_and_import_client();
+
+    let data = vec![1; 1024];
+    let mut hash = crc32::Digest::new(crc32::IEEE);
+    hash.write(&data);
+    let crc32 = hash.sum32();
+
+    let mut upload = UploadSSTRequest::new();
+    upload.set_data(data.clone());
+
+    // Mismatch length
+    let meta = make_sst_meta(0, crc32);
+    upload.set_meta(meta);
+    assert!(send_upload_sst(&client, upload.clone()).is_err());
+
+    // Mismatch checksum
+    let meta = make_sst_meta(data.len(), 0);
+    upload.set_meta(meta);
+    assert!(send_upload_sst(&client, upload.clone()).is_err());
+
+    let meta = make_sst_meta(data.len(), crc32);
+    upload.set_meta(meta);
+    send_upload_sst(&client, upload.clone()).unwrap();
+
+    // Can't upload the same uuid file again.
+    assert!(send_upload_sst(&client, upload.clone()).is_err());
+}
+
+fn make_sst_meta(len: usize, crc32: u32) -> SSTMeta {
+    let mut m = SSTMeta::new();
+    m.set_len(len as u64);
+    m.set_crc32(crc32);
+    m.set_handle(make_sst_handle());
+    m
+}
+
+fn make_sst_handle() -> SSTHandle {
+    let mut h = SSTHandle::new();
+    let uuid = Uuid::new_v4();
+    h.set_uuid(uuid.as_bytes().to_vec());
+    h.set_cf_name("default".to_owned());
+    h.set_region_id(1);
+    h.mut_region_epoch().set_conf_ver(2);
+    h.mut_region_epoch().set_version(3);
+    h
+}
+
+fn send_upload_sst(client: &ImportClient, m: UploadSSTRequest) -> Result<UploadSSTResponse> {
+    let (tx, rx) = client.upload_sst();
+    let stream = stream::once({ Ok((m, WriteFlags::default().buffer_hint(true))) });
+    stream.forward(tx).and_then(|_| rx).wait()
+}

--- a/tests/import/sst_service.rs
+++ b/tests/import/sst_service.rs
@@ -22,7 +22,7 @@ use kvproto::importpb_grpc::*;
 use grpc::{ChannelBuilder, Environment, Result, WriteFlags};
 
 use tikv::util::HandyRwLock;
-use tikv::import::tests::*;
+use tikv::import::test_helpers::*;
 
 use raftstore::server::*;
 use raftstore::cluster::Cluster;
@@ -61,7 +61,7 @@ fn test_upload_sst() {
     let (_cluster, import) = new_cluster_and_import_client();
 
     let data = vec![1; 1024];
-    let crc32 = get_data_crc32(&data);
+    let crc32 = calc_data_crc32(&data);
     let length = data.len() as u64;
 
     let mut upload = UploadRequest::new();

--- a/tests/integrations.rs
+++ b/tests/integrations.rs
@@ -51,6 +51,7 @@ mod storage_cases;
 mod util;
 mod pd;
 mod config;
+mod import;
 
 use std::env;
 

--- a/tests/integrations.rs
+++ b/tests/integrations.rs
@@ -41,6 +41,7 @@ extern crate test;
 extern crate tikv;
 extern crate tipb;
 extern crate toml;
+extern crate uuid;
 
 mod raft;
 mod raftstore;

--- a/tests/raftstore/server.rs
+++ b/tests/raftstore/server.rs
@@ -121,7 +121,7 @@ impl Simulator for ServerCluster {
             Arc::new(SSTImporter::new(dir).unwrap())
         };
         let import_service =
-            ImportSSTService::new(cfg.import.clone(), store.clone(), importer.clone());
+            ImportSSTService::new(cfg.import.clone(), store.clone(), Arc::clone(&importer));
 
         // Create pd client, snapshot manager, server.
         let (worker, resolver) = resolve::new_resolver(Arc::clone(&self.pd_client)).unwrap();

--- a/tests/raftstore/server.rs
+++ b/tests/raftstore/server.rs
@@ -120,8 +120,7 @@ impl Simulator for ServerCluster {
             let dir = TempDir::new("test-import-sst").unwrap().into_path();
             Arc::new(SSTImporter::new(dir).unwrap())
         };
-        let import_service =
-            ImportSSTService::new(cfg.import.clone(), store.clone(), Arc::clone(&importer));
+        let import_service = ImportSSTService::new(cfg.import.clone(), store.clone(), importer);
 
         // Create pd client, snapshot manager, server.
         let (worker, resolver) = resolve::new_resolver(Arc::clone(&self.pd_client)).unwrap();

--- a/tests/raftstore/server.rs
+++ b/tests/raftstore/server.rs
@@ -30,6 +30,7 @@ use tikv::util::transport::SendCh;
 use tikv::util::security::SecurityManager;
 use tikv::util::worker::{FutureWorker, Worker};
 use tikv::storage::{CfName, Engine};
+use tikv::import::{ImportSSTService, SSTImporter};
 use kvproto::raft_serverpb::{self, RaftMessage};
 use kvproto::raft_cmdpb::*;
 
@@ -114,6 +115,14 @@ impl Simulator for ServerCluster {
         store.start(&cfg.storage).unwrap();
         self.storages.insert(node_id, store.get_engine());
 
+        // Create import service.
+        let importer = {
+            let dir = TempDir::new("test-import-sst").unwrap().into_path();
+            Arc::new(SSTImporter::new(dir).unwrap())
+        };
+        let import_service =
+            ImportSSTService::new(cfg.import.clone(), store.clone(), importer.clone());
+
         // Create pd client, snapshot manager, server.
         let (worker, resolver) = resolve::new_resolver(Arc::clone(&self.pd_client)).unwrap();
         let snap_mgr = SnapManager::new(tmp_str, Some(store_sendch), None);
@@ -130,6 +139,7 @@ impl Simulator for ServerCluster {
             snap_mgr.clone(),
             pd_worker.scheduler(),
             Some(engines.clone()),
+            Some(import_service),
         ).unwrap();
         let addr = server.listening_addr();
         cfg.server.addr = format!("{}", addr);


### PR DESCRIPTION
ImportSST Service provides the feature to import a generated SST file to a
region. The service includes two APIs:
- UploadSST: Upload an SST file to a server
- IngestSST: Ingest an uploaded SST file to a region

This PR implements the UploadSST API. An SST file is identified by its meta data
SSTMeta. When an SST file is uploaded, its length and crc32 checksum will be
validated with the SSTMeta. Then when the SST file is ingested, its length and
crc32 checksum will be validated again, plus its range and the region epoch.

If an SST file is uploaded, but the coresponding region's epoch is changed
before the SST file is ingested, the SST file will be invalid, and can be
cleaned up. However, this PR doesn't contain the logic to clean up invalid SST
files, but it will be added in the other PRs later.

The coresponding kvproto PR: https://github.com/pingcap/kvproto/pull/219
  