### PR TITLE
 pd: region heartbeat keep alive

### DIFF
--- a/src/pd/metrics.rs
+++ b/src/pd/metrics.rs
@@ -35,6 +35,12 @@ lazy_static! {
             &["type"]
         ).unwrap();
 
+    pub static ref KEEP_ALIVE_TIMEOUT_COUNTER: Counter =
+        register_counter!(
+            "tikv_pd_keep_alive_timeout_total",
+            "Total number of pd keep alive timeout."
+        ).unwrap();
+
     pub static ref STORE_SIZE_GAUGE_VEC: GaugeVec =
         register_gauge_vec!(
             "tikv_store_size_bytes",

--- a/src/pd/mod.rs
+++ b/src/pd/mod.rs
@@ -25,6 +25,9 @@ pub use self::pd::{Runner as PdRunner, Task as PdTask};
 pub use self::util::RECONNECT_INTERVAL_SEC;
 pub use self::config::Config;
 
+// Do not export it if we find a better way to test the keep alive.
+pub use self::metrics::KEEP_ALIVE_TIMEOUT_COUNTER;
+
 use std::ops::Deref;
 
 use kvproto::metapb;


### PR DESCRIPTION
To keep alive, PD sends region heartbeats periodically. If the client finds that it miss region heartbeats for a long time, it increases a metric counter for alerting.