### PR TITLE
fix cleanup for raw kv

### DIFF
--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -891,6 +891,7 @@ impl Snapshot for Snap {
             {
                 let mut file = cf_file.file.take().unwrap();
                 file.flush()?;
+                file.sync_all()?;
             }
             if cf_file.written_size != cf_file.size {
                 return Err(io::Error::new(
@@ -928,7 +929,11 @@ impl Snapshot for Snap {
         // write meta file
         let mut v = vec![];
         self.meta_file.meta.write_to_vec(&mut v)?;
-        self.meta_file.file.take().unwrap().write_all(&v[..])?;
+        {
+            let mut meta_file = self.meta_file.file.take().unwrap();
+            meta_file.write_all(&v[..])?;
+            meta_file.sync_all()?;
+        }
         fs::rename(&self.meta_file.tmp_path, &self.meta_file.path)?;
         Ok(())
     }

--- a/src/util/rocksdb/mod.rs
+++ b/src/util/rocksdb/mod.rs
@@ -335,7 +335,7 @@ pub fn roughly_cleanup_range(db: &DB, start_key: &[u8], end_key: &[u8]) -> Resul
 
     // Todo: use end_key directly after delete_files_in_range support [start, end) semantics.
     let end = prev_key(end_key)?;
-    if  start_key >= end.as_slice() {
+    if start_key >= end.as_slice() {
         return Ok(());
     }
     for cf in db.cf_names() {

--- a/src/util/rocksdb/mod.rs
+++ b/src/util/rocksdb/mod.rs
@@ -334,8 +334,8 @@ pub fn roughly_cleanup_range(db: &DB, start_key: &[u8], end_key: &[u8]) -> Resul
     }
 
     // Todo: use end_key directly after delete_files_in_range support [start, end) semantics.
-    let end = prev_key(end_key).unwrap();
-    if end.as_slice() >= start_key {
+    let end = prev_key(end_key)?;
+    if  start_key >= end.as_slice() {
         return Ok(());
     }
     for cf in db.cf_names() {


### PR DESCRIPTION
Keys in raw KV scenario don't have ts tail, in that situation we can't use region's `end_key` to involve `delete_files_in_range`.