### PR TITLE
tests: put till approximate size

### DIFF
--- a/src/raftstore/coprocessor/split_check/size.rs
+++ b/src/raftstore/coprocessor/split_check/size.rs
@@ -86,7 +86,15 @@ impl<C: Sender<Msg> + Send> SplitCheckObserver for SizeCheckObserver<C> {
             );
             // Need to check size.
             status.size = Some(size_status);
-        } // else { Does not need to check size. }
+        } else {
+            // Does not need to check size.
+            debug!(
+                "[region {}] approximate size {} < {}, does not need to do split check",
+                region.get_id(),
+                region_size,
+                self.region_max_size
+            );
+        }
     }
 
     fn on_split_check(

--- a/src/raftstore/store/worker/split_check.rs
+++ b/src/raftstore/store/worker/split_check.rs
@@ -162,6 +162,7 @@ impl<C: Sender<Msg>> Runner<C> {
         let mut split_ctx = self.coprocessor
             .new_split_check_status(region, &self.engine);
         if split_ctx.skip() {
+            info!("[region {}] skip split task", region.get_id());
             return;
         }
 

--- a/src/raftstore/store/worker/split_check.rs
+++ b/src/raftstore/store/worker/split_check.rs
@@ -162,7 +162,7 @@ impl<C: Sender<Msg>> Runner<C> {
         let mut split_ctx = self.coprocessor
             .new_split_check_status(region, &self.engine);
         if split_ctx.skip() {
-            info!("[region {}] skip split task", region.get_id());
+            debug!("[region {}] skip split task", region.get_id());
             return;
         }
 

--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -23,6 +23,7 @@ use futures::Future;
 
 use tikv::raftstore::{Error, Result};
 use tikv::raftstore::store::*;
+use tikv::raftstore::store::util::get_approximate_size_cf;
 use tikv::config::TiKvConfig;
 use tikv::storage::CF_DEFAULT;
 use super::util::*;
@@ -678,6 +679,17 @@ impl<T: Simulator> Cluster<T> {
             engines.kv_engine.flush(sync).unwrap();
             engines.raft_engine.flush(sync).unwrap();
         }
+    }
+
+    pub fn get_approximate_size(
+        &mut self,
+        node_id: u64,
+        cf: &str,
+        start: &[u8],
+        end: &[u8],
+    ) -> u64 {
+        let db = &self.engines[&node_id].kv_engine;
+        get_approximate_size_cf(db, cf, &keys::data_key(start), &keys::data_key(end)).unwrap()
     }
 
     pub fn get_region_epoch(&self, region_id: u64) -> RegionEpoch {

--- a/tests/raftstore_cases/test_split_region.rs
+++ b/tests/raftstore_cases/test_split_region.rs
@@ -187,10 +187,6 @@ fn put_till_size<T: Simulator>(
     put_cf_till_approximate_size(cluster, CF_DEFAULT, limit, range)
 }
 
-fn make_key(i: u64) -> Vec<u8> {
-    format!("{:09}", i).into_bytes()
-}
-
 fn put_cf_till_approximate_size<T: Simulator>(
     cluster: &mut Cluster<T>,
     cf: &'static str,
@@ -204,7 +200,7 @@ fn put_cf_till_approximate_size<T: Simulator>(
     let mut start = None;
     let nodes: Vec<u64> = cluster.engines.keys().cloned().collect();
     loop {
-        let key = make_key(range.next().unwrap());
+        let key = format!("{:09}", range.next().unwrap()).into_bytes();
         if start.is_none() {
             start = Some(key.clone());
         }
@@ -215,8 +211,7 @@ fn put_cf_till_approximate_size<T: Simulator>(
         len += key.len() as u64 + 1;
         len += value.len() as u64;
         // Approximate size of memtable is inaccurate for small data,
-        // we flush it to SST so we can use the size properties instead.
-        // Flush memtable to SST periodically, to make approximate size more accurate.
+        // flush memtable to SST periodically, to make approximate size more accurate.
         let gap = if len >= limit { 200 } else { 1000 };
         if len - last_len >= gap {
             cluster.must_flush(true);

--- a/tests/raftstore_cases/test_split_region.rs
+++ b/tests/raftstore_cases/test_split_region.rs
@@ -184,10 +184,14 @@ fn put_till_size<T: Simulator>(
     limit: u64,
     range: &mut Iterator<Item = u64>,
 ) -> Vec<u8> {
-    put_cf_till_size(cluster, CF_DEFAULT, limit, range)
+    put_cf_till_approximate_size(cluster, CF_DEFAULT, limit, range)
 }
 
-fn put_cf_till_size<T: Simulator>(
+fn make_key(i: u64) -> Vec<u8> {
+    format!("{:09}", i).into_bytes()
+}
+
+fn put_cf_till_approximate_size<T: Simulator>(
     cluster: &mut Cluster<T>,
     cf: &'static str,
     limit: u64,
@@ -197,27 +201,35 @@ fn put_cf_till_size<T: Simulator>(
     let mut len = 0;
     let mut last_len = 0;
     let mut rng = rand::thread_rng();
-    let mut key = vec![];
-    while len < limit {
-        let key_id = range.next().unwrap();
-        let key_str = format!("{:09}", key_id);
-        key = key_str.into_bytes();
+    let mut start = None;
+    let nodes: Vec<u64> = cluster.engines.keys().cloned().collect();
+    loop {
+        let key = make_key(range.next().unwrap());
+        if start.is_none() {
+            start = Some(key.clone());
+        }
         let mut value = vec![0; 64];
         rng.fill_bytes(&mut value);
         cluster.must_put_cf(cf, &key, &value);
         // plus 1 for the extra encoding prefix
         len += key.len() as u64 + 1;
         len += value.len() as u64;
+        // Approximate size of memtable is inaccurate for small data,
+        // we flush it to SST so we can use the size properties instead.
         // Flush memtable to SST periodically, to make approximate size more accurate.
-        if len - last_len >= 1000 {
+        let gap = if len >= limit { 200 } else { 1000 };
+        if len - last_len >= gap {
             cluster.must_flush(true);
             last_len = len;
         }
+        if len >= limit {
+            for id in &nodes {
+                if cluster.get_approximate_size(*id, cf, start.as_ref().unwrap(), &key) > limit {
+                    return key;
+                }
+            }
+        }
     }
-    // Approximate size of memtable is inaccurate for small data,
-    // we flush it to SST so we can use the size properties instead.
-    cluster.must_flush(true);
-    key
 }
 
 fn test_auto_split_region<T: Simulator>(cluster: &mut Cluster<T>) {
@@ -243,7 +255,7 @@ fn test_auto_split_region<T: Simulator>(cluster: &mut Cluster<T>) {
 
     assert_eq!(region, target);
 
-    let max_key = put_cf_till_size(
+    let max_key = put_cf_till_approximate_size(
         cluster,
         CF_WRITE,
         REGION_MAX_SIZE - REGION_SPLIT_SIZE + check_size_diff,


### PR DESCRIPTION
This PR tries to stable `test_node_auto_split_region`, the test wants to split a region which's size is reached to the split threshold. But the split checker may skip splitting that region because the approximate size is smaller than the threshold.