### PR TITLE
Handle stale command error

### DIFF
--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -545,9 +545,9 @@ impl<T: Simulator> Cluster<T> {
 
             let resp = result.unwrap();
             if resp.get_header().has_error() {
-                let error = resp.get_header().get_error();
-                if error.has_stale_epoch() || error.has_stale_command() {
-                    warn!("seems split or leader change, let's retry");
+                let e = resp.get_header().get_error();
+                if e.has_not_leader() || e.has_stale_epoch() || e.has_stale_command() {
+                    warn!("retry on {:?}", e);
                     sleep_ms(100);
                     continue;
                 }

--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -544,10 +544,13 @@ impl<T: Simulator> Cluster<T> {
             }
 
             let resp = result.unwrap();
-            if resp.get_header().get_error().has_stale_epoch() {
-                warn!("seems split, let's retry");
-                sleep_ms(100);
-                continue;
+            if resp.get_header().has_error() {
+                let error = resp.get_header().get_error();
+                if error.has_stale_epoch() || error.has_stale_command() {
+                    warn!("seems split or leader change, let's retry");
+                    sleep_ms(100);
+                    continue;
+                }
             }
             return resp;
         }


### PR DESCRIPTION
Some tests may fail like this:

```
thread 'raftstore_cases::test_multi::test_multi_server_latency' panicked at 'response header {error {message: "stale command" stale_command {}} current_term: 60} has error', tests/raftstore/cluster.rs:601:13
stack backtrace:
   0: std::sys::unix::backtrace::tracing::imp::unwind_backtrace
             at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1: std::sys_common::backtrace::print
             at libstd/sys_common/backtrace.rs:68
             at libstd/sys_common/backtrace.rs:57
   2: std::panicking::default_hook::{{closure}}
             at libstd/panicking.rs:380
   3: std::panicking::default_hook
             at libstd/panicking.rs:396
   4: tikv::util::panic_hook::track_hook::{{closure}}
             at src/util/panic_hook.rs:59
   5: <std::thread::local::LocalKey<T>>::try_with
             at /checkout/src/libstd/thread/local.rs:377
   6: <std::thread::local::LocalKey<T>>::with
             at /checkout/src/libstd/thread/local.rs:288
   7: tikv::util::panic_hook::track_hook
             at src/util/panic_hook.rs:53
   8: core::ops::function::Fn::call
             at /checkout/src/libcore/ops/function.rs:73
   9: std::panicking::rust_panic_with_hook
             at libstd/panicking.rs:577
  10: std::panicking::begin_panic
             at libstd/panicking.rs:537
  11: std::panicking::begin_panic_fmt
             at libstd/panicking.rs:521
  12: <integrations::raftstore::cluster::Cluster<T>>::get_impl
             at tests/raftstore/cluster.rs:601
  13: <integrations::raftstore::cluster::Cluster<T>>::must_get
             at tests/raftstore/cluster.rs:590
  14: integrations::raftstore_cases::test_multi::test_multi_base_after_bootstrap
             at tests/raftstore_cases/test_multi.rs:58
  15: integrations::raftstore_cases::test_multi::test_multi_latency
             at tests/raftstore_cases/test_multi.rs:222
  16: integrations::raftstore_cases::test_multi::test_multi_server_latency
             at tests/raftstore_cases/test_multi.rs:229
  17: <F as alloc::boxed::FnBox<A>>::call_box
             at libtest/lib.rs:1440
             at /checkout/src/libcore/ops/function.rs:223
             at /checkout/src/liballoc/boxed.rs:817
  18: __rust_maybe_catch_panic
             at libpanic_unwind/lib.rs:102
```