### PR TITLE
tests: poll HeartbeatResponse

### DIFF
--- a/benches/bin/bench-tikv.rs
+++ b/benches/bin/bench-tikv.rs
@@ -38,6 +38,7 @@ extern crate tempdir;
 extern crate test;
 #[macro_use]
 extern crate tikv;
+extern crate tokio_timer;
 
 #[allow(dead_code)]
 #[path = "../../tests/util/mod.rs"]

--- a/tests/failpoints.rs
+++ b/tests/failpoints.rs
@@ -45,6 +45,7 @@ extern crate test;
 #[macro_use]
 extern crate tikv;
 extern crate tipb;
+extern crate tokio_timer;
 extern crate toml;
 
 #[allow(dead_code)]

--- a/tests/failpoints_cases/test_pending_peers.rs
+++ b/tests/failpoints_cases/test_pending_peers.rs
@@ -31,7 +31,7 @@ fn test_pending_peers() {
 
     let pd_client = Arc::clone(&cluster.pd_client);
     // Disable default max peer count check.
-    pd_client.disable_default_rule();
+    pd_client.disable_default_operator();
 
     let region_id = cluster.run_conf_change();
     pd_client.must_add_peer(region_id, new_peer(2, 2));

--- a/tests/failpoints_cases/test_snap.rs
+++ b/tests/failpoints_cases/test_snap.rs
@@ -32,7 +32,7 @@ fn test_overlap_cleanup() {
 
     let pd_client = Arc::clone(&cluster.pd_client);
     // Disable default max peer count check.
-    pd_client.disable_default_rule();
+    pd_client.disable_default_operator();
 
     let region_id = cluster.run_conf_change();
     pd_client.must_add_peer(region_id, new_peer(2, 2));

--- a/tests/integrations.rs
+++ b/tests/integrations.rs
@@ -41,6 +41,7 @@ extern crate test;
 #[macro_use]
 extern crate tikv;
 extern crate tipb;
+extern crate tokio_timer;
 extern crate toml;
 extern crate uuid;
 

--- a/tests/raftstore/pd.rs
+++ b/tests/raftstore/pd.rs
@@ -12,10 +12,13 @@
 // limitations under the License.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::hash_map::Entry;
 use std::collections::Bound::{Excluded, Unbounded};
 use std::sync::{Arc, RwLock};
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 
+use tokio_timer::Timer;
 use futures::{Future, Stream};
 use futures::future::{err, ok};
 use futures::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
@@ -26,16 +29,8 @@ use raft::eraftpb;
 use tikv::pd::{Error, Key, PdClient, PdFuture, RegionStat, Result};
 use tikv::raftstore::store::keys::{self, data_key, enc_end_key, enc_start_key};
 use tikv::raftstore::store::util::check_key_in_region;
-use tikv::util::{escape, HandyRwLock};
+use tikv::util::{escape, Either, HandyRwLock};
 use super::util::*;
-
-// Rule is just for special test which we want do more accurate control
-// instead of origin max_peer_count check.
-// E.g, for region a, change peers 1,2,3 -> 1,2,4.
-// But unlike real pd, Rule is global, and if you set rule,
-// we won't check the peer count later.
-pub type Rule =
-    Box<Fn(&metapb::Region, &metapb::Peer) -> Option<pdpb::RegionHeartbeatResponse> + Send + Sync>;
 
 struct Store {
     store: metapb::Store,
@@ -56,6 +51,104 @@ impl Default for Store {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+enum SchedulePolicy {
+    /// Repeat a Operator.
+    Repeat(isize),
+    /// Repeat till succcess.
+    TillSuccess,
+}
+
+impl SchedulePolicy {
+    fn schedule(&mut self) -> bool {
+        match *self {
+            SchedulePolicy::Repeat(ref mut c) => if *c > 0 {
+                *c -= 1;
+                true
+            } else {
+                false
+            },
+            SchedulePolicy::TillSuccess => true,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+enum Operator {
+    AddPeer {
+        peer: Either<metapb::Peer, metapb::Peer>,
+        policy: SchedulePolicy,
+    },
+    RemovePeer {
+        peer: metapb::Peer,
+        policy: SchedulePolicy,
+    },
+    TransferLeader {
+        peer: metapb::Peer,
+        policy: SchedulePolicy,
+    },
+}
+
+impl Operator {
+    fn make_region_heartbeat_response(&self) -> pdpb::RegionHeartbeatResponse {
+        match *self {
+            Operator::AddPeer { ref peer, .. } => {
+                if let Either::Left(ref peer) = *peer {
+                    new_pd_change_peer(eraftpb::ConfChangeType::AddNode, peer.clone())
+                } else {
+                    pdpb::RegionHeartbeatResponse::new()
+                }
+            }
+            Operator::RemovePeer { ref peer, .. } => {
+                new_pd_change_peer(eraftpb::ConfChangeType::RemoveNode, peer.clone())
+            }
+            Operator::TransferLeader { ref peer, .. } => new_pd_transfer_leader(peer.clone()),
+        }
+    }
+
+    fn finished(
+        &mut self,
+        pending_peers: &HashMap<u64, metapb::Peer>,
+        region: &metapb::Region,
+        leader: &metapb::Peer,
+    ) -> bool {
+        match *self {
+            Operator::AddPeer {
+                ref mut peer,
+                ref mut policy,
+            } => {
+                if !policy.schedule() {
+                    return true;
+                }
+                let pr = peer.clone();
+                if let Either::Left(pr) = pr {
+                    if region.get_peers().iter().any(|p| p == &pr) {
+                        // TiKV is adding the peer right now,
+                        // set it to Right so it will not be scheduled again.
+                        *peer = Either::Right(pr);
+                    } else {
+                        // TiKV rejects AddNode.
+                        return false;
+                    }
+                }
+                if let Either::Right(ref pr) = *peer {
+                    // Still adding peer?
+                    return !pending_peers.contains_key(&pr.get_id());
+                }
+                unreachable!()
+            }
+            Operator::RemovePeer {
+                ref peer,
+                ref mut policy,
+            } => region.get_peers().iter().all(|p| p != peer) || !policy.schedule(),
+            Operator::TransferLeader {
+                ref peer,
+                ref mut policy,
+            } => leader == peer || !policy.schedule(),
+        }
+    }
+}
+
 struct Cluster {
     meta: metapb::Cluster,
     stores: HashMap<u64, Store>,
@@ -63,11 +156,16 @@ struct Cluster {
     region_id_keys: HashMap<u64, Key>,
     region_sizes: HashMap<u64, u64>,
     base_id: AtomicUsize,
-    rule: Option<Rule>,
 
     store_stats: HashMap<u64, pdpb::StoreStats>,
     split_count: usize,
 
+    // region id -> Operator
+    operators: HashMap<u64, Operator>,
+    enable_max_peer_count_check: bool,
+
+    // region id -> leader
+    leaders: HashMap<u64, metapb::Peer>,
     down_peers: HashMap<u64, pdpb::PeerStats>,
     pending_peers: HashMap<u64, metapb::Peer>,
     is_bootstraped: bool,
@@ -86,9 +184,11 @@ impl Cluster {
             region_id_keys: HashMap::new(),
             region_sizes: HashMap::new(),
             base_id: AtomicUsize::new(1000),
-            rule: None,
             store_stats: HashMap::new(),
             split_count: 0,
+            operators: HashMap::new(),
+            enable_max_peer_count_check: true,
+            leaders: HashMap::new(),
             down_peers: HashMap::new(),
             pending_peers: HashMap::new(),
             is_bootstraped: false,
@@ -234,7 +334,7 @@ impl Cluster {
 
     fn handle_heartbeat_conf_ver(
         &mut self,
-        region: metapb::Region,
+        mut region: metapb::Region,
         leader: metapb::Peer,
     ) -> Result<pdpb::RegionHeartbeatResponse> {
         let conf_ver = region.get_region_epoch().get_conf_ver();
@@ -281,28 +381,25 @@ impl Cluster {
             must_same_peers(&cur_region, &region);
         }
 
-        let mut resp = pdpb::RegionHeartbeatResponse::new();
-        resp.set_region_id(region.get_id());
-        resp.set_region_epoch(region.get_region_epoch().clone());
-        resp.set_target_peer(leader.clone());
+        let resp = self.poll_heartbeat_responses(region.clone(), leader.clone())
+            .unwrap_or_else(|| {
+                let mut resp = pdpb::RegionHeartbeatResponse::new();
+                resp.set_region_id(region.get_id());
+                resp.set_region_epoch(region.take_region_epoch());
+                resp.set_target_peer(leader);
+                resp
+            });
+        Ok(resp)
+    }
 
-        if let Some(ref rule) = self.rule {
-            return Ok(rule(&region, &leader)
-                .map(|mut resp| {
-                    resp.set_region_id(region.get_id());
-                    resp.set_region_epoch(region.get_region_epoch().clone());
-                    resp.set_target_peer(leader.clone());
-                    resp
-                })
-                .unwrap_or(resp));
-        }
-
-        // If no rule, use default max_peer_count check.
-        let mut change_peer = pdpb::ChangePeer::new();
-
+    // max_peer_count check, the default operator for handling region heartbeat.
+    fn handle_heartbeat_max_peer_count(
+        &mut self,
+        region: &metapb::Region,
+        leader: &metapb::Peer,
+    ) -> Option<Operator> {
         let max_peer_count = self.meta.get_max_peer_count() as usize;
         let peer_count = region.get_peers().len();
-
         if peer_count < max_peer_count {
             // find the first store which the region has not covered.
             for store_id in self.stores.keys() {
@@ -311,11 +408,9 @@ impl Cluster {
                     .iter()
                     .all(|x| x.get_store_id() != *store_id)
                 {
-                    let peer = new_peer(*store_id, self.alloc_id().unwrap());
-                    change_peer.set_change_type(eraftpb::ConfChangeType::AddNode);
-                    change_peer.set_peer(peer.clone());
-                    resp.set_change_peer(change_peer);
-                    break;
+                    let peer = Either::Left(new_peer(*store_id, self.alloc_id().unwrap()));
+                    let policy = SchedulePolicy::Repeat(1);
+                    return Some(Operator::AddPeer { peer, policy });
                 }
             }
         } else if peer_count > max_peer_count {
@@ -325,13 +420,61 @@ impl Cluster {
                 .iter()
                 .position(|x| x.get_store_id() != leader.get_store_id())
                 .unwrap();
-
-            change_peer.set_change_type(eraftpb::ConfChangeType::RemoveNode);
-            change_peer.set_peer(region.get_peers()[pos].clone());
-            resp.set_change_peer(change_peer);
+            let peer = region.get_peers()[pos].clone();
+            let policy = SchedulePolicy::Repeat(1);
+            return Some(Operator::RemovePeer { peer, policy });
         }
 
-        Ok(resp)
+        None
+    }
+
+    fn poll_heartbeat_responses_of(&mut self, store_id: u64) -> Vec<pdpb::RegionHeartbeatResponse> {
+        let mut resps = vec![];
+        for (region_id, leader) in self.leaders.clone() {
+            if leader.get_store_id() != store_id {
+                continue;
+            }
+            if let Ok(Some(region)) = self.get_region_by_id(region_id) {
+                if let Some(resp) = self.poll_heartbeat_responses(region, leader) {
+                    resps.push(resp);
+                }
+            }
+        }
+
+        resps
+    }
+
+    fn poll_heartbeat_responses(
+        &mut self,
+        mut region: metapb::Region,
+        leader: metapb::Peer,
+    ) -> Option<pdpb::RegionHeartbeatResponse> {
+        let region_id = region.get_id();
+        let mut operator = None;
+        if let Some(mut op) = self.operators.remove(&region_id) {
+            if !op.finished(&self.pending_peers, &region, &leader) {
+                operator = Some(op);
+            };
+        } else if self.enable_max_peer_count_check {
+            // There is no on-going operator, start next round.
+            operator = self.handle_heartbeat_max_peer_count(&region, &leader);
+        }
+
+        if operator.is_none() {
+            return None;
+        }
+        let operator = operator.unwrap();
+        debug!(
+            "[region {}] schedule {:?} to {:?}, region: {:?}",
+            region_id, operator, leader, region
+        );
+
+        let mut resp = operator.make_region_heartbeat_response();
+        self.operators.insert(region_id, operator);
+        resp.set_region_id(region_id);
+        resp.set_region_epoch(region.take_region_epoch());
+        resp.set_target_peer(leader);
+        Some(resp)
     }
 
     fn region_heartbeat(
@@ -350,6 +493,7 @@ impl Cluster {
         for p in region_stat.pending_peers {
             self.pending_peers.insert(p.get_id(), p);
         }
+        self.leaders.insert(region.get_id(), leader.clone());
 
         self.region_sizes
             .insert(region.get_id(), region_stat.approximate_size);
@@ -415,14 +559,16 @@ pub fn bootstrap_with_first_region(pd_client: Arc<TestPdClient>) -> Result<()> {
 
 pub struct TestPdClient {
     cluster_id: u64,
-    cluster: RwLock<Cluster>,
+    cluster: Arc<RwLock<Cluster>>,
+    timer: Timer,
 }
 
 impl TestPdClient {
     pub fn new(cluster_id: u64) -> TestPdClient {
         TestPdClient {
             cluster_id: cluster_id,
-            cluster: RwLock::new(Cluster::new(cluster_id)),
+            cluster: Arc::new(RwLock::new(Cluster::new(cluster_id))),
+            timer: Timer::default(),
         }
     }
 
@@ -442,14 +588,23 @@ impl TestPdClient {
         self.cluster.rl().regions.is_empty()
     }
 
-    // Set a customized rule to overwrite default max peer count check rule.
-    pub fn set_rule(&self, rule: Rule) {
-        self.cluster.wl().rule = Some(rule);
-    }
-
-    // Clear the customized rule set before and use default rule again.
-    pub fn reset_rule(&self) {
-        self.cluster.wl().rule = None;
+    fn schedule_operator(&self, region_id: u64, op: Operator) {
+        let mut cluster = self.cluster.wl();
+        match cluster.operators.entry(region_id) {
+            Entry::Occupied(mut e) => {
+                debug!(
+                    "[region {}] schedule operator {:?} and remove {:?}",
+                    region_id,
+                    op,
+                    e.get()
+                );
+                e.insert(op);
+            }
+            Entry::Vacant(e) => {
+                debug!("[region {}] schedule operator {:?}", region_id, op);
+                e.insert(op);
+            }
+        }
     }
 
     pub fn get_region_epoch(&self, region_id: u64) -> metapb::RegionEpoch {
@@ -459,13 +614,17 @@ impl TestPdClient {
             .unwrap()
             .take_region_epoch()
     }
+
     pub fn get_regions_number(&self) -> usize {
         self.cluster.rl().get_regions_number()
     }
-    // Set an empty rule which nothing to do to disable default max peer count
-    // check rule, we can use reset_rule to enable default again.
-    pub fn disable_default_rule(&self) {
-        self.set_rule(box move |_, _| None);
+
+    pub fn disable_default_operator(&self) {
+        self.cluster.wl().enable_max_peer_count_check = false;
+    }
+
+    pub fn enable_default_operator(&self) {
+        self.cluster.wl().enable_max_peer_count_check = true;
     }
 
     pub fn must_have_peer(&self, region_id: u64, peer: metapb::Peer) {
@@ -505,39 +664,50 @@ impl TestPdClient {
         let region = self.get_region_by_id(region_id).wait().unwrap();
         panic!("region {:?} has peer {:?}", region, peer);
     }
+
     pub fn add_region(&self, region: &metapb::Region) {
         self.cluster.wl().add_region(region)
     }
 
+    pub fn ensure_transfer_leader(&self, region_id: u64, peer: metapb::Peer) {
+        let op = Operator::TransferLeader {
+            peer,
+            policy: SchedulePolicy::TillSuccess,
+        };
+        self.schedule_operator(region_id, op);
+    }
+
     pub fn add_peer(&self, region_id: u64, peer: metapb::Peer) {
-        self.set_rule(box move |region: &metapb::Region, _: &metapb::Peer| {
-            debug!(
-                "[region {}] trying add {:?} to {:?}",
-                region_id, peer, region
-            );
-            if region.get_id() != region_id {
-                return None;
-            }
-            new_pd_add_change_peer(region, peer.clone())
-        });
+        let op = Operator::AddPeer {
+            peer: Either::Left(peer),
+            policy: SchedulePolicy::Repeat(1),
+        };
+        self.schedule_operator(region_id, op);
     }
 
     pub fn must_add_peer(&self, region_id: u64, peer: metapb::Peer) {
-        self.add_peer(region_id, peer.clone());
+        let op = Operator::AddPeer {
+            peer: Either::Left(peer.clone()),
+            policy: SchedulePolicy::TillSuccess,
+        };
+        self.schedule_operator(region_id, op);
         self.must_have_peer(region_id, peer);
     }
 
     pub fn remove_peer(&self, region_id: u64, peer: metapb::Peer) {
-        self.set_rule(box move |region: &metapb::Region, _: &metapb::Peer| {
-            if region.get_id() != region_id {
-                return None;
-            }
-            new_pd_remove_change_peer(region, peer.clone())
-        });
+        let op = Operator::RemovePeer {
+            peer,
+            policy: SchedulePolicy::Repeat(1),
+        };
+        self.schedule_operator(region_id, op);
     }
 
     pub fn must_remove_peer(&self, region_id: u64, peer: metapb::Peer) {
-        self.remove_peer(region_id, peer.clone());
+        let op = Operator::RemovePeer {
+            peer: peer.clone(),
+            policy: SchedulePolicy::TillSuccess,
+        };
+        self.schedule_operator(region_id, op);
         self.must_none_peer(region_id, peer);
     }
 
@@ -682,14 +852,30 @@ impl PdClient for TestPdClient {
     where
         F: Fn(pdpb::RegionHeartbeatResponse) + Send + 'static,
     {
+        use futures::stream;
+        let cluster1 = Arc::clone(&self.cluster);
+        let timer = self.timer.clone();
         let mut cluster = self.cluster.wl();
         let store = cluster.stores.get_mut(&store_id).unwrap();
         let rx = store.receiver.take().unwrap();
         Box::new(
-            rx.for_each(move |resp| {
-                f(resp);
-                Ok(())
-            }).map_err(|e| box_err!("failed to receive next heartbeat response: {:?}", e)),
+            rx.map(|resp| vec![resp])
+                .select(
+                    stream::unfold(timer, |timer| {
+                        let interval = timer.sleep(Duration::from_millis(500));
+                        Some(interval.then(|_| Ok(((), timer))))
+                    }).map(move |_| {
+                        let mut cluster = cluster1.wl();
+                        cluster.poll_heartbeat_responses_of(store_id)
+                    }),
+                )
+                .map_err(|e| box_err!("failed to receive next heartbeat response: {:?}", e))
+                .for_each(move |resps| {
+                    for resp in resps {
+                        f(resp);
+                    }
+                    Ok(())
+                }),
         )
     }
 

--- a/tests/raftstore/pd.rs
+++ b/tests/raftstore/pd.rs
@@ -674,7 +674,7 @@ impl TestPdClient {
         self.cluster.wl().add_region(region)
     }
 
-    pub fn ensure_transfer_leader(&self, region_id: u64, peer: metapb::Peer) {
+    pub fn transfer_leader(&self, region_id: u64, peer: metapb::Peer) {
         let op = Operator::TransferLeader {
             peer,
             policy: SchedulePolicy::TillSuccess,
@@ -685,7 +685,7 @@ impl TestPdClient {
     pub fn add_peer(&self, region_id: u64, peer: metapb::Peer) {
         let op = Operator::AddPeer {
             peer: Either::Left(peer),
-            policy: SchedulePolicy::Repeat(1),
+            policy: SchedulePolicy::TillSuccess,
         };
         self.schedule_operator(region_id, op);
     }
@@ -702,7 +702,7 @@ impl TestPdClient {
     pub fn remove_peer(&self, region_id: u64, peer: metapb::Peer) {
         let op = Operator::RemovePeer {
             peer,
-            policy: SchedulePolicy::Repeat(1),
+            policy: SchedulePolicy::TillSuccess,
         };
         self.schedule_operator(region_id, op);
     }

--- a/tests/raftstore/pd.rs
+++ b/tests/raftstore/pd.rs
@@ -53,7 +53,7 @@ impl Default for Store {
 
 #[derive(Debug, Clone, PartialEq)]
 enum SchedulePolicy {
-    /// Repeat a Operator.
+    /// Repeat an Operator.
     Repeat(isize),
     /// Repeat till succcess.
     TillSuccess,

--- a/tests/raftstore/pd.rs
+++ b/tests/raftstore/pd.rs
@@ -430,7 +430,10 @@ impl Cluster {
         None
     }
 
-    fn poll_heartbeat_responses_of(&mut self, store_id: u64) -> Vec<pdpb::RegionHeartbeatResponse> {
+    fn poll_heartbeat_responses_for(
+        &mut self,
+        store_id: u64,
+    ) -> Vec<pdpb::RegionHeartbeatResponse> {
         let mut resps = vec![];
         for (region_id, leader) in self.leaders.clone() {
             if leader.get_store_id() != store_id {
@@ -868,7 +871,7 @@ impl PdClient for TestPdClient {
                         Some(interval.then(|_| Ok(((), timer))))
                     }).map(move |_| {
                         let mut cluster = cluster1.wl();
-                        cluster.poll_heartbeat_responses_of(store_id)
+                        cluster.poll_heartbeat_responses_for(store_id)
                     }),
                 )
                 .map_err(|e| box_err!("failed to receive next heartbeat response: {:?}", e))

--- a/tests/raftstore/pd.rs
+++ b/tests/raftstore/pd.rs
@@ -690,15 +690,6 @@ impl TestPdClient {
         self.schedule_operator(region_id, op);
     }
 
-    pub fn must_add_peer(&self, region_id: u64, peer: metapb::Peer) {
-        let op = Operator::AddPeer {
-            peer: Either::Left(peer.clone()),
-            policy: SchedulePolicy::TillSuccess,
-        };
-        self.schedule_operator(region_id, op);
-        self.must_have_peer(region_id, peer);
-    }
-
     pub fn remove_peer(&self, region_id: u64, peer: metapb::Peer) {
         let op = Operator::RemovePeer {
             peer,
@@ -707,12 +698,13 @@ impl TestPdClient {
         self.schedule_operator(region_id, op);
     }
 
+    pub fn must_add_peer(&self, region_id: u64, peer: metapb::Peer) {
+        self.add_peer(region_id, peer.clone());
+        self.must_have_peer(region_id, peer);
+    }
+
     pub fn must_remove_peer(&self, region_id: u64, peer: metapb::Peer) {
-        let op = Operator::RemovePeer {
-            peer: peer.clone(),
-            policy: SchedulePolicy::TillSuccess,
-        };
-        self.schedule_operator(region_id, op);
+        self.remove_peer(region_id, peer.clone());
         self.must_none_peer(region_id, peer);
     }
 

--- a/tests/raftstore/util.rs
+++ b/tests/raftstore/util.rs
@@ -287,36 +287,13 @@ pub fn new_pd_change_peer(
     resp
 }
 
-pub fn new_pd_add_change_peer(
-    region: &metapb::Region,
-    peer: metapb::Peer,
-) -> Option<RegionHeartbeatResponse> {
-    if let Some(p) = find_peer(region, peer.get_store_id()) {
-        assert_eq!(p.get_id(), peer.get_id());
-        return None;
-    }
-
-    Some(new_pd_change_peer(ConfChangeType::AddNode, peer))
-}
-
-pub fn new_pd_remove_change_peer(
-    region: &metapb::Region,
-    peer: metapb::Peer,
-) -> Option<RegionHeartbeatResponse> {
-    if find_peer(region, peer.get_store_id()).is_none() {
-        return None;
-    }
-
-    Some(new_pd_change_peer(ConfChangeType::RemoveNode, peer))
-}
-
-pub fn new_pd_transfer_leader(peer: metapb::Peer) -> Option<RegionHeartbeatResponse> {
+pub fn new_pd_transfer_leader(peer: metapb::Peer) -> RegionHeartbeatResponse {
     let mut transfer_leader = TransferLeader::new();
     transfer_leader.set_peer(peer);
 
     let mut resp = RegionHeartbeatResponse::new();
     resp.set_transfer_leader(transfer_leader);
-    Some(resp)
+    resp
 }
 
 pub fn make_cb(cmd: &RaftCmdRequest) -> (Callback, mpsc::Receiver<RaftCmdResponse>) {

--- a/tests/raftstore_cases/test_clear_stale_data.rs
+++ b/tests/raftstore_cases/test_clear_stale_data.rs
@@ -108,7 +108,7 @@ fn test_clear_stale_data<T: Simulator>(cluster: &mut Cluster<T>) {
     }
 
     // Remove some peers from the node.
-    cluster.pd_client.disable_default_rule();
+    cluster.pd_client.disable_default_operator();
     for i in 0..n {
         if i % 2 == 0 {
             continue;

--- a/tests/raftstore_cases/test_conf_change.rs
+++ b/tests/raftstore_cases/test_conf_change.rs
@@ -35,7 +35,7 @@ use super::pd::TestPdClient;
 fn test_simple_conf_change<T: Simulator>(cluster: &mut Cluster<T>) {
     let pd_client = Arc::clone(&cluster.pd_client);
     // Disable default max peer count check.
-    pd_client.disable_default_rule();
+    pd_client.disable_default_operator();
 
     let r1 = cluster.run_conf_change();
 
@@ -156,7 +156,7 @@ fn new_conf_change_peer(store: &metapb::Store, pd_client: &Arc<TestPdClient>) ->
 fn test_pd_conf_change<T: Simulator>(cluster: &mut Cluster<T>) {
     let pd_client = Arc::clone(&cluster.pd_client);
     // Disable default max peer count check.
-    pd_client.disable_default_rule();
+    pd_client.disable_default_operator();
 
     cluster.start();
 
@@ -329,7 +329,7 @@ fn test_auto_adjust_replica<T: Simulator>(cluster: &mut Cluster<T>) {
     wait_till_reach_count(Arc::clone(&pd_client), region_id, 6);
 
     // it should remove extra replica.
-    pd_client.reset_rule();
+    pd_client.enable_default_operator();
     wait_till_reach_count(Arc::clone(&pd_client), region_id, 5);
 
     region = pd_client
@@ -342,7 +342,7 @@ fn test_auto_adjust_replica<T: Simulator>(cluster: &mut Cluster<T>) {
     wait_till_reach_count(Arc::clone(&pd_client), region_id, 4);
 
     // it should add missing replica.
-    pd_client.reset_rule();
+    pd_client.enable_default_operator();
     wait_till_reach_count(Arc::clone(&pd_client), region_id, 5);
 }
 
@@ -363,7 +363,7 @@ fn test_server_auto_adjust_replica() {
 fn test_after_remove_itself<T: Simulator>(cluster: &mut Cluster<T>) {
     let pd_client = Arc::clone(&cluster.pd_client);
     // Disable default max peer count check.
-    pd_client.disable_default_rule();
+    pd_client.disable_default_operator();
 
     // disable auto compact log.
     cluster.cfg.raft_store.raft_log_gc_threshold = 10000;
@@ -391,7 +391,7 @@ fn test_after_remove_itself<T: Simulator>(cluster: &mut Cluster<T>) {
 
     cluster.stop_node(3);
 
-    pd_client.set_rule(box move |region, _| new_pd_remove_change_peer(region, new_peer(1, 1)));
+    pd_client.remove_peer(1, new_peer(1, 1));
 
     let epoch = cluster
         .pd_client
@@ -449,7 +449,7 @@ fn test_server_after_remove_itself() {
 fn test_split_brain<T: Simulator>(cluster: &mut Cluster<T>) {
     let pd_client = Arc::clone(&cluster.pd_client);
     // Disable default max peer number check.
-    pd_client.disable_default_rule();
+    pd_client.disable_default_operator();
 
     let r1 = cluster.run_conf_change();
 
@@ -534,7 +534,7 @@ fn test_node_split_brain() {
 fn test_conf_change_safe<T: Simulator>(cluster: &mut Cluster<T>) {
     let pd_client = Arc::clone(&cluster.pd_client);
     // Disable default max peer count check.
-    pd_client.disable_default_rule();
+    pd_client.disable_default_operator();
 
     let region_id = cluster.run_conf_change();
 
@@ -610,7 +610,7 @@ fn test_conf_change_remove_leader() {
     let mut cluster = new_node_cluster(0, 3);
     cluster.cfg.raft_store.allow_remove_leader = false;
     let pd_client = Arc::clone(&cluster.pd_client);
-    pd_client.disable_default_rule();
+    pd_client.disable_default_operator();
     let r1 = cluster.run_conf_change();
     pd_client.must_add_peer(r1, new_peer(2, 2));
     pd_client.must_add_peer(r1, new_peer(3, 3));

--- a/tests/raftstore_cases/test_lease_read.rs
+++ b/tests/raftstore_cases/test_lease_read.rs
@@ -61,7 +61,7 @@ fn test_renew_lease<T: Simulator>(cluster: &mut Cluster<T>) {
     let node_id = 1u64;
     let store_id = 1u64;
     let peer = new_peer(store_id, node_id);
-    cluster.pd_client.disable_default_rule();
+    cluster.pd_client.disable_default_operator();
     let region_id = cluster.run_conf_change();
     for id in 2..cluster.engines.len() as u64 + 1 {
         cluster.pd_client.must_add_peer(region_id, new_peer(id, id));
@@ -139,7 +139,7 @@ fn test_node_renew_lease() {
 fn test_lease_expired<T: Simulator>(cluster: &mut Cluster<T>) {
     let pd_client = Arc::clone(&cluster.pd_client);
     // Disable default max peer number check.
-    pd_client.disable_default_rule();
+    pd_client.disable_default_operator();
 
     // Avoid triggering the log compaction in this test case.
     cluster.cfg.raft_store.raft_log_gc_threshold = 100;

--- a/tests/raftstore_cases/test_region_heartbeat.rs
+++ b/tests/raftstore_cases/test_region_heartbeat.rs
@@ -92,7 +92,7 @@ fn test_server_down_peers() {
 fn test_pending_peers<T: Simulator>(cluster: &mut Cluster<T>) {
     let pd_client = Arc::clone(&cluster.pd_client);
     // Disable default max peer count check.
-    pd_client.disable_default_rule();
+    pd_client.disable_default_operator();
 
     let region_id = cluster.run_conf_change();
 

--- a/tests/raftstore_cases/test_snap.rs
+++ b/tests/raftstore_cases/test_snap.rs
@@ -44,7 +44,7 @@ fn test_huge_snapshot<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.cfg.raft_store.snap_apply_batch_size = ReadableSize(500);
     let pd_client = Arc::clone(&cluster.pd_client);
     // Disable default max peer count check.
-    pd_client.disable_default_rule();
+    pd_client.disable_default_operator();
 
     let r1 = cluster.run_conf_change();
 
@@ -115,7 +115,7 @@ fn test_snap_gc<T: Simulator>(cluster: &mut Cluster<T>) {
 
     let pd_client = Arc::clone(&cluster.pd_client);
     // Disable default max peer count check.
-    pd_client.disable_default_rule();
+    pd_client.disable_default_operator();
     let r1 = cluster.run_conf_change();
     cluster.must_put(b"k1", b"v1");
     pd_client.must_add_peer(r1, new_peer(2, 2));
@@ -216,7 +216,7 @@ fn test_concurrent_snap<T: Simulator>(cluster: &mut Cluster<T>) {
 
     let pd_client = Arc::clone(&cluster.pd_client);
     // Disable default max peer count check.
-    pd_client.disable_default_rule();
+    pd_client.disable_default_operator();
 
     let r1 = cluster.run_conf_change();
     cluster.must_put(b"k1", b"v1");
@@ -354,7 +354,7 @@ fn test_node_stale_snap() {
 
     let pd_client = Arc::clone(&cluster.pd_client);
     // Disable default max peer count check.
-    pd_client.disable_default_rule();
+    pd_client.disable_default_operator();
 
     let r1 = cluster.run_conf_change();
     // add peer (2,2) to region 1.
@@ -438,7 +438,7 @@ fn test_snapshot_with_append<T: Simulator>(cluster: &mut Cluster<T>) {
 
     let pd_client = Arc::clone(&cluster.pd_client);
     // Disable default max peer count check.
-    pd_client.disable_default_rule();
+    pd_client.disable_default_operator();
     cluster.run();
 
     pd_client.must_remove_peer(1, new_peer(4, 4));
@@ -448,7 +448,7 @@ fn test_snapshot_with_append<T: Simulator>(cluster: &mut Cluster<T>) {
         .sim
         .wl()
         .add_recv_filter(4, box SnapshotAppendFilter::new(tx));
-    pd_client.add_peer(1, new_peer(4, 5));
+    pd_client.must_add_peer(1, new_peer(4, 5));
     rx.recv_timeout(Duration::from_secs(3)).unwrap();
     cluster.must_put(b"k1", b"v1");
     cluster.must_put(b"k2", b"v2");

--- a/tests/raftstore_cases/test_snap.rs
+++ b/tests/raftstore_cases/test_snap.rs
@@ -448,7 +448,7 @@ fn test_snapshot_with_append<T: Simulator>(cluster: &mut Cluster<T>) {
         .sim
         .wl()
         .add_recv_filter(4, box SnapshotAppendFilter::new(tx));
-    pd_client.must_add_peer(1, new_peer(4, 5));
+    pd_client.add_peer(1, new_peer(4, 5));
     rx.recv_timeout(Duration::from_secs(3)).unwrap();
     cluster.must_put(b"k1", b"v1");
     cluster.must_put(b"k2", b"v2");

--- a/tests/raftstore_cases/test_split_region.rs
+++ b/tests/raftstore_cases/test_split_region.rs
@@ -498,7 +498,7 @@ fn test_split_with_stale_peer<T: Simulator>(cluster: &mut Cluster<T>) {
 
     let pd_client = Arc::clone(&cluster.pd_client);
     // Disable default max peer count check.
-    pd_client.disable_default_rule();
+    pd_client.disable_default_operator();
 
     let r1 = cluster.run_conf_change();
 

--- a/tests/raftstore_cases/test_stale_peer.rs
+++ b/tests/raftstore_cases/test_stale_peer.rs
@@ -44,7 +44,7 @@ use super::util::*;
 fn test_stale_peer_out_of_region<T: Simulator>(cluster: &mut Cluster<T>) {
     let pd_client = Arc::clone(&cluster.pd_client);
     // Disable default max peer number check.
-    pd_client.disable_default_rule();
+    pd_client.disable_default_operator();
 
     let r1 = cluster.run_conf_change();
     pd_client.must_add_peer(r1, new_peer(2, 2));
@@ -124,7 +124,7 @@ fn test_stale_peer_without_data<T: Simulator>(cluster: &mut Cluster<T>, right_de
 
     let pd_client = Arc::clone(&cluster.pd_client);
     // Disable default max peer number check.
-    pd_client.disable_default_rule();
+    pd_client.disable_default_operator();
 
     let r1 = cluster.run_conf_change();
     cluster.must_put(b"k1", b"v1");

--- a/tests/raftstore_cases/test_stats.rs
+++ b/tests/raftstore_cases/test_stats.rs
@@ -109,7 +109,7 @@ fn test_server_store_snap_stats() {
 
     let pd_client = Arc::clone(&cluster.pd_client);
     // Disable default max peer number check.
-    pd_client.disable_default_rule();
+    pd_client.disable_default_operator();
 
     let r1 = cluster.run_conf_change();
 

--- a/tests/raftstore_cases/test_tombstone.rs
+++ b/tests/raftstore_cases/test_tombstone.rs
@@ -31,7 +31,7 @@ use tikv::util::rocksdb::get_cf_handle;
 fn test_tombstone<T: Simulator>(cluster: &mut Cluster<T>) {
     let pd_client = Arc::clone(&cluster.pd_client);
     // Disable default max peer number check.
-    pd_client.disable_default_rule();
+    pd_client.disable_default_operator();
 
     let r1 = cluster.run_conf_change();
 
@@ -135,7 +135,7 @@ fn test_fast_destroy<T: Simulator>(cluster: &mut Cluster<T>) {
     let pd_client = Arc::clone(&cluster.pd_client);
 
     // Disable default max peer number check.
-    pd_client.disable_default_rule();
+    pd_client.disable_default_operator();
 
     cluster.run();
     cluster.must_put(b"k1", b"v1");
@@ -186,7 +186,7 @@ fn test_server_fast_destroy() {
 fn test_readd_peer<T: Simulator>(cluster: &mut Cluster<T>) {
     let pd_client = Arc::clone(&cluster.pd_client);
     // Disable default max peer number check.
-    pd_client.disable_default_rule();
+    pd_client.disable_default_operator();
 
     let r1 = cluster.run_conf_change();
 
@@ -258,7 +258,7 @@ fn test_server_stale_meta() {
     let mut cluster = new_server_cluster(0, count);
     let pd_client = Arc::clone(&cluster.pd_client);
     // Disable default max peer number check.
-    pd_client.disable_default_rule();
+    pd_client.disable_default_operator();
 
     cluster.run();
     cluster.add_send_filter(IsolationFilterFactory::new(3));

--- a/tests/raftstore_cases/test_transfer_leader.rs
+++ b/tests/raftstore_cases/test_transfer_leader.rs
@@ -79,7 +79,7 @@ fn test_node_basic_transfer_leader() {
 
 fn test_pd_transfer_leader<T: Simulator>(cluster: &mut Cluster<T>) {
     let pd_client = Arc::clone(&cluster.pd_client);
-    pd_client.disable_default_rule();
+    pd_client.disable_default_operator();
 
     cluster.run();
 
@@ -96,12 +96,7 @@ fn test_pd_transfer_leader<T: Simulator>(cluster: &mut Cluster<T>) {
 
     for id in 1..4 {
         // select a new leader to transfer
-        pd_client.set_rule(box move |_, peer| {
-            if peer.get_id() == id {
-                return None;
-            }
-            new_pd_transfer_leader(new_peer(id, id))
-        });
+        pd_client.ensure_transfer_leader(region.get_id(), new_peer(id, id));
 
         for _ in 0..100 {
             // reset leader and wait transfer successfully.
@@ -142,7 +137,7 @@ fn test_node_pd_transfer_leader() {
 fn test_transfer_leader_during_snapshot<T: Simulator>(cluster: &mut Cluster<T>) {
     let pd_client = Arc::clone(&cluster.pd_client);
     // Disable default max peer count check.
-    pd_client.disable_default_rule();
+    pd_client.disable_default_operator();
     cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::millis(20);
     cluster.cfg.raft_store.raft_log_gc_count_limit = 2;
     cluster.cfg.raft_store.merge_max_log_gap = 1;

--- a/tests/raftstore_cases/test_transfer_leader.rs
+++ b/tests/raftstore_cases/test_transfer_leader.rs
@@ -96,7 +96,7 @@ fn test_pd_transfer_leader<T: Simulator>(cluster: &mut Cluster<T>) {
 
     for id in 1..4 {
         // select a new leader to transfer
-        pd_client.ensure_transfer_leader(region.get_id(), new_peer(id, id));
+        pd_client.transfer_leader(region.get_id(), new_peer(id, id));
 
         for _ in 0..100 {
             // reset leader and wait transfer successfully.


### PR DESCRIPTION
In tests, the mock pd-server(TestPdClient::Cluster) does not push region heartbeat responses. This PR try to simulate pushing by polling responses in the background. 

It's part of region heartbeat cache #2701, for fixing tests.