### PR TITLE
disable portable on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ENABLE_FEATURES ?= default
 
-# Disable portable on MacOS
+# Disable portable on MacOS to sidestep the compiler bug in clang 4.9
 ifeq ($(shell uname -s),Darwin)
 ROCKSDB_SYS_PORTABLE=0
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 ENABLE_FEATURES ?= default
 
+# Disable portable on MacOS
+ifeq ($(shell uname -s),Darwin)
+ROCKSDB_SYS_PORTABLE=0
+endif
+
 # Build portable binary by default unless disable explicitly
 ifneq ($(ROCKSDB_SYS_PORTABLE),0)
 ENABLE_FEATURES += portable


### PR DESCRIPTION
Disable portable on MacOS to sidestep the compiler bug in clang 4.9.