### PR TITLE
Implement CompactFiles API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git#6bcc71d6f5f7495938656a38ca90d110f5e60b6c"
+source = "git+https://github.com/huachaohuang/kvproto.git?branch=compact-files#7d225f78ebf9eca07baef23c0cc0dba5a240cc44"
 dependencies = [
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -443,7 +443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#cb63dcd12e20c51e2957e017dc84fa460dcc1b06"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#4838a9684fd1955cf59564f4a2a345f4fd87bac0"
 dependencies = [
  "bzip2-sys 0.1.6 (git+https://github.com/alexcrichton/bzip2-rs.git)",
  "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -784,7 +784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#cb63dcd12e20c51e2957e017dc84fa460dcc1b06"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#4838a9684fd1955cf59564f4a2a345f4fd87bac0"
 dependencies = [
  "crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1011,7 +1011,7 @@ dependencies = [
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)",
- "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto 0.0.1 (git+https://github.com/huachaohuang/kvproto.git?branch=compact-files)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1300,7 +1300,7 @@ dependencies = [
 "checksum jemalloc-sys 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)" = "<none>"
+"checksum kvproto 0.0.1 (git+https://github.com/huachaohuang/kvproto.git?branch=compact-files)" = "<none>"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,8 @@ signal = "0.4"
 git = "https://github.com/pingcap/rust-rocksdb.git"
 
 [dependencies.kvproto]
-git = "https://github.com/pingcap/kvproto.git"
+git = "https://github.com/huachaohuang/kvproto.git"
+branch = "compact-files"
 
 [dependencies.tipb]
 git = "https://github.com/pingcap/tipb.git"

--- a/src/server/service/debug.rs
+++ b/src/server/service/debug.rs
@@ -227,6 +227,21 @@ impl debugpb_grpc::Debug for Service {
         self.handle_response(ctx, sink, f, "debug_compact");
     }
 
+    fn compact_files(
+        &self,
+        ctx: RpcContext,
+        req: CompactFilesRequest,
+        sink: UnarySink<CompactFilesResponse>,
+    ) {
+        let debugger = self.debugger.clone();
+        let f = self.pool.spawn_fn(move || {
+            debugger
+                .compact_files(req.get_db(), req.get_cf(), req.get_output_level())
+                .map(|_| CompactFilesResponse::default())
+        });
+        self.handle_response(ctx, sink, f, "debug_compact_files");
+    }
+
     fn inject_fail_point(
         &self,
         ctx: RpcContext,


### PR DESCRIPTION
CompactFiles is faster than CompactRange when we want to do full compaction because CompactFiles can take good use of multiple threads. But CompactFiles can only be used when auto compaction is disabled.