### PR TITLE
cherrypick rafactor tikv-ctl(#2377)

### DIFF
--- a/src/bin/tikv-ctl.rs
+++ b/src/bin/tikv-ctl.rs
@@ -21,25 +21,462 @@ extern crate clap;
 extern crate protobuf;
 extern crate kvproto;
 extern crate rocksdb;
-#[cfg(test)]
-extern crate tempdir;
+extern crate grpcio;
+extern crate futures;
 extern crate rustc_serialize;
 
-use std::{str, u64};
-use clap::{App, Arg, SubCommand};
+use std::{process, str, u64};
+use std::iter::FromIterator;
+use std::cmp::Ordering;
+use std::error::Error;
+use std::sync::Arc;
+use std::path::PathBuf;
 use rustc_serialize::hex::{FromHex, ToHex};
+
+use clap::{App, Arg, SubCommand};
 use protobuf::Message;
+use futures::{future, stream, Future, Stream};
+use grpcio::{ChannelBuilder, Environment};
+use protobuf::RepeatedField;
+
 use kvproto::raft_cmdpb::RaftCmdRequest;
-use kvproto::raft_serverpb::{PeerState, RaftApplyState, RaftLocalState, RegionLocalState};
+use kvproto::raft_serverpb::PeerState;
 use kvproto::eraftpb::Entry;
-use rocksdb::{ReadOptions, SeekKey, DB};
+use kvproto::kvrpcpb::MvccInfo;
+use kvproto::debugpb::*;
+use kvproto::debugpb::DB as DBType;
+use kvproto::debugpb_grpc::DebugClient;
 use tikv::util::{self, escape, unescape};
-use tikv::util::codec::bytes::encode_bytes;
-use tikv::raftstore::store::keys;
-use tikv::raftstore::store::engine::{IterOption, Iterable, Peekable};
-use tikv::storage::{CfName, ALL_CFS, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
-use tikv::storage::mvcc::{Lock, Write};
-use tikv::storage::types::Key;
+use tikv::raftstore::store::{keys, Engines};
+use tikv::raftstore::store::debug::{Debugger, RegionInfo};
+use tikv::storage::{ALL_CFS, CF_DEFAULT, CF_LOCK, CF_WRITE};
+
+fn perror_and_exit<E: Error>(prefix: &str, e: E) -> ! {
+    eprintln!("{}: {}", prefix, e);
+    process::exit(-1);
+}
+
+fn new_debug_executor(
+    db: Option<&str>,
+    raft_db: Option<&str>,
+    host: Option<&str>,
+) -> Box<DebugExecutor> {
+    match (host, db) {
+        (None, Some(kv_path)) => {
+            let db = util::rocksdb::open(kv_path, ALL_CFS).unwrap();
+            let raft_db = if let Some(raft_path) = raft_db {
+                util::rocksdb::open(raft_path, &[CF_DEFAULT]).unwrap()
+            } else {
+                let raft_path = PathBuf::from(kv_path).join("../raft");
+                util::rocksdb::open(raft_path.to_str().unwrap(), &[CF_DEFAULT]).unwrap()
+            };
+            Box::new(Debugger::new(Engines::new(Arc::new(db), Arc::new(raft_db)))) as
+                Box<DebugExecutor>
+        }
+        (Some(remote), None) => {
+            let env = Arc::new(Environment::new(1));
+            let channel = ChannelBuilder::new(env).connect(remote);
+            let client = DebugClient::new(channel);
+            Box::new(client) as Box<DebugExecutor>
+        }
+        _ => unreachable!(),
+    }
+}
+
+trait DebugExecutor {
+    fn dump_value(&self, cf: &str, key: Vec<u8>) {
+        let value = self.get_value_by_key(cf, key);
+        println!("value: {}", escape(&value));
+    }
+
+    fn dump_region_size(&self, region: u64, cfs: Vec<&str>) -> usize {
+        let sizes = self.get_region_size(region, cfs);
+        let mut total_size = 0;
+        println!("region id: {}", region);
+        for (cf, size) in sizes {
+            println!("cf {} region size: {}", cf, convert_gbmb(size as u64));
+            total_size += size;
+        }
+        total_size
+    }
+
+    fn dump_all_region_size(&self, cfs: Vec<&str>) {
+        let regions = self.get_all_meta_regions();
+        let regions_number = regions.len();
+        let mut total_size = 0;
+        for region in regions {
+            total_size += self.dump_region_size(region, cfs.clone());
+        }
+        println!("total region number: {}", regions_number);
+        println!("total region size: {}", convert_gbmb(total_size as u64));
+    }
+
+    fn dump_region_info(&self, region: u64, skip_tombstone: bool) {
+        let r = self.get_region_info(region);
+        if skip_tombstone {
+            let region_state = r.region_local_state.as_ref();
+            if region_state.map_or(false, |s| s.get_state() == PeerState::Tombstone) {
+                return;
+            }
+        }
+        let region_state_key = keys::region_state_key(region);
+        let raft_state_key = keys::raft_state_key(region);
+        let apply_state_key = keys::apply_state_key(region);
+        println!("region id: {}", region);
+        println!("region state key: {}", escape(&region_state_key));
+        println!("region state: {:?}", r.region_local_state);
+        println!("raft state key: {}", escape(&raft_state_key));
+        println!("raft state: {:?}", r.raft_local_state);
+        println!("apply state key: {}", escape(&apply_state_key));
+        println!("apply state: {:?}", r.raft_apply_state);
+    }
+
+    fn dump_all_region_info(&self, skip_tombstone: bool) {
+        for region in self.get_all_meta_regions() {
+            self.dump_region_info(region, skip_tombstone);
+        }
+    }
+
+    fn dump_raft_log(&self, region: u64, index: u64) {
+        let idx_key = keys::raft_log_key(region, index);
+        println!("idx_key: {}", escape(&idx_key));
+        println!("region: {}", region);
+        println!("log index: {}", index);
+
+        let mut entry = self.get_raft_log(region, index);
+        let data = entry.take_data();
+        println!("entry {:?}", entry);
+        println!("msg len: {}", data.len());
+
+        let mut msg = RaftCmdRequest::new();
+        msg.merge_from_bytes(&data).unwrap();
+        println!("{:?}", msg);
+    }
+
+    fn dump_mvccs_infos(
+        &self,
+        from: Vec<u8>,
+        to: Option<Vec<u8>>,
+        limit: Option<u64>,
+        cfs: Vec<&str>,
+        start_ts: Option<u64>,
+        commit_ts: Option<u64>,
+    ) {
+        let to = to.unwrap_or_default();
+        let limit = limit.unwrap_or_default();
+        if to.is_empty() && limit == 0 {
+            eprintln!(r#"please pass "to" or "limit""#);
+            process::exit(-1);
+        }
+        if !to.is_empty() && to < from {
+            eprintln!("The region's from pos must greater than the to pos.");
+            process::exit(-1);
+        }
+        let scan_future = self.get_mvcc_infos(from, to, limit).for_each(
+            move |(key, mvcc)| {
+                println!("key: {}", escape(&key));
+                if cfs.contains(&CF_LOCK) && mvcc.has_lock() {
+                    let lock_info = mvcc.get_lock();
+                    if start_ts.map_or(true, |ts| lock_info.get_lock_version() == ts) {
+                        // FIXME: "lock type" is lost in kvproto.
+                        println!("\tlock cf value: {:?}", lock_info);
+                    }
+                }
+                if cfs.contains(&CF_DEFAULT) {
+                    for value_info in mvcc.get_values() {
+                        if commit_ts.map_or(true, |ts| value_info.get_ts() == ts) {
+                            println!("\tdefault cf value: {:?}", value_info);
+                        }
+                    }
+                }
+                if cfs.contains(&CF_WRITE) {
+                    for write_info in mvcc.get_writes() {
+                        if start_ts.map_or(true, |ts| write_info.get_start_ts() == ts) &&
+                            commit_ts.map_or(true, |ts| write_info.get_commit_ts() == ts)
+                        {
+                            // FIXME: short_value is lost in kvproto.
+                            println!("\t write cf value: {:?}", write_info);
+                        }
+                    }
+                }
+                println!("");
+                future::ok::<(), String>(())
+            },
+        );
+        if let Err(e) = scan_future.wait() {
+            eprintln!("{}", e);
+            process::exit(-1);
+        }
+    }
+
+    fn diff_region(
+        &self,
+        region: u64,
+        db: Option<&str>,
+        raft_db: Option<&str>,
+        host: Option<&str>,
+    ) {
+        let rhs_debug_executor = new_debug_executor(db, raft_db, host);
+
+        let r1 = self.get_region_info(region);
+        let r2 = rhs_debug_executor.get_region_info(region);
+        println!("region id: {}", region);
+        println!("db1 region state: {:?}", r1.region_local_state);
+        println!("db2 region state: {:?}", r2.region_local_state);
+        println!("db1 apply state: {:?}", r1.raft_apply_state);
+        println!("db2 apply state: {:?}", r2.raft_apply_state);
+
+        match (r1.region_local_state, r2.region_local_state) {
+            (None, None) => return,
+            (Some(_), None) | (None, Some(_)) => {
+                println!("db1 and db2 don't have same region local_state");
+                return;
+            }
+            (Some(region_local_1), Some(region_local_2)) => {
+                let region1 = region_local_1.get_region();
+                let region2 = region_local_2.get_region();
+                if region1 != region2 {
+                    println!("db1 and db2 have different region:");
+                    println!("db1 region: {:?}", region1);
+                    println!("db2 region: {:?}", region2);
+                    return;
+                }
+                let start_key = keys::data_key(region1.get_start_key());
+                let end_key = keys::data_key(region1.get_end_key());
+                let mut mvcc_infos_1 = self.get_mvcc_infos(start_key.clone(), end_key.clone(), 0);
+                let mut mvcc_infos_2 = rhs_debug_executor.get_mvcc_infos(start_key, end_key, 0);
+
+                let mut has_diff = false;
+                let mut key_counts = [0; 2];
+
+                let mut take_item = |i: usize| -> Option<(Vec<u8>, MvccInfo)> {
+                    let wait = match i {
+                        1 => future::poll_fn(|| mvcc_infos_1.poll()).wait(),
+                        _ => future::poll_fn(|| mvcc_infos_2.poll()).wait(),
+                    };
+                    match wait {
+                        Ok(item1) => item1,
+                        Err(e) => {
+                            println!("db{} scan data in region {} fail: {}", i, region, e);
+                            process::exit(-1);
+                        }
+                    }
+                };
+
+                let show_only = |i: usize, k: &[u8]| {
+                    println!("only db{} has: {}", i, escape(k));
+                };
+
+                let (mut item1, mut item2) = (take_item(1), take_item(2));
+                while item1.is_some() && item2.is_some() {
+                    key_counts[0] += 1;
+                    key_counts[1] += 1;
+                    let t1 = item1.take().unwrap();
+                    let t2 = item2.take().unwrap();
+                    match t1.0.cmp(&t2.0) {
+                        Ordering::Less => {
+                            show_only(1, &t1.0);
+                            has_diff = true;
+                            item1 = take_item(1);
+                            item2 = Some(t2);
+                            key_counts[1] -= 1;
+                        }
+                        Ordering::Greater => {
+                            show_only(2, &t2.0);
+                            has_diff = true;
+                            item1 = Some(t1);
+                            item2 = take_item(2);
+                            key_counts[0] -= 1;
+                        }
+                        _ => {
+                            if t1.1 != t2.1 {
+                                println!("diff mvcc on key: {}", escape(&t1.0));
+                                has_diff = true;
+                            }
+                            item1 = take_item(1);
+                            item2 = take_item(2);
+                        }
+                    }
+                }
+                let mut item = item1.map(|t| (1, t)).or_else(|| item2.map(|t| (2, t)));
+                while let Some((i, (key, _))) = item.take() {
+                    key_counts[i - 1] += 1;
+                    show_only(i, &key);
+                    has_diff = true;
+                    item = take_item(i).map(|t| (i, t));
+                }
+                if !has_diff {
+                    println!("db1 and db2 have same data in region: {}", region);
+                }
+                println!(
+                    "db1 has {} keys, db2 has {} keys",
+                    key_counts[0],
+                    key_counts[1]
+                );
+            }
+        }
+    }
+
+    fn compact(&self, db: DBType, cf: &str, from: Option<Vec<u8>>, to: Option<Vec<u8>>) {
+        let from = from.unwrap_or_default();
+        let to = to.unwrap_or_default();
+        self.do_compact(db, cf, from, to);
+    }
+
+    fn get_all_meta_regions(&self) -> Vec<u64>;
+
+    fn get_value_by_key(&self, cf: &str, key: Vec<u8>) -> Vec<u8>;
+
+    fn get_region_size(&self, region: u64, cfs: Vec<&str>) -> Vec<(String, usize)>;
+
+    fn get_region_info(&self, region: u64) -> RegionInfo;
+
+    fn get_raft_log(&self, region: u64, index: u64) -> Entry;
+
+    fn get_mvcc_infos(
+        &self,
+        from: Vec<u8>,
+        to: Vec<u8>,
+        limit: u64,
+    ) -> Box<Stream<Item = (Vec<u8>, MvccInfo), Error = String>>;
+
+    fn do_compact(&self, db: DBType, cf: &str, from: Vec<u8>, to: Vec<u8>);
+}
+
+
+impl DebugExecutor for DebugClient {
+    fn get_all_meta_regions(&self) -> Vec<u64> {
+        unimplemented!();
+    }
+
+    fn get_value_by_key(&self, cf: &str, key: Vec<u8>) -> Vec<u8> {
+        let mut req = GetRequest::new();
+        req.set_db(DBType::KV);
+        req.set_cf(cf.to_owned());
+        req.set_key(key);
+        self.get(req)
+            .unwrap_or_else(|e| perror_and_exit("DebugClient::get", e))
+            .take_value()
+    }
+
+    fn get_region_size(&self, region: u64, cfs: Vec<&str>) -> Vec<(String, usize)> {
+        let cfs = cfs.into_iter().map(|s| s.to_owned()).collect();
+        let mut req = RegionSizeRequest::new();
+        req.set_cfs(RepeatedField::from_vec(cfs));
+        req.set_region_id(region);
+        self.region_size(req)
+            .unwrap_or_else(|e| perror_and_exit("DebugClient::region_size", e))
+            .take_entries()
+            .into_iter()
+            .map(|mut entry| (entry.take_cf(), entry.get_size() as usize))
+            .collect()
+    }
+
+    fn get_region_info(&self, region: u64) -> RegionInfo {
+        let mut req = RegionInfoRequest::new();
+        req.set_region_id(region);
+        let mut resp = self.region_info(req)
+            .unwrap_or_else(|e| perror_and_exit("DebugClient::region_info", e));
+
+        let mut region_info = RegionInfo::default();
+        if resp.has_raft_local_state() {
+            region_info.raft_local_state = Some(resp.take_raft_local_state());
+        }
+        if resp.has_raft_apply_state() {
+            region_info.raft_apply_state = Some(resp.take_raft_apply_state());
+        }
+        if resp.has_region_local_state() {
+            region_info.region_local_state = Some(resp.take_region_local_state());
+        }
+        region_info
+    }
+
+    fn get_raft_log(&self, region: u64, index: u64) -> Entry {
+        let mut req = RaftLogRequest::new();
+        req.set_region_id(region);
+        req.set_log_index(index);
+        self.raft_log(req)
+            .unwrap_or_else(|e| perror_and_exit("DebugClient::raft_log", e))
+            .take_entry()
+    }
+
+    fn get_mvcc_infos(
+        &self,
+        from: Vec<u8>,
+        to: Vec<u8>,
+        limit: u64,
+    ) -> Box<Stream<Item = (Vec<u8>, MvccInfo), Error = String>> {
+        let mut req = ScanMvccRequest::new();
+        req.set_from_key(from);
+        req.set_to_key(to);
+        req.set_limit(limit);
+        Box::new(
+            self.scan_mvcc(req)
+                .map_err(|e| e.to_string())
+                .map(|mut resp| (resp.take_key(), resp.take_info())),
+        ) as Box<Stream<Item = (Vec<u8>, MvccInfo), Error = String>>
+    }
+
+    fn do_compact(&self, db: DBType, cf: &str, from: Vec<u8>, to: Vec<u8>) {
+        let mut req = CompactRequest::new();
+        req.set_db(db);
+        req.set_cf(cf.to_owned());
+        req.set_from_key(from);
+        req.set_to_key(to);
+        self.compact(req)
+            .unwrap_or_else(|e| perror_and_exit("DebugClient::compact", e));
+        println!("success!");
+    }
+}
+
+impl DebugExecutor for Debugger {
+    fn get_all_meta_regions(&self) -> Vec<u64> {
+        self.get_all_meta_regions()
+            .unwrap_or_else(|e| perror_and_exit("Debugger::get_all_meta_regions", e))
+    }
+
+    fn get_value_by_key(&self, cf: &str, key: Vec<u8>) -> Vec<u8> {
+        self.get(DBType::KV, cf, &key)
+            .unwrap_or_else(|e| perror_and_exit("Debugger::get", e))
+    }
+
+    fn get_region_size(&self, region: u64, cfs: Vec<&str>) -> Vec<(String, usize)> {
+        self.region_size(region, cfs)
+            .unwrap_or_else(|e| perror_and_exit("Debugger::region_size", e))
+            .into_iter()
+            .map(|(cf, size)| (cf.to_owned(), size as usize))
+            .collect()
+    }
+
+    fn get_region_info(&self, region: u64) -> RegionInfo {
+        self.region_info(region)
+            .unwrap_or_else(|e| perror_and_exit("Debugger::region_info", e))
+    }
+
+    fn get_raft_log(&self, region: u64, index: u64) -> Entry {
+        self.raft_log(region, index)
+            .unwrap_or_else(|e| perror_and_exit("Debugger::raft_log", e))
+    }
+
+    fn get_mvcc_infos(
+        &self,
+        from: Vec<u8>,
+        to: Vec<u8>,
+        limit: u64,
+    ) -> Box<Stream<Item = (Vec<u8>, MvccInfo), Error = String>> {
+        let iter = self.scan_mvcc(&from, &to, limit)
+            .unwrap_or_else(|e| perror_and_exit("Debugger::scan_mvcc", e));
+        #[allow(deprecated)]
+        let stream = stream::iter(iter).map_err(|e| e.to_string());
+        Box::new(stream) as Box<Stream<Item = (Vec<u8>, MvccInfo), Error = String>>
+    }
+
+    fn do_compact(&self, db: DBType, cf: &str, from: Vec<u8>, to: Vec<u8>) {
+        self.compact(db, cf, &from, &to)
+            .unwrap_or_else(|e| perror_and_exit("Debugger::compact", e));
+        println!("success!");
+    }
+}
 
 fn main() {
     let mut app = App::new("TiKV Ctl")
@@ -49,25 +486,34 @@ fn main() {
         )
         .arg(
             Arg::with_name("db")
-                .short("d")
+                .long("db")
                 .takes_value(true)
                 .help("set rocksdb path"),
         )
         .arg(
             Arg::with_name("raftdb")
-                .short("r")
+                .long("raftdb")
                 .takes_value(true)
                 .help("set raft rocksdb path"),
         )
         .arg(
+            Arg::with_name("host")
+                .long("host")
+                .conflicts_with_all(&["db", "raftdb"])
+                .takes_value(true)
+                .help("set remote host"),
+        )
+        .arg(
             Arg::with_name("hex-to-escaped")
-                .short("h")
+                .conflicts_with("escaped-to-hex")
+                .long("to-escaped")
                 .takes_value(true)
                 .help("convert hex key to escaped key"),
         )
         .arg(
             Arg::with_name("escaped-to-hex")
-                .short("e")
+                .conflicts_with("hex-to-escaped")
+                .long("to-hex")
                 .takes_value(true)
                 .help("convert escaped key to hex key"),
         )
@@ -79,21 +525,27 @@ fn main() {
                         .about("print the raft log entry info")
                         .arg(
                             Arg::with_name("region")
+                                .required_unless("key")
+                                .conflicts_with("key")
                                 .short("r")
                                 .takes_value(true)
                                 .help("set the region id"),
                         )
                         .arg(
                             Arg::with_name("index")
+                                .required_unless("key")
+                                .conflicts_with("key")
                                 .short("i")
                                 .takes_value(true)
                                 .help("set the raft log index"),
                         )
                         .arg(
                             Arg::with_name("key")
+                                .required_unless_one(&["region", "index"])
+                                .conflicts_with_all(&["region", "index"])
                                 .short("k")
                                 .takes_value(true)
-                                .help("set the raw key"),
+                                .help("set the raw key, in escaped form"),
                         ),
                 )
                 .subcommand(
@@ -107,7 +559,7 @@ fn main() {
                         )
                         .arg(
                             Arg::with_name("skip-tombstone")
-                                .short("s")
+                                .long("skip-tombstone")
                                 .takes_value(false)
                                 .help("skip tombstone region."),
                         ),
@@ -126,6 +578,11 @@ fn main() {
                     Arg::with_name("cf")
                         .short("c")
                         .takes_value(true)
+                        .multiple(true)
+                        .use_delimiter(true)
+                        .require_delimiter(true)
+                        .value_delimiter(",")
+                        .default_value("default,write,lock")
                         .help("set the cf name, if not specified, print all cf."),
                 ),
         )
@@ -135,37 +592,45 @@ fn main() {
                 .arg(
                     Arg::with_name("from")
                         .short("f")
+                        .long("from")
                         .takes_value(true)
                         .help("set the scan from raw key, in escaped format"),
                 )
                 .arg(
                     Arg::with_name("to")
                         .short("t")
+                        .long("to")
                         .takes_value(true)
                         .help("set the scan end raw key, in escaped format"),
                 )
                 .arg(
                     Arg::with_name("limit")
-                        .short("l")
+                        .long("limit")
                         .takes_value(true)
                         .help("set the scan limit"),
                 )
                 .arg(
                     Arg::with_name("start_ts")
-                        .short("s")
+                        .long("start-ts")
                         .takes_value(true)
                         .help("set the scan start_ts as filter"),
                 )
                 .arg(
                     Arg::with_name("commit_ts")
+                        .long("commit-ts")
                         .takes_value(true)
                         .help("set the scan commit_ts as filter"),
                 )
                 .arg(
                     Arg::with_name("cf")
-                        .short("c")
+                        .long("cf")
                         .takes_value(true)
-                        .help("column family name"),
+                        .multiple(true)
+                        .use_delimiter(true)
+                        .require_delimiter(true)
+                        .value_delimiter(",")
+                        .default_value(CF_DEFAULT)
+                        .help("column family names, combined from default/lock/write"),
                 ),
         )
         .subcommand(
@@ -175,10 +640,12 @@ fn main() {
                     Arg::with_name("cf")
                         .short("c")
                         .takes_value(true)
+                        .default_value(CF_DEFAULT)
                         .help("column family name"),
                 )
                 .arg(
                     Arg::with_name("key")
+                        .required(true)
                         .short("k")
                         .takes_value(true)
                         .help("set the query raw key, in escaped form"),
@@ -188,31 +655,31 @@ fn main() {
             SubCommand::with_name("mvcc")
                 .about("print the mvcc value")
                 .arg(
+                    Arg::with_name("key")
+                        .short("k")
+                        .takes_value(true)
+                        .help("set the query raw key, in escaped form"),
+                )
+                .arg(
                     Arg::with_name("cf")
                         .short("c")
                         .takes_value(true)
-                        .help("column family name, only can be default/lock/write"),
-                )
-                .arg(
-                    Arg::with_name("key")
-                        .short("key")
-                        .takes_value(true)
-                        .help("the query key"),
-                )
-                .arg(
-                    Arg::with_name("encoded")
-                        .short("e")
-                        .takes_value(false)
-                        .help("set it when the key is already encoded."),
+                        .multiple(true)
+                        .use_delimiter(true)
+                        .require_delimiter(true)
+                        .value_delimiter(",")
+                        .default_value(CF_DEFAULT)
+                        .help("column family names, combined from default/lock/write"),
                 )
                 .arg(
                     Arg::with_name("start_ts")
-                        .short("s")
+                        .long("start-ts")
                         .takes_value(true)
                         .help("set start_ts as filter"),
                 )
                 .arg(
                     Arg::with_name("commit_ts")
+                        .long("commit-ts")
                         .takes_value(true)
                         .help("set commit_ts as filter"),
                 ),
@@ -221,16 +688,55 @@ fn main() {
             SubCommand::with_name("diff")
                 .about("diff two region keys")
                 .arg(
-                    Arg::with_name("to")
-                        .short("t")
-                        .takes_value(true)
-                        .help("to which db"),
-                )
-                .arg(
                     Arg::with_name("region")
                         .short("r")
                         .takes_value(true)
                         .help("specify region id"),
+                )
+                .arg(
+                    Arg::with_name("to_db")
+                        .long("to-db")
+                        .takes_value(true)
+                        .help("to which db path"),
+                )
+                .arg(
+                    Arg::with_name("to_host")
+                        .long("to-host")
+                        .takes_value(true)
+                        .conflicts_with("to_db")
+                        .help("to which remote host"),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("compact")
+                .about("compact a column family in a specified range")
+                .arg(
+                    Arg::with_name("db")
+                        .short("d")
+                        .takes_value(true)
+                        .default_value("kv")
+                        .help("kv or raft"),
+                )
+                .arg(
+                    Arg::with_name("cf")
+                        .short("c")
+                        .takes_value(true)
+                        .default_value(CF_DEFAULT)
+                        .help("column family name, only can be default/lock/write"),
+                )
+                .arg(
+                    Arg::with_name("from")
+                        .short("f")
+                        .long("from")
+                        .takes_value(true)
+                        .help("set the start raw key, in escaped form"),
+                )
+                .arg(
+                    Arg::with_name("to")
+                        .short("t")
+                        .long("to")
+                        .takes_value(true)
+                        .help("set the end raw key, in escaped form"),
                 ),
         );
     let matches = app.clone().get_matches();
@@ -238,8 +744,6 @@ fn main() {
     let hex_key = matches.value_of("hex-to-escaped");
     let escaped_key = matches.value_of("escaped-to-hex");
     match (hex_key, escaped_key) {
-        (None, None) => {}
-        (Some(_), Some(_)) => panic!("hex and escaped can not be passed together!"),
         (Some(hex), None) => {
             println!("{}", escape(&from_hex(hex)));
             return;
@@ -248,129 +752,77 @@ fn main() {
             println!("{}", &unescape(escaped).to_hex().to_uppercase());
             return;
         }
-    };
-    let db_path = matches.value_of("db").unwrap();
-    let db = util::rocksdb::open(db_path, ALL_CFS).unwrap();
-    let raft_db = if let Some(raftdb_path) = matches.value_of("raftdb") {
-        util::rocksdb::open(raftdb_path, &[CF_DEFAULT]).unwrap()
-    } else {
-        let raftdb_path = db_path.to_owned() + "../raft";
-        util::rocksdb::open(&raftdb_path, &[CF_DEFAULT]).unwrap()
+        (None, None) => {}
+        _ => unreachable!(),
     };
 
+    let db = matches.value_of("db");
+    let raft_db = matches.value_of("raftdb");
+    let host = matches.value_of("host");
+
+    let debug_executor = new_debug_executor(db, raft_db, host);
+
     if let Some(matches) = matches.subcommand_matches("print") {
-        let cf_name = matches.value_of("cf").unwrap_or(CF_DEFAULT);
-        let key = String::from(matches.value_of("key").unwrap());
-        dump_raw_value(db, cf_name, key);
+        let cf = matches.value_of("cf").unwrap();
+        let key = unescape(matches.value_of("key").unwrap());
+        debug_executor.dump_value(cf, key);
     } else if let Some(matches) = matches.subcommand_matches("raft") {
         if let Some(matches) = matches.subcommand_matches("log") {
-            let key = match matches.value_of("key") {
-                None => {
-                    let region = String::from(matches.value_of("region").unwrap());
-                    let index = String::from(matches.value_of("index").unwrap());
-                    keys::raft_log_key(region.parse().unwrap(), index.parse().unwrap())
-                }
-                Some(k) => unescape(k),
+            let (id, index) = if let Some(key) = matches.value_of("key") {
+                keys::decode_raft_log_key(&unescape(key)).unwrap()
+            } else {
+                let id = matches.value_of("region").unwrap().parse().unwrap();
+                let index = matches.value_of("index").unwrap().parse().unwrap();
+                (id, index)
             };
-            dump_raft_log_entry(raft_db, &key);
+            debug_executor.dump_raft_log(id, index);
         } else if let Some(matches) = matches.subcommand_matches("region") {
             let skip_tombstone = matches.is_present("skip-tombstone");
-            match matches.value_of("region") {
-                Some(id) => {
-                    dump_region_info(&db, &raft_db, id.parse().unwrap(), skip_tombstone);
-                }
-                None => {
-                    dump_all_region_info(&db, &raft_db, skip_tombstone);
-                }
+            if let Some(id) = matches.value_of("region") {
+                debug_executor.dump_region_info(id.parse().unwrap(), skip_tombstone);
+            } else {
+                debug_executor.dump_all_region_info(skip_tombstone);
             }
         } else {
-            panic!("Currently only support raft log entry and scan.")
+            let _ = app.print_help();
         }
     } else if let Some(matches) = matches.subcommand_matches("size") {
-        let cf_name = matches.value_of("cf");
-        match matches.value_of("region") {
-            Some(id) => {
-                dump_region_size(&db, id.parse().unwrap(), cf_name);
-            }
-            None => dump_all_region_size(&db, cf_name),
+        let cfs = Vec::from_iter(matches.values_of("cf").unwrap());
+        if let Some(id) = matches.value_of("region") {
+            debug_executor.dump_region_size(id.parse().unwrap(), cfs);
+        } else {
+            debug_executor.dump_all_region_size(cfs);
         }
     } else if let Some(matches) = matches.subcommand_matches("scan") {
-        let from = String::from(matches.value_of("from").unwrap());
-        let to = matches.value_of("to").map(String::from);
+        let from = unescape(matches.value_of("from").unwrap());
+        let to = matches.value_of("to").map(|to| unescape(to));
         let limit = matches.value_of("limit").map(|s| s.parse().unwrap());
-        let cf_name = matches.value_of("cf").unwrap_or(CF_DEFAULT);
+        let cfs = Vec::from_iter(matches.values_of("cf").unwrap());
         let start_ts = matches.value_of("start_ts").map(|s| s.parse().unwrap());
         let commit_ts = matches.value_of("commit_ts").map(|s| s.parse().unwrap());
-        if let Some(ref to) = to {
-            if to <= &from {
-                panic!("The region's start pos must greater than the end pos.")
-            }
-        }
-        dump_range(db, from, to, limit, cf_name, start_ts, commit_ts);
+        debug_executor.dump_mvccs_infos(from, to, limit, cfs, start_ts, commit_ts);
     } else if let Some(matches) = matches.subcommand_matches("mvcc") {
-        let cf_name = matches.value_of("cf").unwrap_or(CF_DEFAULT);
-        let key = matches.value_of("key").unwrap();
-        let key_encoded = matches.is_present("encoded");
+        let from = unescape(matches.value_of("key").unwrap());
+        let cfs = Vec::from_iter(matches.values_of("cf").unwrap());
         let start_ts = matches.value_of("start_ts").map(|s| s.parse().unwrap());
         let commit_ts = matches.value_of("commit_ts").map(|s| s.parse().unwrap());
-        println!("You are searching Key {}: ", key);
-        match cf_name {
-            CF_DEFAULT => {
-                dump_mvcc_default(&db, key, key_encoded, start_ts);
-            }
-            CF_LOCK => {
-                dump_mvcc_lock(&db, key, key_encoded, start_ts);
-            }
-            CF_WRITE => {
-                dump_mvcc_write(&db, key, key_encoded, start_ts, commit_ts);
-            }
-            "all" => {
-                dump_mvcc_default(&db, key, key_encoded, start_ts);
-                dump_mvcc_lock(&db, key, key_encoded, start_ts);
-                dump_mvcc_write(&db, key, key_encoded, start_ts, commit_ts);
-            }
-            _ => {
-                println!("The cf: {} cannot be dumped", cf_name);
-                let _ = app.print_help();
-            }
-        }
+        debug_executor.dump_mvccs_infos(from, None, Some(1), cfs, start_ts, commit_ts);
     } else if let Some(matches) = matches.subcommand_matches("diff") {
-        let region_id: u64 = matches.value_of("region").unwrap().parse().unwrap();
-        let db_path2 = matches.value_of("to").unwrap();
-        let db2 = util::rocksdb::open(db_path2, ALL_CFS).unwrap();
-        dump_diff(&db, &db2, region_id);
+        let region = matches.value_of("region").unwrap().parse().unwrap();
+        let to_db = matches.value_of("to_db");
+        let to_host = matches.value_of("to_host");
+        debug_executor.diff_region(region, to_db, None, to_host);
+    } else if let Some(matches) = matches.subcommand_matches("compact") {
+        let db = matches.value_of("db").unwrap();
+        let db_type = if db == "kv" { DBType::KV } else { DBType::RAFT };
+        let cf = matches.value_of("cf").unwrap();
+        let from_key = matches.value_of("from").map(|k| unescape(k));
+        let to_key = matches.value_of("to").map(|k| unescape(k));
+        debug_executor.compact(db_type, cf, from_key, to_key);
     } else {
         let _ = app.print_help();
     }
 
-}
-
-pub trait MvccDeserializable: PartialEq {
-    fn deserialize(bytes: &[u8]) -> Self;
-}
-
-impl MvccDeserializable for Write {
-    fn deserialize(bytes: &[u8]) -> Self {
-        Write::parse(bytes).unwrap()
-    }
-}
-
-impl MvccDeserializable for Lock {
-    fn deserialize(bytes: &[u8]) -> Self {
-        Lock::parse(bytes).unwrap()
-    }
-}
-
-impl MvccDeserializable for Vec<u8> {
-    fn deserialize(bytes: &[u8]) -> Self {
-        bytes.to_vec()
-    }
-}
-
-#[derive(PartialEq, Debug)]
-pub struct MvccKv<T> {
-    key: Key,
-    value: T,
 }
 
 fn from_hex(key: &str) -> Vec<u8> {
@@ -382,221 +834,6 @@ fn from_hex(key: &str) -> Vec<u8> {
         s.truncate(new_len);
     }
     s.as_str().from_hex().unwrap()
-}
-
-pub fn gen_mvcc_iter<T: MvccDeserializable>(
-    db: &DB,
-    key_prefix: &str,
-    prefix_is_encoded: bool,
-    mvcc_type: CfName,
-) -> Vec<MvccKv<T>> {
-    let encoded_prefix = if prefix_is_encoded {
-        unescape(key_prefix)
-    } else {
-        encode_bytes(unescape(key_prefix).as_slice())
-    };
-    let iter_opt = IterOption::new(None, None, false);
-    let mut iter = db.new_iterator_cf(mvcc_type, iter_opt).unwrap();
-    iter.seek(keys::data_key(&encoded_prefix).as_slice().into());
-    if !iter.valid() {
-        vec![]
-    } else {
-        let kvs = iter.map(|s| {
-            let key = &keys::origin_key(&s.0);
-            MvccKv {
-                key: Key::from_encoded(key.to_vec()),
-                value: T::deserialize(&s.1),
-            }
-        });
-        kvs.take_while(|s| s.key.encoded().starts_with(&encoded_prefix))
-            .collect()
-    }
-}
-
-
-fn dump_mvcc_default(db: &DB, key: &str, encoded: bool, start_ts: Option<u64>) {
-    let kvs: Vec<MvccKv<Vec<u8>>> = gen_mvcc_iter(db, key, encoded, CF_DEFAULT);
-    for kv in kvs {
-        let ts = kv.key.decode_ts().unwrap();
-        let key = kv.key.truncate_ts().unwrap();
-        if start_ts.is_none() || start_ts.unwrap() == ts {
-            let v = key.encoded();
-            println!("Key: {:?}", escape(v));
-            println!("Value: {:?}", escape(kv.value.as_slice()));
-            println!("Start_ts: {:?}", ts);
-            println!("");
-        }
-    }
-}
-
-fn dump_mvcc_lock(db: &DB, key: &str, encoded: bool, start_ts: Option<u64>) {
-    let kvs: Vec<MvccKv<Lock>> = gen_mvcc_iter(db, key, encoded, CF_LOCK);
-    for kv in kvs {
-        let lock = &kv.value;
-        if start_ts.is_none() || start_ts.unwrap() == lock.ts {
-            println!("Key: {:?}", escape(kv.key.encoded()));
-            println!("Primary: {:?}", escape(lock.primary.as_slice()));
-            println!("Type: {:?}", lock.lock_type);
-            println!("Start_ts: {:?}", lock.ts);
-            println!("");
-        }
-    }
-}
-
-fn dump_mvcc_write(
-    db: &DB,
-    key: &str,
-    encoded: bool,
-    start_ts: Option<u64>,
-    commit_ts: Option<u64>,
-) {
-    let kvs: Vec<MvccKv<Write>> = gen_mvcc_iter(db, key, encoded, CF_WRITE);
-    for kv in kvs {
-        let write = &kv.value;
-        let cmt_ts = kv.key.decode_ts().unwrap();
-        let key = kv.key.truncate_ts().unwrap();
-        if (start_ts.is_none() || start_ts.unwrap() == write.start_ts) &&
-            (commit_ts.is_none() || commit_ts.unwrap() == cmt_ts)
-        {
-            println!("Key: {:?}", escape(key.encoded()));
-            println!("Type: {:?}", write.write_type);
-            println!("Start_ts: {:?}", write.start_ts);
-            println!("Commit_ts: {:?}", cmt_ts);
-            println!("Short value: {:?}", write.short_value);
-            println!("");
-        }
-    }
-}
-
-fn dump_raw_value(db: DB, cf: &str, key: String) {
-    let key = unescape(&key);
-    let value = db.get_value_cf(cf, &key).unwrap();
-    println!("value: {}", value.map_or("None".to_owned(), |v| escape(&v)));
-}
-
-fn dump_raft_log_entry(raft_db: DB, idx_key: &[u8]) {
-    let (region_id, idx) = keys::decode_raft_log_key(idx_key).unwrap();
-    println!("idx_key: {}", escape(idx_key));
-    println!("region: {}", region_id);
-    println!("log index: {}", idx);
-    let mut ent: Entry = raft_db.get_msg(idx_key).unwrap().unwrap();
-    let data = ent.take_data();
-    println!("entry {:?}", ent);
-    let mut msg = RaftCmdRequest::new();
-    msg.merge_from_bytes(&data).unwrap();
-    println!("msg len: {}", data.len());
-    println!("{:?}", msg);
-}
-
-fn dump_diff(db: &DB, db2: &DB, region_id: u64) {
-    println!("region id: {}", region_id);
-    let region_state_key = keys::region_state_key(region_id);
-    let region_state: RegionLocalState =
-        db.get_msg_cf(CF_RAFT, &region_state_key).unwrap().unwrap();
-    println!("db1 region state: {:?}", region_state);
-    let region_state2: RegionLocalState =
-        db2.get_msg_cf(CF_RAFT, &region_state_key).unwrap().unwrap();
-    println!("db2 region state: {:?}", region_state2);
-
-    let raft_state_key = keys::apply_state_key(region_id);
-
-    let apply_state: RaftApplyState = db.get_msg_cf(CF_RAFT, &raft_state_key).unwrap().unwrap();
-    println!("db1 apply state: {:?}", apply_state);
-
-    let apply_state: RaftApplyState = db2.get_msg_cf(CF_RAFT, &raft_state_key).unwrap().unwrap();
-    println!("db2 apply state: {:?}", apply_state);
-
-    let region = region_state.get_region();
-    let start_key = &keys::data_key(region.get_start_key());
-    let end_key = &keys::data_end_key(region.get_end_key());
-    for cf in ALL_CFS {
-        let handle = db.cf_handle(cf).unwrap();
-        let handle2 = db2.cf_handle(cf).unwrap();
-        println!("cf: {}", cf);
-        let mut ropt = ReadOptions::new();
-        ropt.set_iterate_upper_bound(end_key);
-        let mut iter = db.iter_cf_opt(handle, ropt);
-        let mut ropt = ReadOptions::new();
-        ropt.set_iterate_upper_bound(end_key);
-        let mut iter2 = db2.iter_cf_opt(handle2, ropt);
-        iter.seek(SeekKey::Key(start_key));
-        iter2.seek(SeekKey::Key(start_key));
-        let mut has_diff = false;
-        let mut common_head_len = 0;
-        while iter.valid() && iter2.valid() {
-            if iter.key() != iter2.key() {
-                if iter.key() > iter2.key() {
-                    has_diff = true;
-                    println!("only db2 has : {}", escape(iter2.key()));
-                    if cf == &CF_DEFAULT || cf == &CF_WRITE {
-                        println!(
-                            "timestamp: {}",
-                            Key::from_encoded(iter2.key().to_vec()).decode_ts().unwrap()
-                        );
-                    }
-                    iter2.next();
-                    continue;
-                }
-                if iter.key() < iter2.key() {
-                    has_diff = true;
-                    println!("only db1 has : {}", escape(iter.key()));
-                    if cf == &CF_DEFAULT || cf == &CF_WRITE {
-                        println!(
-                            "timestamp: {}",
-                            Key::from_encoded(iter.key().to_vec()).decode_ts().unwrap()
-                        );
-                    }
-                    iter.next();
-                    continue;
-                }
-            }
-            if !has_diff {
-                common_head_len += 1;
-            }
-            iter.next();
-            iter2.next();
-        }
-        println!("head have {} same keys", common_head_len);
-
-        if !iter.valid() && iter2.valid() {
-            println!("iter1 invalid but iter2 valid!");
-            while iter2.valid() {
-                println!("only db2 has : {:?}", escape(iter2.key()));
-                iter2.next();
-            }
-        }
-        if iter.valid() && !iter2.valid() {
-            println!("iter2 invalid but iter1 valid!");
-            while iter.valid() {
-                println!("only db1 has : {:?}", escape(iter.key()));
-                iter.next();
-            }
-        }
-    }
-}
-
-fn dump_region_info(db: &DB, raft_db: &DB, region_id: u64, skip_tombstone: bool) {
-    let region_state_key = keys::region_state_key(region_id);
-    let region_state: Option<RegionLocalState> = db.get_msg_cf(CF_RAFT, &region_state_key).unwrap();
-    if skip_tombstone &&
-        region_state
-            .as_ref()
-            .map_or(false, |s| s.get_state() == PeerState::Tombstone)
-    {
-        return;
-    }
-    println!("region state key: {}", escape(&region_state_key));
-    println!("region state: {:?}", region_state);
-
-    let raft_state_key = keys::raft_state_key(region_id);
-    println!("raft state key: {}", escape(&raft_state_key));
-    let raft_state: Option<RaftLocalState> = raft_db.get_msg(&raft_state_key).unwrap();
-    println!("raft state: {:?}", raft_state);
-
-    let apply_state_key = keys::apply_state_key(region_id);
-    println!("apply state key: {}", escape(&apply_state_key));
-    let apply_state: Option<RaftApplyState> = db.get_msg_cf(CF_RAFT, &apply_state_key).unwrap();
-    println!("apply state: {:?}", apply_state);
 }
 
 fn convert_gbmb(mut bytes: u64) -> String {
@@ -617,256 +854,4 @@ fn convert_gbmb(mut bytes: u64) -> String {
         format!("{} GB ", bytes)
     };
     format!("{}{}", gb, mb)
-}
-
-fn dump_region_size(db: &DB, region_id: u64, cf: Option<&str>) {
-    println!("region id: {}", region_id);
-    if let Some(cf_name) = cf {
-        println!("cf_name: {}", cf_name);
-    }
-    let size = get_region_size(db, region_id, cf);
-    println!("region size: {}", convert_gbmb(size));
-}
-
-fn dump_all_region_info(db: &DB, raft_db: &DB, skip_tombstone: bool) {
-    let region_ids = get_all_region_ids(db);
-    for region_id in region_ids {
-        dump_region_info(db, raft_db, region_id, skip_tombstone);
-    }
-}
-
-fn dump_all_region_size(db: &DB, cf: Option<&str>) {
-    let mut region_ids = get_all_region_ids(db);
-    let mut region_sizes: Vec<u64> = region_ids
-        .iter()
-        .map(|&region_id| get_region_size(db, region_id, cf))
-        .collect();
-    let region_number = region_ids.len();
-    let total_size = region_sizes.iter().sum();
-    let mut v: Vec<(u64, u64)> = region_sizes.drain(..).zip(region_ids.drain(..)).collect();
-    v.sort();
-    v.reverse();
-    println!("total region number: {}", region_number);
-    println!("total region size: {}", convert_gbmb(total_size));
-    for (size, id) in v {
-        println!("region_id: {}", id);
-        println!("region size: {}", convert_gbmb(size));
-    }
-}
-
-fn get_all_region_ids(db: &DB) -> Vec<u64> {
-    let start_key = keys::REGION_META_MIN_KEY;
-    let end_key = keys::REGION_META_MAX_KEY;
-    let mut region_ids = vec![];
-    db.scan_cf(CF_RAFT, start_key, end_key, false, &mut |key, _| {
-        let (region_id, suffix) = keys::decode_region_meta_key(key)?;
-        if suffix != keys::REGION_STATE_SUFFIX {
-            return Ok(true);
-        }
-        region_ids.push(region_id);
-        Ok(true)
-    }).unwrap();
-    region_ids
-}
-
-fn get_region_size(db: &DB, region_id: u64, cf: Option<&str>) -> u64 {
-    let region_state_key = keys::region_state_key(region_id);
-    let region_state: RegionLocalState =
-        db.get_msg_cf(CF_RAFT, &region_state_key).unwrap().unwrap();
-    let region = region_state.get_region();
-    let start_key = &keys::data_key(region.get_start_key());
-    let end_key = &keys::data_end_key(region.get_end_key());
-    let mut size: u64 = 0;
-    let cf_arr = match cf {
-        Some(s) => vec![s],
-        None => vec![CF_DEFAULT, CF_WRITE, CF_LOCK],
-    };
-    for cf in &cf_arr {
-        db.scan_cf(cf, start_key, end_key, true, &mut |_, v| {
-            size += v.len() as u64;
-            Ok(true)
-        }).unwrap();
-    }
-    size
-}
-
-fn parse_ts_key_from_key(encode_key: Vec<u8>) -> (u64, Vec<u8>) {
-    let item_key = Key::from_encoded(encode_key);
-    let ts = item_key.decode_ts().unwrap();
-    let item_key = item_key.truncate_ts().unwrap();
-    let key = item_key.encoded();
-    (ts, key.clone())
-}
-
-fn dump_range(
-    db: DB,
-    from: String,
-    to: Option<String>,
-    limit: Option<u64>,
-    cf: &str,
-    start_ts: Option<u64>,
-    commit_ts: Option<u64>,
-) {
-    let from = unescape(&from);
-    let to = to.map_or_else(|| vec![0xff], |s| unescape(&s));
-    let limit = limit.unwrap_or(u64::MAX);
-
-    if limit == 0 {
-        return;
-    }
-    let mut cnt = 0;
-    db.scan_cf(cf, &from, &to, true, &mut |k, v| {
-        let mut right_key = true;
-        match cf {
-            CF_DEFAULT => {
-                let (ts, _) = parse_ts_key_from_key(escape(k).into_bytes());
-                right_key = start_ts.is_none() || ts == start_ts.unwrap();
-            }
-            CF_WRITE => {
-                let value = Write::deserialize(v.as_ref());
-                let (cmt_ts, _) = parse_ts_key_from_key(escape(k).into_bytes());
-                right_key = (start_ts.is_none() || value.start_ts == start_ts.unwrap()) &&
-                    (commit_ts.is_none() || cmt_ts == commit_ts.unwrap());
-            }
-            CF_LOCK => {
-                let value = Lock::deserialize(v.as_ref());
-                right_key = start_ts.is_none() || value.ts == start_ts.unwrap();
-            }
-            _ => {}
-        }
-
-        if right_key {
-            println!("key: {}, value len: {}", escape(k), v.len());
-            println!("{}", escape(v));
-            cnt += 1;
-        }
-        Ok(cnt < limit)
-    }).unwrap()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use rocksdb::Writable;
-    use tikv::util::codec::bytes::encode_bytes;
-    use tikv::util::codec::number::NumberEncoder;
-    use tikv::raftstore::store::keys;
-    use tikv::storage::{ALL_CFS, CF_DEFAULT, CF_LOCK, CF_WRITE};
-    use tikv::storage::mvcc::{Lock, LockType, Write, WriteType};
-    use tempdir::TempDir;
-    use tikv::util::rocksdb::new_engine;
-    use tikv::storage::types::Key;
-    use tikv::util::escape;
-
-    const PREFIX: &'static [u8] = b"k";
-
-    #[test]
-    fn test_ctl_mvcc() {
-        let tmp_dir = TempDir::new("mvcc_tmp").expect("create mvcc_tmp dir");
-        //        let file_path = tmp_dir.path().join("tmp_db");
-        let db = new_engine(tmp_dir.path().to_str().unwrap(), ALL_CFS).unwrap();
-        let test_data = vec![(PREFIX, b"v", 5), (PREFIX, b"x", 10), (PREFIX, b"y", 15)];
-        for &(k, v, ts) in &test_data {
-            let key = keys::data_key(Key::from_raw(k).append_ts(ts).encoded().as_slice());
-            db.put(key.as_slice(), v).unwrap();
-        }
-        let kvs_gen: Vec<MvccKv<Vec<u8>>> = gen_mvcc_iter(&db, "k", false, CF_DEFAULT);
-        assert_eq!(
-            kvs_gen,
-            gen_mvcc_iter(&db, &escape(&encode_bytes(b"k")), true, CF_DEFAULT)
-        );
-        let mut test_iter = test_data.clone();
-        assert_eq!(test_iter.len(), kvs_gen.len());
-        for kv in kvs_gen {
-            let ts = kv.key.decode_ts().unwrap();
-            let key = kv.key.truncate_ts().unwrap().raw().unwrap();
-            let value = kv.value.as_slice();
-            test_iter.retain(|&s| {
-                !(&s.0[..] == key.as_slice() && &s.1[..] == value && s.2 == ts)
-            });
-        }
-        assert_eq!(test_iter.len(), 0);
-
-        // Test MVCC Lock
-        let test_data_lock = vec![
-            (b"kv", LockType::Put, b"v", 5),
-            (b"kx", LockType::Lock, b"x", 10),
-            (b"kz", LockType::Delete, b"y", 15),
-        ];
-        let keys: Vec<_> = test_data_lock
-            .iter()
-            .map(|data| {
-                let encoded = encode_bytes(&data.0[..]);
-                keys::data_key(encoded.as_slice())
-            })
-            .collect();
-        let lock_value: Vec<_> = test_data_lock
-            .iter()
-            .map(|data| {
-                Lock::new(data.1, data.2.to_vec(), data.3, 0, None).to_bytes()
-            })
-            .collect();
-        let kvs = keys.iter().zip(lock_value.iter());
-        let lock_cf = db.cf_handle(CF_LOCK).unwrap();
-        for (k, v) in kvs {
-            db.put_cf(lock_cf, k.as_slice(), v.as_slice()).unwrap();
-        }
-        fn assert_iter(kvs_gen: &[MvccKv<Lock>], test_data: (&[u8; 2], LockType, &[u8; 1], u64)) {
-            assert_eq!(kvs_gen.len(), 1);
-            let kv = &kvs_gen[0];
-            let lock = &kv.value;
-            let key = kv.key.raw().unwrap();
-            assert!(
-                &key[..] == test_data.0 && test_data.1 == lock.lock_type &&
-                    test_data.2 == lock.primary.as_slice() &&
-                    test_data.3 == lock.ts
-            );
-        }
-        assert_iter(&gen_mvcc_iter(&db, "kv", false, CF_LOCK), test_data_lock[0]);
-        assert_iter(&gen_mvcc_iter(&db, "kx", false, CF_LOCK), test_data_lock[1]);
-        assert_iter(&gen_mvcc_iter(&db, "kz", false, CF_LOCK), test_data_lock[2]);
-
-        // Test MVCC Write
-        let test_data_write = vec![
-            (PREFIX, WriteType::Delete, 5, 10),
-            (PREFIX, WriteType::Lock, 15, 20),
-            (PREFIX, WriteType::Put, 25, 30),
-            (PREFIX, WriteType::Rollback, 35, 40),
-        ];
-        let keys: Vec<_> = test_data_write
-            .iter()
-            .map(|data| {
-                let encoded = encode_bytes(&data.0[..]);
-                let mut d = keys::data_key(encoded.as_slice());
-                let _ = d.encode_u64_desc(data.3);
-                d
-            })
-            .collect();
-        let write_value: Vec<_> = test_data_write
-            .iter()
-            .map(|data| Write::new(data.1, data.2, None).to_bytes())
-            .collect();
-        let kvs = keys.iter().zip(write_value.iter());
-        let write_cf = db.cf_handle(CF_WRITE).unwrap();
-        for (k, v) in kvs {
-            db.put_cf(write_cf, k.as_slice(), v.as_slice()).unwrap();
-        }
-        let kvs_gen: Vec<MvccKv<Write>> = gen_mvcc_iter(&db, "k", false, CF_WRITE);
-        assert_eq!(
-            kvs_gen,
-            gen_mvcc_iter(&db, &escape(&encode_bytes(b"k")), true, CF_WRITE)
-        );
-        let mut test_iter = test_data_write.clone();
-        assert_eq!(test_iter.len(), kvs_gen.len());
-        for kv in kvs_gen {
-            let write = &kv.value;
-            let ts = kv.key.decode_ts().unwrap();
-            let key = kv.key.truncate_ts().unwrap().raw().unwrap();
-            test_iter.retain(|&s| {
-                !(&s.0[..] == key.as_slice() && s.1 == write.write_type &&
-                    s.2 == write.start_ts && s.3 == ts)
-            });
-        }
-        assert_eq!(test_iter.len(), 0);
-    }
 }

--- a/src/raftstore/store/debug.rs
+++ b/src/raftstore/store/debug.rs
@@ -20,7 +20,8 @@ use protobuf::RepeatedField;
 use rocksdb::{Kv, SeekKey, DB};
 use kvproto::kvrpcpb::{LockInfo, MvccInfo, Op, ValueInfo, WriteInfo};
 use kvproto::debugpb::DB as DBType;
-use kvproto::{eraftpb, raft_serverpb};
+use kvproto::eraftpb::Entry;
+use kvproto::raft_serverpb::*;
 
 use raftstore::store::{keys, Engines, Iterable, Peekable};
 use raftstore::store::engine::IterOption;
@@ -53,6 +54,27 @@ quick_error!{
     }
 }
 
+#[derive(PartialEq, Debug, Default)]
+pub struct RegionInfo {
+    pub raft_local_state: Option<RaftLocalState>,
+    pub raft_apply_state: Option<RaftApplyState>,
+    pub region_local_state: Option<RegionLocalState>,
+}
+
+impl RegionInfo {
+    fn new(
+        raft_local: Option<RaftLocalState>,
+        raft_apply: Option<RaftApplyState>,
+        region_local: Option<RegionLocalState>,
+    ) -> Self {
+        RegionInfo {
+            raft_local_state: raft_local,
+            raft_apply_state: raft_apply,
+            region_local_state: region_local,
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct Debugger {
     engines: Engines,
@@ -61,6 +83,24 @@ pub struct Debugger {
 impl Debugger {
     pub fn new(engines: Engines) -> Debugger {
         Debugger { engines }
+    }
+
+    /// Get all regions holding region meta data from raft CF in KV storage.
+    pub fn get_all_meta_regions(&self) -> Result<Vec<u64>> {
+        let db = &self.engines.kv_engine;
+        let cf = CF_RAFT;
+        let start_key = keys::REGION_META_MIN_KEY;
+        let end_key = keys::REGION_META_MAX_KEY;
+        let mut regions = Vec::with_capacity(128);
+        box_try!(db.scan_cf(cf, start_key, end_key, false, &mut |key, _| {
+            let (id, suffix) = keys::decode_region_meta_key(key)?;
+            if suffix != keys::REGION_STATE_SUFFIX {
+                return Ok(true);
+            }
+            regions.push(id);
+            Ok(true)
+        }));
+        Ok(regions)
     }
 
     fn get_db_from_type(&self, db: DBType) -> Result<&DB> {
@@ -83,7 +123,7 @@ impl Debugger {
         }
     }
 
-    pub fn raft_log(&self, region_id: u64, log_index: u64) -> Result<eraftpb::Entry> {
+    pub fn raft_log(&self, region_id: u64, log_index: u64) -> Result<Entry> {
         let key = keys::raft_log_key(region_id, log_index);
         match self.engines.raft_engine.get_msg(&key) {
             Ok(Some(entry)) => Ok(entry),
@@ -96,40 +136,33 @@ impl Debugger {
         }
     }
 
-    pub fn region_info(
-        &self,
-        region_id: u64,
-    ) -> Result<
-        (
-            Option<raft_serverpb::RaftLocalState>,
-            Option<raft_serverpb::RaftApplyState>,
-            Option<raft_serverpb::RegionLocalState>,
-        ),
-    > {
+    pub fn region_info(&self, region_id: u64) -> Result<RegionInfo> {
         let raft_state_key = keys::raft_state_key(region_id);
         let raft_state = box_try!(
             self.engines
                 .raft_engine
-                .get_msg::<raft_serverpb::RaftLocalState>(&raft_state_key)
+                .get_msg::<RaftLocalState>(&raft_state_key)
         );
 
         let apply_state_key = keys::apply_state_key(region_id);
         let apply_state = box_try!(
             self.engines
                 .kv_engine
-                .get_msg_cf::<raft_serverpb::RaftApplyState>(CF_RAFT, &apply_state_key)
+                .get_msg_cf::<RaftApplyState>(CF_RAFT, &apply_state_key)
         );
 
         let region_state_key = keys::region_state_key(region_id);
         let region_state = box_try!(
             self.engines
                 .kv_engine
-                .get_msg_cf::<raft_serverpb::RegionLocalState>(CF_RAFT, &region_state_key)
+                .get_msg_cf::<RegionLocalState>(CF_RAFT, &region_state_key)
         );
 
         match (raft_state, apply_state, region_state) {
             (None, None, None) => Err(Error::NotFound(format!("info for region {}", region_id))),
-            (raft_state, apply_state, region_state) => Ok((raft_state, apply_state, region_state)),
+            (raft_state, apply_state, region_state) => {
+                Ok(RegionInfo::new(raft_state, apply_state, region_state))
+            }
         }
     }
 
@@ -141,7 +174,7 @@ impl Debugger {
         let region_state_key = keys::region_state_key(region_id);
         match self.engines
             .kv_engine
-            .get_msg_cf::<raft_serverpb::RegionLocalState>(CF_RAFT, &region_state_key)
+            .get_msg_cf::<RegionLocalState>(CF_RAFT, &region_state_key)
         {
             Ok(Some(region_state)) => {
                 let region = region_state.get_region();
@@ -365,6 +398,7 @@ mod tests {
 
     use rocksdb::{ColumnFamilyOptions, DBOptions, Writable};
     use kvproto::metapb;
+    use kvproto::eraftpb::EntryType;
     use tempdir::TempDir;
 
     use raftstore::store::engine::Mutable;
@@ -441,17 +475,14 @@ mod tests {
         let engine = &debugger.engines.raft_engine;
         let (region_id, log_index) = (1, 1);
         let key = keys::raft_log_key(region_id, log_index);
-        let mut entry = eraftpb::Entry::new();
+        let mut entry = Entry::new();
         entry.set_term(1);
         entry.set_index(1);
-        entry.set_entry_type(eraftpb::EntryType::EntryNormal);
+        entry.set_entry_type(EntryType::EntryNormal);
         entry.set_data(vec![42]);
         engine.put_msg(key.as_slice(), &entry).unwrap();
         assert_eq!(
-            engine
-                .get_msg::<eraftpb::Entry>(key.as_slice())
-                .unwrap()
-                .unwrap(),
+            engine.get_msg::<Entry>(key.as_slice()).unwrap().unwrap(),
             entry
         );
 
@@ -471,40 +502,40 @@ mod tests {
         let region_id = 1;
 
         let raft_state_key = keys::raft_state_key(region_id);
-        let mut raft_state = raft_serverpb::RaftLocalState::new();
+        let mut raft_state = RaftLocalState::new();
         raft_state.set_last_index(42);
         raft_engine.put_msg(&raft_state_key, &raft_state).unwrap();
         assert_eq!(
             raft_engine
-                .get_msg::<raft_serverpb::RaftLocalState>(&raft_state_key)
+                .get_msg::<RaftLocalState>(&raft_state_key)
                 .unwrap()
                 .unwrap(),
             raft_state
         );
 
         let apply_state_key = keys::apply_state_key(region_id);
-        let mut apply_state = raft_serverpb::RaftApplyState::new();
+        let mut apply_state = RaftApplyState::new();
         apply_state.set_applied_index(42);
         kv_engine
             .put_msg_cf(raft_cf, &apply_state_key, &apply_state)
             .unwrap();
         assert_eq!(
             kv_engine
-                .get_msg_cf::<raft_serverpb::RaftApplyState>(CF_RAFT, &apply_state_key)
+                .get_msg_cf::<RaftApplyState>(CF_RAFT, &apply_state_key)
                 .unwrap()
                 .unwrap(),
             apply_state
         );
 
         let region_state_key = keys::region_state_key(region_id);
-        let mut region_state = raft_serverpb::RegionLocalState::new();
-        region_state.set_state(raft_serverpb::PeerState::Tombstone);
+        let mut region_state = RegionLocalState::new();
+        region_state.set_state(PeerState::Tombstone);
         kv_engine
             .put_msg_cf(raft_cf, &region_state_key, &region_state)
             .unwrap();
         assert_eq!(
             kv_engine
-                .get_msg_cf::<raft_serverpb::RegionLocalState>(CF_RAFT, &region_state_key)
+                .get_msg_cf::<RegionLocalState>(CF_RAFT, &region_state_key)
                 .unwrap()
                 .unwrap(),
             region_state
@@ -512,7 +543,7 @@ mod tests {
 
         assert_eq!(
             debugger.region_info(region_id).unwrap(),
-            (Some(raft_state), Some(apply_state), Some(region_state))
+            RegionInfo::new(Some(raft_state), Some(apply_state), Some(region_state))
         );
         match debugger.region_info(region_id + 1) {
             Err(Error::NotFound(_)) => (),
@@ -532,7 +563,7 @@ mod tests {
         region.set_id(region_id);
         region.set_start_key(b"a".to_vec());
         region.set_end_key(b"zz".to_vec());
-        let mut state = raft_serverpb::RegionLocalState::new();
+        let mut state = RegionLocalState::new();
         state.set_region(region);
         let cf_raft = engine.cf_handle(CF_RAFT).unwrap();
         engine

--- a/src/server/service/debug.rs
+++ b/src/server/service/debug.rs
@@ -131,15 +131,15 @@ impl debugpb_grpc::Debug for Service {
                 future::ok(self.debugger.clone())
                     .and_then(move |debugger| debugger.region_info(region_id)),
             )
-            .map(|(raft_local_state, raft_apply_state, region_state)| {
+            .map(|region_info| {
                 let mut resp = RegionInfoResponse::new();
-                if let Some(raft_local_state) = raft_local_state {
+                if let Some(raft_local_state) = region_info.raft_local_state {
                     resp.set_raft_local_state(raft_local_state);
                 }
-                if let Some(raft_apply_state) = raft_apply_state {
+                if let Some(raft_apply_state) = region_info.raft_apply_state {
                     resp.set_raft_apply_state(raft_apply_state);
                 }
-                if let Some(region_state) = region_state {
+                if let Some(region_state) = region_info.region_local_state {
                     resp.set_region_local_state(region_state);
                 }
                 resp


### PR DESCRIPTION
Old tikv-server run on pb2, but after that we upgrade pb2 to pb3. So use latest tikv-ctl can't always access some old tikv cluster. This PR fix this.