### PR TITLE
tune default snapshot io limitation

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -61,7 +61,7 @@
 
 # the max bytes that snapshot can be written to disk in one second,
 # should be set based on your disk performance
-# snap-max-write-bytes-per-sec = "30MB"
+# snap-max-write-bytes-per-sec = "100MB"
 
 # set attributes about this server, e.g. { zone = "us-west-1", disk = "ssd" }.
 # labels = {}

--- a/src/util/io_limiter.rs
+++ b/src/util/io_limiter.rs
@@ -21,7 +21,7 @@ const PRIORITY_HIGH: u8 = 1;
 const REFILL_PERIOD: i64 = 100 * 1000;
 const FARENESS: i32 = 10;
 const SNAP_MAX_BYTES_PER_TIME: i64 = 4 * 1024 * 1024;
-pub const DEFAULT_SNAP_MAX_BYTES_PER_SEC: u64 = 30 * 1024 * 1024;
+pub const DEFAULT_SNAP_MAX_BYTES_PER_SEC: u64 = 100 * 1024 * 1024;
 
 pub struct IOLimiter {
     inner: RateLimiter,


### PR DESCRIPTION
The formal default value for snapshot IO is too conservative. BTW this pr is not related to reducing memory usage.