### PR TITLE
pd: cancel call when refreshing client

### DIFF
--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -310,7 +310,7 @@ impl PdClient for RpcClient {
                                     Error::Other(box_err!("failed to recv heartbeat: {:?}", e))
                                 }).map(|r| (r, WriteFlags::default())),
                             )
-                            .map(|(mut sender, _)| sender.get_mut().cancel())
+                            .map(|(mut sender, _)| sender.get_mut().cancel()),
                     ) as PdFuture<_>
                 }
                 None => unreachable!(),

--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -310,7 +310,7 @@ impl PdClient for RpcClient {
                                     Error::Other(box_err!("failed to recv heartbeat: {:?}", e))
                                 }).map(|r| (r, WriteFlags::default())),
                             )
-                            .map(|_| ()),
+                            .map(|(mut sender, _)| sender.get_mut().cancel())
                     ) as PdFuture<_>
                 }
                 None => unreachable!(),

--- a/src/pd/util.rs
+++ b/src/pd/util.rs
@@ -67,12 +67,14 @@ impl Stream for HeartbeatReceiver {
                 }
             }
 
+            warn!("heartbeat receiver is stale, refreshing..");
             self.receiver.take();
 
             let mut inner = self.inner.wl();
             let mut receiver = None;
             if let Either::Left(ref mut recv) = inner.hb_receiver {
                 receiver = recv.take();
+                info!("heartbeat receiver is refreshed.");
             }
             if receiver.is_some() {
                 self.receiver = receiver;


### PR DESCRIPTION
This is a quick fix for possible stale heartbeat streaming call.

Streaming call won't report error when messages are dropped silently in network. However there are sync requests in pd client can detect this error by timeout. When the error is detected, client will be refreshed. At that time, streaming call created by old client should be canceled automatically. But this doesn't happen as expected, so this pr cancels it explicitly.

We need to add a test case to tested this with iptables.

The issue needs to be investaged further too. /cc pingcap/grpc-rs#150