### PR TITLE
pd: handle reconnect

### DIFF
--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -454,6 +454,6 @@ impl PdClient for RpcClient {
     }
 
     fn handle_reconnect<F: Fn() + Sync + Send + 'static>(&self, f: F) {
-        self.leader_client.handle_reconnect(Box::new(f))
+        self.leader_client.on_reconnect(Box::new(f))
     }
 }

--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -452,4 +452,8 @@ impl PdClient for RpcClient {
         })?;
         check_resp_header(resp.get_header())
     }
+
+    fn handle_reconnect<F: Fn() + Sync + Send + 'static>(&self, f: F) {
+        self.leader_client.handle_reconnect(Box::new(f))
+    }
 }

--- a/src/pd/mod.rs
+++ b/src/pd/mod.rs
@@ -187,6 +187,11 @@ pub trait PdClient: Send + Sync {
     fn scatter_region(&self, _: RegionInfo) -> Result<()> {
         unimplemented!();
     }
+
+    // Register a handler to the client, it will be invoked after reconnecting to PD.
+    //
+    // Please note that this method should only be called once.
+    fn handle_reconnect<F: Fn() + Sync + Send + 'static>(&self, _: F) {}
 }
 
 const REQUEST_TIMEOUT: u64 = 2; // 2s


### PR DESCRIPTION
This PR adds a handler which will be invoked after the client reconnects to PD.  

It's part of region heartbeat cache #2701, for invalidated region cache.