### PR TITLE
Implement IngestSST API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,7 +422,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git#7839cb7338370fbe4b496b888872533943d744d1"
+source = "git+https://github.com/pingcap/kvproto.git#5d41f201048b3fecbf953f267d64a739398e0b13"
 dependencies = [
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,8 @@ signal = "0.4"
 git = "https://github.com/pingcap/rust-rocksdb.git"
 
 [dependencies.kvproto]
-git = "https://github.com/pingcap/kvproto.git"
+git = "https://github.com/huachaohuang/kvproto.git"
+branch = "ingest-sst"
 
 [dependencies.tipb]
 git = "https://github.com/pingcap/tipb.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,8 +79,7 @@ signal = "0.4"
 git = "https://github.com/pingcap/rust-rocksdb.git"
 
 [dependencies.kvproto]
-git = "https://github.com/huachaohuang/kvproto.git"
-branch = "ingest-sst"
+git = "https://github.com/pingcap/kvproto.git"
 
 [dependencies.tipb]
 git = "https://github.com/pingcap/tipb.git"

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -223,7 +223,11 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
         );
 
     let importer = Arc::new(SSTImporter::new(import_path).unwrap());
-    let import_service = ImportSSTService::new(cfg.import.clone(), storage.clone(), importer);
+    let import_service = ImportSSTService::new(
+        cfg.import.clone(),
+        raft_router.clone(),
+        Arc::clone(&importer),
+    );
 
     let server_cfg = Arc::new(cfg.server.clone());
     // Create server
@@ -255,6 +259,7 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
         significant_msg_receiver,
         pd_worker,
         coprocessor_host,
+        importer,
     ).unwrap_or_else(|e| fatal!("failed to start node: {:?}", e));
     initial_metric(&cfg.metric, Some(node.id()));
 

--- a/src/import/errors.rs
+++ b/src/import/errors.rs
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 use std::io::Error as IoError;
+use std::num::ParseIntError;
 use std::path::PathBuf;
 use std::result;
 
@@ -19,6 +20,7 @@ use futures::sync::oneshot::Canceled;
 use grpc::Error as GrpcError;
 use uuid::ParseError;
 
