### PR TITLE
[DNM] Add timeout to the raft client

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -40,6 +40,8 @@
 # grpc-concurrency = 4
 # The number of max concurrent streams/requests on a client connection.
 # grpc-concurrent-stream = 1024
+# The timeout of the raft client to send raft message.
+# grpc-raft-timeout = "30s"
 # The number of connections with each tikv server to send raft messages.
 # grpc-raft-conn-num = 10
 # Amount to read ahead on individual grpc streams.

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -14,7 +14,7 @@
 use sys_info;
 
 use util::collections::HashMap;
-use util::config::{self, ReadableSize};
+use util::config::{self, ReadableDuration, ReadableSize};
 use util::io_limiter::DEFAULT_SNAP_MAX_BYTES_PER_SEC;
 use super::Result;
 
@@ -27,6 +27,7 @@ const DEFAULT_ADVERTISE_LISTENING_ADDR: &str = "";
 const DEFAULT_NOTIFY_CAPACITY: usize = 40960;
 const DEFAULT_GRPC_CONCURRENCY: usize = 4;
 const DEFAULT_GRPC_CONCURRENT_STREAM: usize = 1024;
+const DEFAULT_GRPC_RAFT_TIMEOUT_SECONDS: u64 = 30;
 const DEFAULT_GRPC_RAFT_CONN_NUM: usize = 10;
 const DEFAULT_GRPC_STREAM_INITIAL_WINDOW_SIZE: u64 = 2 * 1024 * 1024;
 const DEFAULT_MESSAGES_PER_TICK: usize = 4096;
@@ -59,6 +60,7 @@ pub struct Config {
     pub messages_per_tick: usize,
     pub grpc_concurrency: usize,
     pub grpc_concurrent_stream: usize,
+    pub grpc_raft_timeout: ReadableDuration,
     pub grpc_raft_conn_num: usize,
     pub grpc_stream_initial_window_size: ReadableSize,
     pub end_point_concurrency: usize,
@@ -89,6 +91,7 @@ impl Default for Config {
             messages_per_tick: DEFAULT_MESSAGES_PER_TICK,
             grpc_concurrency: DEFAULT_GRPC_CONCURRENCY,
             grpc_concurrent_stream: DEFAULT_GRPC_CONCURRENT_STREAM,
+            grpc_raft_timeout: ReadableDuration::secs(DEFAULT_GRPC_RAFT_TIMEOUT_SECONDS),
             grpc_raft_conn_num: DEFAULT_GRPC_RAFT_CONN_NUM,
             grpc_stream_initial_window_size: ReadableSize(DEFAULT_GRPC_STREAM_INITIAL_WINDOW_SIZE),
             end_point_concurrency: concurrency,

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -18,7 +18,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 use futures::sync::mpsc::{self, UnboundedSender};
 use futures::sync::oneshot::{self, Sender};
 use futures::{stream, Future, Sink, Stream};
-use grpc::{ChannelBuilder, Environment, WriteFlags};
+use grpc::{CallOption, ChannelBuilder, Environment, WriteFlags};
 use kvproto::raft_serverpb::RaftMessage;
 use kvproto::tikvpb_grpc::TikvClient;
 
@@ -68,7 +68,8 @@ impl Conn {
         let client = TikvClient::new(channel);
         let (tx, rx) = mpsc::unbounded();
         let (tx_close, rx_close) = oneshot::channel();
-        let (sink, _) = client.raft().unwrap();
+        let opt = CallOption::default().timeout(cfg.grpc_raft_timeout.0);
+        let (sink, _) = client.raft_opt(opt).unwrap();
         let addr = addr.to_owned();
         client.spawn(
             rx_close

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -64,6 +64,7 @@ fn test_serde_custom_tikv_config() {
         messages_per_tick: 123,
         grpc_concurrency: 123,
         grpc_concurrent_stream: 1_234,
+        grpc_raft_timeout: ReadableDuration::secs(12),
         grpc_raft_conn_num: 123,
         grpc_stream_initial_window_size: ReadableSize(12_345),
         end_point_concurrency: 12,

--- a/tests/config/test-custom.toml
+++ b/tests/config/test-custom.toml
@@ -17,6 +17,7 @@ notify-capacity = 12345
 messages-per-tick = 123
 grpc-concurrency = 123
 grpc-concurrent-stream = 1234
+grpc-raft-timeout = "12s"
 grpc-raft-conn-num = 123
 grpc-stream-initial-window-size = 12345
 end-point-concurrency = 12


### PR DESCRIPTION
A test shows that TiKV will not report unreachable errors until a long time
after a peer is isolated.