### PR TITLE
set dynamic_level_bytes on by default

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -356,7 +356,7 @@
 # read-amp-bytes-per-bit = 0
 
 # Pick target size of each level dynamically.
-# dynamic-level-bytes = false
+# dynamic-level-bytes = true
 
 # Options for Column Family write
 # Column Family write used to store commit informations in MVCC model
@@ -378,7 +378,7 @@
 # pin-l0-filter-and-index-blocks = true
 # compaction-pri = 3
 # read-amp-bytes-per-bit = 0
-# dynamic-level-bytes = false
+# dynamic-level-bytes = true
 
 [rocksdb.lockcf]
 # compression-per-level = ["no", "no", "no", "no", "no", "no", "no"]
@@ -396,7 +396,7 @@
 # pin-l0-filter-and-index-blocks = true
 # compaction-pri = 0
 # read-amp-bytes-per-bit = 0
-# dynamic-level-bytes = false
+# dynamic-level-bytes = true
 
 [raftdb]
 # max-sub-compactions = 1
@@ -433,7 +433,7 @@
 # compaction-pri = 0
 # read-amp-bytes-per-bit = 0
 # wal-bytes-per-sync = 0
-# dynamic-level-bytes = false
+# dynamic-level-bytes = true
 
 [security]
 # set the path for certificates. Empty string means disabling secure connectoins.

--- a/src/config.rs
+++ b/src/config.rs
@@ -165,7 +165,7 @@ impl Default for DefaultCfConfig {
             level0_stop_writes_trigger: 36,
             max_compaction_bytes: ReadableSize::gb(2),
             compaction_pri: CompactionPriority::MinOverlappingRatio,
-            dynamic_level_bytes: false,
+            dynamic_level_bytes: true,
             num_levels: 7,
             max_bytes_for_level_multiplier: 10,
         }
@@ -215,7 +215,7 @@ impl Default for WriteCfConfig {
             level0_stop_writes_trigger: 36,
             max_compaction_bytes: ReadableSize::gb(2),
             compaction_pri: CompactionPriority::MinOverlappingRatio,
-            dynamic_level_bytes: false,
+            dynamic_level_bytes: true,
             num_levels: 7,
             max_bytes_for_level_multiplier: 10,
         }
@@ -267,7 +267,7 @@ impl Default for LockCfConfig {
             level0_stop_writes_trigger: 36,
             max_compaction_bytes: ReadableSize::gb(2),
             compaction_pri: CompactionPriority::ByCompensatedSize,
-            dynamic_level_bytes: false,
+            dynamic_level_bytes: true,
             num_levels: 7,
             max_bytes_for_level_multiplier: 10,
         }
@@ -312,7 +312,7 @@ impl Default for RaftCfConfig {
             level0_stop_writes_trigger: 36,
             max_compaction_bytes: ReadableSize::gb(2),
             compaction_pri: CompactionPriority::ByCompensatedSize,
-            dynamic_level_bytes: false,
+            dynamic_level_bytes: true,
             num_levels: 7,
             max_bytes_for_level_multiplier: 10,
         }
@@ -487,7 +487,7 @@ impl Default for RaftDefaultCfConfig {
             level0_stop_writes_trigger: 36,
             max_compaction_bytes: ReadableSize::gb(2),
             compaction_pri: CompactionPriority::ByCompensatedSize,
-            dynamic_level_bytes: false,
+            dynamic_level_bytes: true,
             num_levels: 7,
             max_bytes_for_level_multiplier: 10,
         }


### PR DESCRIPTION
We set `dynamic_level_bytes` on by default to limit space amplification in some situations.
`ingest sst` will add the sst to the bottommost level if there is no overlap with existing ssts, level 6 by default. We use `ingest sst` to replicate regions' peers, so the LSM structure may like this:
L0 ssts
L1 ssts
L2 ssts
L3~L5 is empty
L6 ssts(ingested by replicating)
When user delete these datas which contained in ssts at level 6, these delete marks are hard to reach level 6. So the disk space occupied by these ssts is hard to reclaim.
When `dynamic_level_bytes` is on, for an empty DB, RocksDB makes last level the base level, which means merging L0 data into the last level, until it exceeds max_bytes_for_level_base. And then RocksDB makes the second last level to be base level, and so on.
For the above case, if `dynamic_level_bytes` is on, the LSM structure is like this:
L0 ssts
L5 ssts
L6 ssts
The delete marks will be compacted from L0 to L5, from L5 to L6. The relevant space occupied by these keys will be freed.

It is not recommended to change this value on db which is not empty. If you really want to change this value, please use `pd-ctl` to compact the whole db first.
$./bin/tikv-ctl --host={$tikv-ip}:{$tikv-port} compact -c write
$./bin/tikv-ctl --host={$tikv-ip}:{$tikv-port} compact -c default