### PR TITLE
Improve approximate size for small data in tests

### DIFF
--- a/src/raftstore/coprocessor/split_check/size.rs
+++ b/src/raftstore/coprocessor/split_check/size.rs
@@ -86,7 +86,15 @@ impl<C: Sender<Msg> + Send> SplitCheckObserver for SizeCheckObserver<C> {
             );
             // Need to check size.
             status.size = Some(size_status);
-        } // else { Does not need to check size. }
+        } else {
+            // Does not need to check size.
+            debug!(
+                "[region {}] approximate size {} < {}, does not need to do split check",
+                region.get_id(),
+                region_size,
+                self.region_max_size
+            );
+        }
     }
 
     fn on_split_check(

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -2726,7 +2726,7 @@ mod tests {
         region_ranges.insert(b"c".to_vec(), 3);
 
         let declined_bytes = calc_region_declined_bytes(event, &region_ranges, 1024);
-        let expected_declined_bytes = vec![(2, 4096), (3, 4096)];
+        let expected_declined_bytes = vec![(2, 8192), (3, 4096)];
         assert_eq!(declined_bytes, expected_declined_bytes);
     }
 }

--- a/src/raftstore/store/util.rs
+++ b/src/raftstore/store/util.rs
@@ -527,14 +527,11 @@ mod tests {
         let cf_size = 2 + 1024 + 2 + 2048 + 2 + 4096;
         for &(key, vlen) in &cases {
             for cfname in LARGE_CFS {
-                let k1 = keys::data_key(b" ");
-                let v1 = vec![];
-                let k2 = keys::data_key(key.as_bytes());
-                let v2 = vec![0; vlen as usize];
-                assert_eq!(k2.len(), 2);
+                let k1 = keys::data_key(key.as_bytes());
+                let v1 = vec![0; vlen as usize];
+                assert_eq!(k1.len(), 2);
                 let cf = db.cf_handle(cfname).unwrap();
                 db.put_cf(cf, &k1, &v1).unwrap();
-                db.put_cf(cf, &k2, &v2).unwrap();
                 db.flush_cf(cf, true).unwrap();
             }
         }

--- a/src/raftstore/store/worker/split_check.rs
+++ b/src/raftstore/store/worker/split_check.rs
@@ -162,6 +162,7 @@ impl<C: Sender<Msg>> Runner<C> {
         let mut split_ctx = self.coprocessor
             .new_split_check_status(region, &self.engine);
         if split_ctx.skip() {
+            debug!("[region {}] skip split check", region.get_id());
             return;
         }
 

--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -673,10 +673,10 @@ impl<T: Simulator> Cluster<T> {
         assert_eq!(resp.get_responses()[0].get_cmd_type(), CmdType::DeleteRange);
     }
 
-    pub fn must_flush(&mut self, sync: bool) {
+    pub fn must_flush_cf(&mut self, cf: &str, sync: bool) {
         for engines in &self.dbs {
-            engines.kv_engine.flush(sync).unwrap();
-            engines.raft_engine.flush(sync).unwrap();
+            let handle = engines.kv_engine.cf_handle(cf).unwrap();
+            engines.kv_engine.flush_cf(handle, sync).unwrap();
         }
     }
 

--- a/tests/raftstore_cases/test_split_region.rs
+++ b/tests/raftstore_cases/test_split_region.rs
@@ -210,13 +210,13 @@ fn put_cf_till_size<T: Simulator>(
         len += value.len() as u64;
         // Flush memtable to SST periodically, to make approximate size more accurate.
         if len - last_len >= 1000 {
-            cluster.must_flush(true);
+            cluster.must_flush_cf(cf, true);
             last_len = len;
         }
     }
     // Approximate size of memtable is inaccurate for small data,
     // we flush it to SST so we can use the size properties instead.
-    cluster.must_flush(true);
+    cluster.must_flush_cf(cf, true);
     key
 }
 


### PR DESCRIPTION
The current approximate size can miss the first size handle even if the range covers the whole file. This may not be a problem in practice since we don't need to be that accurate, but it may fail some tests. This PR improve the approximate size by including the size handle before the range start, which may result in larger approximate size, but that's generally desirable.