### PR TITLE
raftstore: remove sync snapshot file

### DIFF
--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -891,7 +891,6 @@ impl Snapshot for Snap {
             {
                 let mut file = cf_file.file.take().unwrap();
                 file.flush()?;
-                file.sync_all()?;
             }
             if cf_file.written_size != cf_file.size {
                 return Err(io::Error::new(


### PR DESCRIPTION
Snapshot receiving is spawned in RpcContext, it should not be too heavy, so we sync meta file only.