### PR TITLE
[cherry-pick] Update rocksdb: fix a segfault

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#cb63dcd12e20c51e2957e017dc84fa460dcc1b06"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#b127863a82fcf7784d5697261207df827f6c74a0"
 dependencies = [
  "bzip2-sys 0.1.6 (git+https://github.com/alexcrichton/bzip2-rs.git)",
  "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -426,7 +426,6 @@ dependencies = [
  "libz-sys 1.0.18 (git+https://github.com/busyjay/libz-sys.git?branch=static-link)",
  "lz4-sys 1.8.0 (git+https://github.com/busyjay/lz4-rs.git?branch=adjust-build)",
  "snappy-sys 0.1.0 (git+https://github.com/busyjay/rust-snappy.git?branch=static-link)",
- "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "zstd-sys 1.4.1+zstd.1.3.2 (git+https://github.com/gyscos/zstd-rs.git)",
 ]
 
@@ -719,12 +718,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#cb63dcd12e20c51e2957e017dc84fa460dcc1b06"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#b127863a82fcf7784d5697261207df827f6c74a0"
 dependencies = [
  "crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "librocksdb_sys 0.1.0 (git+https://github.com/pingcap/rust-rocksdb.git)",
- "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]


### PR DESCRIPTION
Fix a potential segfault when we have a very large number of ranges on stack in https://github.com/pingcap/rust-rocksdb/commit/b127863a82fcf7784d5697261207df827f6c74a0.