### PR TITLE
pd: cancel unused region heartbeat rpc

### DIFF
--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -307,33 +307,38 @@ impl PdClient for RpcClient {
 
         let executor = |client: &RwLock<Inner>, req: pdpb::RegionHeartbeatRequest| {
             let mut inner = client.wl();
-            let sender = match inner.hb_sender {
-                Either::Left(ref mut sender) => sender.take(),
-                Either::Right(ref sender) => {
-                    return Box::new(future::result(
-                        sender
-                            .unbounded_send(req)
-                            .map_err(|e| Error::Other(Box::new(e))),
-                    )) as PdFuture<_>
-                }
-            };
-
-            match sender {
-                Some(sender) => {
-                    let (tx, rx) = mpsc::unbounded();
-                    tx.unbounded_send(req).unwrap();
-                    inner.hb_sender = Either::Right(tx);
-                    Box::new(
-                        sender
-                            .sink_map_err(Error::Grpc)
-                            .send_all(rx.map_err(|e| {
-                                Error::Other(box_err!("failed to recv heartbeat: {:?}", e))
-                            }).map(|r| (r, WriteFlags::default())))
-                            .map(|(mut sender, _)| sender.get_mut().cancel()),
-                    ) as PdFuture<_>
-                }
-                None => unreachable!(),
+            if let Either::Right(ref sender) = inner.hb_sender {
+                return Box::new(future::result(
+                    sender
+                        .unbounded_send(req)
+                        .map_err(|e| Error::Other(Box::new(e))),
+                )) as PdFuture<_>;
             }
+
+            info!("heartbeat sender is refreshed.");
+            let sender = inner.hb_sender.as_mut().left().unwrap().take().unwrap();
+            let (tx, rx) = mpsc::unbounded();
+            tx.unbounded_send(req).unwrap();
+            inner.hb_sender = Either::Right(tx);
+            Box::new(
+                sender
+                    .sink_map_err(Error::Grpc)
+                    .send_all(rx.then(|r| match r {
+                        Ok(r) => Ok((r, WriteFlags::default())),
+                        Err(()) => Err(Error::Other(box_err!("failed to recv heartbeat"))),
+                    }))
+                    .then(|result| match result {
+                        Ok((mut sender, _)) => {
+                            info!("cancel region heartbeat sender");
+                            sender.get_mut().cancel();
+                            Ok(())
+                        }
+                        Err(e) => {
+                            error!("failed to send heartbeat: {:?}", e);
+                            Err(e)
+                        }
+                    }),
+            ) as PdFuture<_>
         };
 
         self.leader_client

--- a/src/pd/mod.rs
+++ b/src/pd/mod.rs
@@ -34,7 +34,7 @@ use futures::Future;
 pub type Key = Vec<u8>;
 pub type PdFuture<T> = Box<Future<Item = T, Error = Error> + Send>;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct RegionStat {
     pub down_peers: Vec<pdpb::PeerStats>,
     pub pending_peers: Vec<metapb::Peer>,

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -309,6 +309,14 @@ impl<L, R> Either<L, R> {
     }
 
     #[inline]
+    pub fn as_mut(&mut self) -> Either<&mut L, &mut R> {
+        match *self {
+            Either::Left(ref mut l) => Either::Left(l),
+            Either::Right(ref mut r) => Either::Right(r),
+        }
+    }
+
+    #[inline]
     pub fn left(self) -> Option<L> {
         match self {
             Either::Left(l) => Some(l),

--- a/tests/pd/test_rpc_client.rs
+++ b/tests/pd/test_rpc_client.rs
@@ -426,9 +426,9 @@ fn test_region_heartbeat_on_leader_change() {
             .unwrap();
     };
 
-    // Change PD leader once.
+    // Change PD leader once then heartbeat PD.
     heartbeat_on_leader_change(1);
 
-    // Change PD leader twice without update the heartbeat sender.
+    // Change PD leader twice without update the heartbeat sender, then heartbeat PD.
     heartbeat_on_leader_change(2);
 }

--- a/tests/pd/test_rpc_client.rs
+++ b/tests/pd/test_rpc_client.rs
@@ -405,11 +405,11 @@ fn test_region_heartbeat_on_leader_change() {
     rx.recv_timeout(LeaderChange::get_leader_interval())
         .unwrap();
 
-    let change_leader = |count| {
+    let heartbeat_on_leader_change = |count| {
         let mut leader = client.get_leader();
         for _ in 0..count {
             loop {
-                client.get_region_by_id(1).wait().ok();
+                let _ = client.get_region_by_id(1).wait();
                 let new = client.get_leader();
                 if leader != new {
                     leader = new;
@@ -427,8 +427,8 @@ fn test_region_heartbeat_on_leader_change() {
     };
 
     // Change PD leader once.
-    change_leader(1);
+    heartbeat_on_leader_change(1);
 
     // Change PD leader twice without update the heartbeat sender.
-    change_leader(2);
+    heartbeat_on_leader_change(2);
 }


### PR DESCRIPTION
PdClient may leak gRPC calls if PD leader changes rapidly.

Cc #2669