+use raftstore::errors::Error as RaftStoreError;
 use util::codec::Error as CodecError;
 
 quick_error! {
@@ -52,6 +54,16 @@ quick_error! {
             from()
             display("RocksDB {}", msg)
         }
+        RaftStore(err: RaftStoreError) {
+            from()
+            cause(err)
+            description(err.description())
+        }
+        ParseIntError(err: ParseIntError) {
+            from()
+            cause(err)
+            description(err.description())
+        }
         FileExists(path: PathBuf) {
             display("File {:?} exists", path)
         }
@@ -60,6 +72,9 @@ quick_error! {
         }
         FileCorrupted(path: PathBuf, reason: String) {
             display("File {:?} corrupted: {}", path, reason)
+        }
+        InvalidSSTPath(path: PathBuf) {
+            display("Invalid SST path {:?}", path)
         }
         TokenExists(token: usize) {
             display("Token {} exists", token)

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -1091,7 +1091,9 @@ impl Peer {
         for r in req.get_requests() {
             match r.get_cmd_type() {
                 CmdType::Get | CmdType::Snap => is_read = true,
-                CmdType::Delete | CmdType::Put | CmdType::DeleteRange => is_write = true,
+                CmdType::Delete | CmdType::Put | CmdType::DeleteRange | CmdType::IngestSST => {
+                    is_write = true
+                }
                 CmdType::Prewrite | CmdType::Invalid => {
                     return Err(box_err!(
                         "invalid cmd type {:?}, message maybe currupted",
@@ -1638,6 +1640,7 @@ impl Peer {
                 | CmdType::Put
                 | CmdType::Delete
                 | CmdType::DeleteRange
+                | CmdType::IngestSST
                 | CmdType::Invalid => unreachable!(),
             };
             resp.set_cmd_type(cmd_type);

--- a/src/raftstore/store/worker/cleanup_sst.rs
+++ b/src/raftstore/store/worker/cleanup_sst.rs
@@ -1,0 +1,60 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+use std::sync::Arc;
+
+use uuid::Uuid;
+use kvproto::importpb::SSTMeta;
+
+use import::SSTImporter;
+use util::worker::Runnable;
+
+pub enum Task {
+    DeleteSST { sst: SSTMeta },
+}
+
+impl fmt::Display for Task {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Task::DeleteSST { ref sst } => match Uuid::from_bytes(sst.get_uuid()) {
+                Ok(uuid) => write!(f, "Delete SST {}", uuid),
+                Err(e) => write!(f, "Delete SST {:?}", e),
+            },
+        }
+    }
+}
+
+pub struct Runner {
+    importer: Arc<SSTImporter>,
+}
+
+impl Runner {
+    pub fn new(importer: Arc<SSTImporter>) -> Runner {
+        Runner { importer: importer }
+    }
+
+    fn handle_delete_sst(&self, sst: SSTMeta) {
+        let _ = self.importer.delete(&sst);
+    }
+}
+
+impl Runnable<Task> for Runner {
+    fn run(&mut self, task: Task) {
+        match task {
+            Task::DeleteSST { sst } => {
+                self.handle_delete_sst(sst);
+            }
+        }
+    }
+}

--- a/src/raftstore/store/worker/mod.rs
+++ b/src/raftstore/store/worker/mod.rs
@@ -50,6 +50,7 @@ mod compact;
 mod raftlog_gc;
 mod metrics;
 mod consistency_check;
+mod cleanup_sst;
 pub mod apply;
 
 pub use self::region::{Runner as RegionRunner, Task as RegionTask};
@@ -57,5 +58,6 @@ pub use self::split_check::{Runner as SplitCheckRunner, Task as SplitCheckTask};
 pub use self::compact::{Runner as CompactRunner, Task as CompactTask};
 pub use self::raftlog_gc::{Runner as RaftlogGcRunner, Task as RaftlogGcTask};
 pub use self::consistency_check::{Runner as ConsistencyCheckRunner, Task as ConsistencyCheckTask};
+pub use self::cleanup_sst::{Runner as CleanupSSTRunner, Task as CleanupSSTTask};
 pub use self::apply::{Apply, ApplyMetrics, ApplyRes, Proposal, RegionProposal, Registration,
                       Runner as ApplyRunner, Task as ApplyTask, TaskRes as ApplyTaskRes};

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -29,6 +29,7 @@ use raftstore::coprocessor::dispatcher::CoprocessorHost;
 use raftstore::store::{self, keys, Config as StoreConfig, Engines, Msg, Peekable, SignificantMsg,
                        SnapManager, Store, StoreChannel, Transport};
 use super::Result;
+use import::SSTImporter;
 use server::Config as ServerConfig;
 use storage::{self, Config as StorageConfig, RaftKv, Storage};
 use super::transport::RaftStoreRouter;
@@ -133,6 +134,7 @@ where
         significant_msg_receiver: Receiver<SignificantMsg>,
         pd_worker: FutureWorker<PdTask>,
         coprocessor_host: CoprocessorHost,
+        importer: Arc<SSTImporter>,
     ) -> Result<()>
     where
         T: Transport + 'static,
@@ -172,6 +174,7 @@ where
             significant_msg_receiver,
             pd_worker,
             coprocessor_host,
+            importer,
         )?;
         Ok(())
     }
@@ -323,6 +326,7 @@ where
         significant_msg_receiver: Receiver<SignificantMsg>,
         pd_worker: FutureWorker<PdTask>,
         coprocessor_host: CoprocessorHost,
+        importer: Arc<SSTImporter>,
     ) -> Result<()>
     where
         T: Transport + 'static,
@@ -355,6 +359,7 @@ where
                 snap_mgr,
                 pd_worker,
                 coprocessor_host,
+                importer,
             ) {
                 Err(e) => panic!("construct store {} err {:?}", store_id, e),
                 Ok(s) => s,

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -68,7 +68,7 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver + 'static> Server<T, S> {
         snap_mgr: SnapManager,
         pd_scheduler: FutureScheduler<PdTask>,
         debug_engines: Option<Engines>,
-        import_service: Option<ImportSSTService>,
+        import_service: Option<ImportSSTService<T>>,
     ) -> Result<Server<T, S>> {
         let env = Arc::new(
             EnvBuilder::new()

--- a/tests/import/sst_service.rs
+++ b/tests/import/sst_service.rs
@@ -15,8 +15,10 @@ use std::sync::Arc;
 
 use uuid::Uuid;
 use futures::{stream, Future, Stream};
+use tempdir::TempDir;
 
 use kvproto::kvrpcpb::*;
+use kvproto::tikvpb_grpc::*;
 use kvproto::importpb::*;
 use kvproto::importpb_grpc::*;
 use grpc::{ChannelBuilder, Environment, Result, WriteFlags};
@@ -43,7 +45,8 @@ fn new_cluster() -> (Cluster<ServerCluster>, Context) {
     (cluster, ctx)
 }
 
-fn new_cluster_and_import_client() -> (Cluster<ServerCluster>, ImportSstClient) {
+fn new_cluster_and_tikv_import_client(
+) -> (Cluster<ServerCluster>, Context, TikvClient, ImportSstClient) {
     let (cluster, ctx) = new_cluster();
 
     let ch = {
@@ -51,14 +54,15 @@ fn new_cluster_and_import_client() -> (Cluster<ServerCluster>, ImportSstClient) 
         let node = ctx.get_peer().get_store_id();
         ChannelBuilder::new(env).connect(cluster.sim.rl().get_addr(node))
     };
-    let import = ImportSstClient::new(ch);
+    let tikv = TikvClient::new(ch.clone());
+    let import = ImportSstClient::new(ch.clone());
 
-    (cluster, import)
+    (cluster, ctx, tikv, import)
 }
 
 #[test]
 fn test_upload_sst() {
-    let (_cluster, import) = new_cluster_and_import_client();
+    let (_cluster, _, _, import) = new_cluster_and_tikv_import_client();
 
     let data = vec![1; 1024];
     let crc32 = calc_data_crc32(&data);
@@ -83,6 +87,55 @@ fn test_upload_sst() {
 
     // Can't upload the same uuid file again.
     assert!(send_upload_sst(&import, &upload).is_err());
+}
+
+#[test]
+fn test_ingest_sst() {
+    let (_cluster, ctx, tikv, import) = new_cluster_and_tikv_import_client();
+
+    let temp_dir = TempDir::new("test_ingest_sst").unwrap();
+
+    let sst_path = temp_dir.path().join("test.sst");
+    let sst_range = (0, 100);
+    let (mut meta, data) = gen_sst_file(sst_path, sst_range);
+
+    // No region id and epoch.
+    let mut upload = UploadRequest::new();
+    upload.set_meta(meta.clone());
+    upload.set_data(data.clone());
+    send_upload_sst(&import, &upload).unwrap();
+
+    let mut ingest = IngestRequest::new();
+    ingest.set_context(ctx.clone());
+    ingest.set_sst(meta.clone());
+    let resp = import.ingest(&ingest).unwrap();
+    assert!(resp.has_error());
+
+    // Set region id and epoch.
+    meta.set_region_id(ctx.get_region_id());
+    meta.set_region_epoch(ctx.get_region_epoch().clone());
+    upload.set_meta(meta.clone());
+    send_upload_sst(&import, &upload).unwrap();
+    // Cann't upload the same file again.
+    assert!(send_upload_sst(&import, &upload).is_err());
+
+    ingest.set_sst(meta.clone());
+    let resp = import.ingest(&ingest).unwrap();
+    assert!(!resp.has_error());
+
+    // Check ingested kvs
+    for i in sst_range.0..sst_range.1 {
+        let mut m = RawGetRequest::new();
+        m.set_context(ctx.clone());
+        m.set_key(vec![i]);
+        let resp = tikv.raw_get(&m).unwrap();
+        assert!(resp.get_error().is_empty());
+        assert!(!resp.has_region_error());
+        assert_eq!(resp.get_value(), &[i]);
+    }
+
+    // Upload the same file again to check if the ingested file has been deleted.
+    send_upload_sst(&import, &upload).unwrap();
 }
 
 fn new_sst_meta(crc32: u32, length: u64) -> SSTMeta {

--- a/tests/raftstore/server.rs
+++ b/tests/raftstore/server.rs
@@ -13,6 +13,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{mpsc, Arc, RwLock};
+use std::path::Path;
 
 use grpc::EnvBuilder;
 use tempdir::TempDir;
@@ -130,10 +131,14 @@ impl Simulator for ServerCluster {
 
         // Create import service.
         let importer = {
-            let dir = TempDir::new("test-import-sst").unwrap().into_path();
+            let dir = Path::new(engines.kv_engine.path()).join("import-sst");
             Arc::new(SSTImporter::new(dir).unwrap())
         };
-        let import_service = ImportSSTService::new(cfg.import.clone(), store.clone(), importer);
+        let import_service = ImportSSTService::new(
+            cfg.import.clone(),
+            sim_router.clone(),
+            Arc::clone(&importer),
+        );
 
         // Create pd client, snapshot manager, server.
         let (worker, resolver) = resolve::new_resolver(Arc::clone(&self.pd_client)).unwrap();
@@ -178,6 +183,7 @@ impl Simulator for ServerCluster {
             snap_status_receiver,
             pd_worker,
             coprocessor_host,
+            importer,
         ).unwrap();
         assert!(node_id == 0 || node_id == node.id());
         let node_id = node.id();

--- a/tests/raftstore/util.rs
+++ b/tests/raftstore/util.rs
@@ -327,7 +327,9 @@ pub fn make_cb(cmd: &RaftCmdRequest) -> (Callback, mpsc::Receiver<RaftCmdRespons
     for req in cmd.get_requests() {
         match req.get_cmd_type() {
             CmdType::Get | CmdType::Snap => is_read = true,
-            CmdType::Put | CmdType::Delete | CmdType::DeleteRange => is_write = true,
+            CmdType::Put | CmdType::Delete | CmdType::DeleteRange | CmdType::IngestSST => {
+                is_write = true
+            }
             CmdType::Invalid | CmdType::Prewrite => panic!("Invalid RaftCmdRequest: {:?}", cmd),
         }
     }

--- a/tests/raftstore_cases/test_bootstrap.rs
+++ b/tests/raftstore_cases/test_bootstrap.rs
@@ -13,6 +13,7 @@
 
 use std::sync::{mpsc, Arc};
 use std::path::Path;
+use tikv::import::SSTImporter;
 use tikv::raftstore::store::{bootstrap_store, create_event_loop, keys, Engines, Peekable,
                              SnapManager};
 use tikv::server::Node;
@@ -95,6 +96,11 @@ fn test_node_bootstrap_with_prepared_data() {
     // Create coprocessor.
     let coprocessor_host = CoprocessorHost::new(cfg.coprocessor, node.get_sendch());
 
+    let importer = {
+        let dir = tmp_path.path().join("import-sst");
+        Arc::new(SSTImporter::new(dir).unwrap())
+    };
+
     // try to restart this node, will clear the prepare data
     node.start(
         event_loop,
@@ -104,6 +110,7 @@ fn test_node_bootstrap_with_prepared_data() {
         snapshot_status_receiver,
         pd_worker,
         coprocessor_host,
+        importer,
     ).unwrap();
     assert!(
         Arc::clone(&engine)


### PR DESCRIPTION
An uploaded SST file can be ingested to a region by sending an IngestSST request. The client must guarantee that the SST file has been uploaded to each peer of the region before issuing the IngestSST request. Upon ingestion, the metadata of the SST file will be replicated to the raft group first. Then before the IngestSST command can be applied, the range and the epoch of the metadata must be checked, and the length and checksum of the coresponding SST file must match the metadata too. Finally, the SST file will be deleted after it has been applied.

The coresponding kvproto PR: https://github.com/pingcap/kvproto/pull/224