### PR TITLE
coprocessor/endpoint: check range for dag and analyze

### DIFF
--- a/src/coprocessor/codec/table.rs
+++ b/src/coprocessor/codec/table.rs
@@ -66,8 +66,8 @@ pub fn extract_table_prefix(key: &[u8]) -> Result<&[u8]> {
 }
 
 /// Check if the range is for table record or index.
-pub fn check_table_ranges(range: &[KeyRange]) -> Result<()> {
-    for range in range.iter() {
+pub fn check_table_ranges(ranges: &[KeyRange]) -> Result<()> {
+    for range in ranges {
         extract_table_prefix(range.get_start())?;
         extract_table_prefix(range.get_end())?;
     }

--- a/src/coprocessor/codec/table.rs
+++ b/src/coprocessor/codec/table.rs
@@ -14,6 +14,7 @@
 use std::io::Write;
 use std::{cmp, u8};
 use tipb::schema::ColumnInfo;
+use kvproto::coprocessor::KeyRange;
 
 use coprocessor::dag::expr::EvalContext;
 use util::escape;
@@ -53,7 +54,6 @@ trait TableEncoder: NumberEncoder {
 impl<T: Write> TableEncoder for T {}
 
 /// Extract table prefix from table record or index.
-// It is useful in tests.
 pub fn extract_table_prefix(key: &[u8]) -> Result<&[u8]> {
     if !key.starts_with(TABLE_PREFIX) || key.len() < TABLE_PREFIX_KEY_LEN {
         Err(invalid_type!(
@@ -63,6 +63,15 @@ pub fn extract_table_prefix(key: &[u8]) -> Result<&[u8]> {
     } else {
         Ok(&key[..TABLE_PREFIX_KEY_LEN])
     }
+}
+
+/// Check if the range is for table record or index.
+pub fn check_table_ranges(range: &[KeyRange]) -> Result<()> {
+    for range in range.iter() {
+        extract_table_prefix(range.get_start())?;
+        extract_table_prefix(range.get_end())?;
+    }
+    Ok(())
 }
 
 pub fn flatten(data: Datum) -> Result<Datum> {

--- a/src/coprocessor/dag/executor/aggregation.rs
+++ b/src/coprocessor/dag/executor/aggregation.rs
@@ -330,7 +330,7 @@ mod test {
         let key_ranges = vec![get_range(tid, i64::MIN, i64::MAX)];
         let (snapshot, start_ts) = test_store.get_snapshot();
         let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
-        let ts_ect = TableScanExecutor::new(&table_scan, key_ranges, store);
+        let ts_ect = TableScanExecutor::new(&table_scan, key_ranges, store).unwrap();
 
         // init aggregation meta
         let mut aggregation = Aggregation::default();

--- a/src/coprocessor/dag/executor/index_scan.rs
+++ b/src/coprocessor/dag/executor/index_scan.rs
@@ -47,7 +47,8 @@ impl IndexScanExecutor {
         mut key_ranges: Vec<KeyRange>,
         store: SnapshotStore,
         unique: bool,
-    ) -> IndexScanExecutor {
+    ) -> Result<IndexScanExecutor> {
+        box_try!(table::check_table_ranges(&key_ranges));
         let mut pk_col = None;
         let desc = meta.get_desc();
         if desc {
@@ -60,7 +61,7 @@ impl IndexScanExecutor {
         let col_ids = cols.iter().map(|c| c.get_column_id()).collect();
 
         COPR_EXECUTOR_COUNT.with_label_values(&["idxscan"]).inc();
-        IndexScanExecutor {
+        Ok(IndexScanExecutor {
             store: store,
             statistics: Statistics::default(),
             desc: desc,
@@ -71,17 +72,18 @@ impl IndexScanExecutor {
             unique: unique,
             count: 0,
             scan_counter: ScanCounter::default(),
-        }
+        })
     }
 
     pub fn new_with_cols_len(
         cols: i64,
         key_ranges: Vec<KeyRange>,
         store: SnapshotStore,
-    ) -> IndexScanExecutor {
+    ) -> Result<IndexScanExecutor> {
+        box_try!(table::check_table_ranges(&key_ranges));
         let col_ids: Vec<i64> = (0..cols).collect();
         COPR_EXECUTOR_COUNT.with_label_values(&["idxscan"]).inc();
-        IndexScanExecutor {
+        Ok(IndexScanExecutor {
             store: store,
             statistics: Statistics::default(),
             desc: false,
@@ -92,7 +94,7 @@ impl IndexScanExecutor {
             unique: false,
             count: 0,
             scan_counter: ScanCounter::default(),
-        }
+        })
     }
 
     fn get_row_from_range_scanner(&mut self) -> Result<Option<Row>> {
@@ -353,7 +355,8 @@ mod test {
         let (snapshot, start_ts) = wrapper.store.get_snapshot();
         let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
 
-        let mut scanner = IndexScanExecutor::new(wrapper.scan, wrapper.ranges, store, false);
+        let mut scanner =
+            IndexScanExecutor::new(wrapper.scan, wrapper.ranges, store, false).unwrap();
 
         for handle in 0..KEY_NUMBER / 2 {
             let row = scanner.next().unwrap().unwrap();
@@ -393,7 +396,8 @@ mod test {
 
         let (snapshot, start_ts) = wrapper.store.get_snapshot();
         let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
-        let mut scanner = IndexScanExecutor::new(wrapper.scan, wrapper.ranges, store, unique);
+        let mut scanner =
+            IndexScanExecutor::new(wrapper.scan, wrapper.ranges, store, unique).unwrap();
         for handle in 0..KEY_NUMBER {
             let row = scanner.next().unwrap().unwrap();
             assert_eq!(row.handle, handle as i64);
@@ -432,7 +436,8 @@ mod test {
         let (snapshot, start_ts) = wrapper.store.get_snapshot();
         let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
 
-        let mut scanner = IndexScanExecutor::new(wrapper.scan, wrapper.ranges, store, unique);
+        let mut scanner =
+            IndexScanExecutor::new(wrapper.scan, wrapper.ranges, store, unique).unwrap();
 
         for tid in 0..KEY_NUMBER {
             let handle = KEY_NUMBER - tid - 1;
@@ -455,7 +460,8 @@ mod test {
         let (snapshot, start_ts) = wrapper.store.get_snapshot();
         let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
 
-        let mut scanner = IndexScanExecutor::new(wrapper.scan, wrapper.ranges, store, false);
+        let mut scanner =
+            IndexScanExecutor::new(wrapper.scan, wrapper.ranges, store, false).unwrap();
 
         for handle in 0..KEY_NUMBER {
             let row = scanner.next().unwrap().unwrap();

--- a/src/coprocessor/dag/executor/limit.rs
+++ b/src/coprocessor/dag/executor/limit.rs
@@ -110,7 +110,7 @@ mod test {
         // init TableScan
         let (snapshot, start_ts) = test_store.get_snapshot();
         let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
-        let ts_ect = TableScanExecutor::new(&table_scan, key_ranges, store);
+        let ts_ect = TableScanExecutor::new(&table_scan, key_ranges, store).unwrap();
 
         // init Limit meta
         let mut limit_meta = Limit::default();

--- a/src/coprocessor/dag/executor/mod.rs
+++ b/src/coprocessor/dag/executor/mod.rs
@@ -203,7 +203,7 @@ fn build_first_executor(
     match first.get_tp() {
         ExecType::TypeTableScan => {
             let cols = Arc::new(first.get_tbl_scan().get_columns().to_vec());
-            let ex = Box::new(TableScanExecutor::new(first.get_tbl_scan(), ranges, store));
+            let ex = Box::new(TableScanExecutor::new(first.get_tbl_scan(), ranges, store)?);
             Ok((ex, cols))
         }
         ExecType::TypeIndexScan => {
@@ -214,7 +214,7 @@ fn build_first_executor(
                 ranges,
                 store,
                 unique,
-            ));
+            )?);
             Ok((ex, cols))
         }
         _ => Err(box_err!(

--- a/src/coprocessor/dag/executor/selection.rs
+++ b/src/coprocessor/dag/executor/selection.rs
@@ -207,7 +207,7 @@ mod tests {
         let (snapshot, start_ts) = test_store.get_snapshot();
         let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
 
-        let inner_table_scan = TableScanExecutor::new(&table_scan, key_ranges, store);
+        let inner_table_scan = TableScanExecutor::new(&table_scan, key_ranges, store).unwrap();
 
         // selection executor
         let mut selection = Selection::new();
@@ -261,7 +261,7 @@ mod tests {
 
         let (snapshot, start_ts) = test_store.get_snapshot();
         let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
-        let inner_table_scan = TableScanExecutor::new(&table_scan, key_ranges, store);
+        let inner_table_scan = TableScanExecutor::new(&table_scan, key_ranges, store).unwrap();
 
         // selection executor
         let mut selection = Selection::new();

--- a/src/coprocessor/dag/executor/topn.rs
+++ b/src/coprocessor/dag/executor/topn.rs
@@ -424,7 +424,7 @@ pub mod test {
         // init TableScan
         let (snapshot, start_ts) = test_store.get_snapshot();
         let snap = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
-        let ts_ect = TableScanExecutor::new(&table_scan, key_ranges, snap);
+        let ts_ect = TableScanExecutor::new(&table_scan, key_ranges, snap).unwrap();
 
         // init TopN meta
         let mut ob_vec = Vec::with_capacity(2);

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -37,7 +37,6 @@ use pd::PdTask;
 
 use super::codec::mysql;
 use super::codec::datum::Datum;
-use super::codec::table::check_table_ranges;
 use super::dag::DAGContext;
 use super::statistics::analyze::AnalyzeContext;
 use super::metrics::*;
@@ -328,9 +327,7 @@ impl RequestTask {
                 let mut is = CodedInputStream::from_bytes(req.get_data());
                 is.set_recursion_limit(recursion_limit);
                 let mut dag = DAGRequest::new();
-                if let Err(e) = check_table_ranges(req.get_ranges()) {
-                    Err(box_err!(e))
-                } else if let Err(e) = dag.merge_from(&mut is) {
+                if let Err(e) = dag.merge_from(&mut is) {
                     Err(box_err!(e))
                 } else {
                     start_ts = Some(dag.get_start_ts());
@@ -346,9 +343,7 @@ impl RequestTask {
                 let mut is = CodedInputStream::from_bytes(req.get_data());
                 is.set_recursion_limit(recursion_limit);
                 let mut analyze = AnalyzeReq::new();
-                if let Err(e) = check_table_ranges(req.get_ranges()) {
-                    Err(box_err!(e))
-                } else if let Err(e) = analyze.merge_from(&mut is) {
+                if let Err(e) = analyze.merge_from(&mut is) {
                     Err(box_err!(e))
                 } else {
                     start_ts = Some(analyze.get_start_ts());

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -37,6 +37,7 @@ use pd::PdTask;
 
 use super::codec::mysql;
 use super::codec::datum::Datum;
+use super::codec::table::check_table_ranges;
 use super::dag::DAGContext;
 use super::statistics::analyze::AnalyzeContext;
 use super::metrics::*;
@@ -327,7 +328,9 @@ impl RequestTask {
                 let mut is = CodedInputStream::from_bytes(req.get_data());
                 is.set_recursion_limit(recursion_limit);
                 let mut dag = DAGRequest::new();
-                if let Err(e) = dag.merge_from(&mut is) {
+                if let Err(e) = check_table_ranges(req.get_ranges()) {
+                    Err(box_err!(e))
+                } else if let Err(e) = dag.merge_from(&mut is) {
                     Err(box_err!(e))
                 } else {
                     start_ts = Some(dag.get_start_ts());
@@ -343,7 +346,9 @@ impl RequestTask {
                 let mut is = CodedInputStream::from_bytes(req.get_data());
                 is.set_recursion_limit(recursion_limit);
                 let mut analyze = AnalyzeReq::new();
-                if let Err(e) = analyze.merge_from(&mut is) {
+                if let Err(e) = check_table_ranges(req.get_ranges()) {
+                    Err(box_err!(e))
+                } else if let Err(e) = analyze.merge_from(&mut is) {
                     Err(box_err!(e))
                 } else {
                     start_ts = Some(analyze.get_start_ts());
@@ -667,6 +672,7 @@ impl TiDbEndPoint {
         if let Err(e) = t.check_outdated() {
             return on_error(e, t);
         }
+
         let resp = match t.cop_req.take().unwrap() {
             Ok(CopRequest::DAG(dag)) => self.handle_dag(dag, &mut t, batch_row_limit),
             Ok(CopRequest::Analyze(analyze)) => self.handle_analyze(analyze, &mut t),

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -64,7 +64,7 @@ impl AnalyzeContext {
                     i64::from(req.get_num_columns()),
                     mem::replace(&mut self.ranges, Vec::new()),
                     self.snap.take().unwrap(),
-                );
+                )?;
                 let res = AnalyzeContext::handle_index(req, &mut scanner);
                 scanner.collect_statistics_into(stats);
                 res
@@ -173,7 +173,7 @@ impl SampleBuilder {
 
         let mut meta = TableScan::new();
         meta.set_columns(cols_info);
-        let table_scanner = TableScanExecutor::new(&meta, ranges, snap);
+        let table_scanner = TableScanExecutor::new(&meta, ranges, snap)?;
         Ok(SampleBuilder {
             data: table_scanner,
             cols: meta.take_columns().to_vec(),

--- a/tests/coprocessor/test_analyze.rs
+++ b/tests/coprocessor/test_analyze.rs
@@ -217,7 +217,7 @@ fn test_invalid_range() {
     ];
 
     let product = ProductTable::new();
-    let (_, end_point) = init_data_with_commit(&product, &data, true);
+    let (_, mut end_point) = init_data_with_commit(&product, &data, true);
     let mut req = new_analyze_index_req(&product.table, 3, product.name.index, 4, 32);
     let mut key_range = KeyRange::new();
     key_range.set_start(b"xxx".to_vec());
@@ -225,4 +225,5 @@ fn test_invalid_range() {
     req.set_ranges(RepeatedField::from_vec(vec![key_range]));
     let resp = handle_request(&end_point, req);
     assert!(!resp.get_other_error().is_empty());
+    end_point.stop().unwrap().join().unwrap();
 }

--- a/tests/coprocessor/test_analyze.rs
+++ b/tests/coprocessor/test_analyze.rs
@@ -206,3 +206,23 @@ fn test_analyze_index() {
     assert_eq!(sum, 4);
     end_point.stop().unwrap().join().unwrap();
 }
+
+#[test]
+fn test_invalid_range() {
+    let data = vec![
+        (1, Some("name:0"), 2),
+        (2, Some("name:4"), 3),
+        (4, Some("name:3"), 1),
+        (5, Some("name:1"), 4),
+    ];
+
+    let product = ProductTable::new();
+    let (_, end_point) = init_data_with_commit(&product, &data, true);
+    let mut req = new_analyze_index_req(&product.table, 3, product.name.index, 4, 32);
+    let mut key_range = KeyRange::new();
+    key_range.set_start(b"xxx".to_vec());
+    key_range.set_end(b"zzz".to_vec());
+    req.set_ranges(RepeatedField::from_vec(vec![key_range]));
+    let resp = handle_request(&end_point, req);
+    assert!(!resp.get_other_error().is_empty());
+}

--- a/tests/coprocessor/test_select.rs
+++ b/tests/coprocessor/test_select.rs
@@ -2201,7 +2201,7 @@ fn test_invalid_range() {
     ];
 
     let product = ProductTable::new();
-    let (_, end_point) = init_with_data(&product, &data);
+    let (_, mut end_point) = init_with_data(&product, &data);
 
     let mut select = DAGSelect::from(&product.table);
     select.key_range.set_start(b"xxx".to_vec());
@@ -2209,4 +2209,6 @@ fn test_invalid_range() {
     let req = select.build();
     let resp = handle_request(&end_point, req);
     assert!(!resp.get_other_error().is_empty());
+
+    end_point.stop().unwrap().join().unwrap();
 }

--- a/tests/coprocessor/test_select.rs
+++ b/tests/coprocessor/test_select.rs
@@ -2190,3 +2190,23 @@ fn test_exec_details() {
 
     end_point.stop().unwrap().join().unwrap();
 }
+
+#[test]
+fn test_invalid_range() {
+    let data = vec![
+        (1, Some("name:0"), 2),
+        (2, Some("name:4"), 3),
+        (4, Some("name:3"), 1),
+        (5, Some("name:1"), 4),
+    ];
+
+    let product = ProductTable::new();
+    let (_, end_point) = init_with_data(&product, &data);
+
+    let mut select = DAGSelect::from(&product.table);
+    select.key_range.set_start(b"xxx".to_vec());
+    select.key_range.set_end(b"zzz".to_vec());
+    let req = select.build();
+    let resp = handle_request(&end_point, req);
+    assert!(!resp.get_other_error().is_empty());
+}


### PR DESCRIPTION
For coprocessor request with type is dag or analyze, we check req's ranges to make sure the scanned keys should always be table record or index. @BusyJay @hicqu PTAL