### PR TITLE
separate read pool config and name_prefix

### DIFF
--- a/benches/bin/mvcc.rs
+++ b/benches/bin/mvcc.rs
@@ -28,7 +28,7 @@ use super::print_result;
 /// In mvcc kv is not actually deleted, which may cause performance issue
 /// when doing scan.
 fn bench_tombstone_scan() -> BenchSamples {
-    let read_pool = ReadPool::new(&readpool::Config::default_for_test(), || {
+    let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
         || storage::ReadPoolContext::new(None)
     });
     let store = SyncStorage::new(&Default::default(), read_pool);

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -10,7 +10,7 @@
 # file to store log, write to stderr if it's empty.
 # log-file = ""
 
-[readpool]
+[readpool.storage]
 # size of thread pool for high-priority read operations
 # high-concurrency = 8
 # size of thread pool for normal-priority read operations

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -194,11 +194,11 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
             .unwrap_or_else(|s| fatal!("failed to create kv engine: {:?}", s)),
     );
     let pd_sender = pd_worker.scheduler();
-    let read_pool = ReadPool::new(&cfg.readpool, || {
+    let storage_read_pool = ReadPool::new("store-read", &cfg.readpool.storage, || {
         let pd_sender = pd_sender.clone();
         move || storage::ReadPoolContext::new(Some(pd_sender.clone()))
     });
-    let mut storage = create_raft_storage(raft_router.clone(), &cfg.storage, read_pool)
+    let mut storage = create_raft_storage(raft_router.clone(), &cfg.storage, storage_read_pool)
         .unwrap_or_else(|e| fatal!("failed to create raft stroage: {:?}", e));
 
     // Create raft engine.

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,7 +28,7 @@ use sys_info;
 
 use import::Config as ImportConfig;
 use server::Config as ServerConfig;
-use server::readpool::Config as ReadPoolConfig;
+use server::readpool::Config as ReadPoolInstanceConfig;
 use pd::Config as PdConfig;
 use raftstore::coprocessor::Config as CopConfig;
 use raftstore::store::Config as RaftstoreConfig;
@@ -649,6 +649,21 @@ pub enum LogLevel {
     Warn,
     Error,
     Off,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+#[serde(default)]
+#[serde(rename_all = "kebab-case")]
+pub struct ReadPoolConfig {
+    pub storage: ReadPoolInstanceConfig,
+}
+
+impl Default for ReadPoolConfig {
+    fn default() -> ReadPoolConfig {
+        ReadPoolConfig {
+            storage: ReadPoolInstanceConfig::default(),
+        }
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -263,7 +263,7 @@ mod tests {
         let storage_cfg = StorageConfig::default();
         cfg.addr = "127.0.0.1:0".to_owned();
 
-        let read_pool = ReadPool::new(&readpool::Config::default_for_test(), || {
+        let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
             || storage::ReadPoolContext::new(None)
         });
         let mut storage = Storage::new(&storage_cfg, read_pool).unwrap();

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1204,7 +1204,7 @@ mod tests {
 
     #[test]
     fn test_get_put() {
-        let read_pool = ReadPool::new(&readpool::Config::default_for_test(), || {
+        let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
             read_pool_context_factory
         });
         let config = Config::default();
@@ -1253,7 +1253,7 @@ mod tests {
 
     #[test]
     fn test_put_with_err() {
-        let read_pool = ReadPool::new(&readpool::Config::default_for_test(), || {
+        let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
             read_pool_context_factory
         });
         let config = Config::default();
@@ -1282,7 +1282,7 @@ mod tests {
 
     #[test]
     fn test_scan() {
-        let read_pool = ReadPool::new(&readpool::Config::default_for_test(), || {
+        let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
             read_pool_context_factory
         });
         let config = Config::default();
@@ -1335,7 +1335,7 @@ mod tests {
 
     #[test]
     fn test_batch_get() {
-        let read_pool = ReadPool::new(&readpool::Config::default_for_test(), || {
+        let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
             read_pool_context_factory
         });
         let config = Config::default();
@@ -1391,7 +1391,7 @@ mod tests {
 
     #[test]
     fn test_txn() {
-        let read_pool = ReadPool::new(&readpool::Config::default_for_test(), || {
+        let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
             read_pool_context_factory
         });
         let config = Config::default();
@@ -1468,7 +1468,7 @@ mod tests {
 
     #[test]
     fn test_sched_too_busy() {
-        let read_pool = ReadPool::new(&readpool::Config::default_for_test(), || {
+        let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
             read_pool_context_factory
         });
         let mut config = Config::default();
@@ -1519,7 +1519,7 @@ mod tests {
 
     #[test]
     fn test_cleanup() {
-        let read_pool = ReadPool::new(&readpool::Config::default_for_test(), || {
+        let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
             read_pool_context_factory
         });
         let config = Config::default();
@@ -1556,7 +1556,7 @@ mod tests {
 
     #[test]
     fn test_high_priority_get_put() {
-        let read_pool = ReadPool::new(&readpool::Config::default_for_test(), || {
+        let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
             read_pool_context_factory
         });
         let config = Config::default();
@@ -1605,7 +1605,7 @@ mod tests {
 
     #[test]
     fn test_high_priority_no_block() {
-        let read_pool = ReadPool::new(&readpool::Config::default_for_test(), || {
+        let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
             read_pool_context_factory
         });
         let mut config = Config::default();
@@ -1657,7 +1657,7 @@ mod tests {
 
     #[test]
     fn test_delete_range() {
-        let read_pool = ReadPool::new(&readpool::Config::default_for_test(), || {
+        let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
             read_pool_context_factory
         });
         let config = Config::default();

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -19,7 +19,7 @@ use log::LogLevelFilter;
 use rocksdb::{CompactionPriority, DBCompressionType, DBRecoveryMode};
 use tikv::pd::Config as PdConfig;
 use tikv::server::Config as ServerConfig;
-use tikv::server::readpool::Config as ReadPoolConfig;
+use tikv::server::readpool::Config as ReadPoolInstanceConfig;
 use tikv::raftstore::store::Config as RaftstoreConfig;
 use tikv::raftstore::coprocessor::Config as CopConfig;
 use tikv::config::*;
@@ -76,13 +76,15 @@ fn test_serde_custom_tikv_config() {
         snap_max_total_size: ReadableSize::gb(10),
     };
     value.readpool = ReadPoolConfig {
-        high_concurrency: 1,
-        normal_concurrency: 3,
-        low_concurrency: 7,
-        max_tasks_high: 10000,
-        max_tasks_normal: 20000,
-        max_tasks_low: 30000,
-        stack_size: ReadableSize::mb(20),
+        storage: ReadPoolInstanceConfig {
+            high_concurrency: 1,
+            normal_concurrency: 3,
+            low_concurrency: 7,
+            max_tasks_high: 10000,
+            max_tasks_normal: 20000,
+            max_tasks_low: 30000,
+            stack_size: ReadableSize::mb(20),
+        },
     };
     value.metric = MetricConfig {
         interval: ReadableDuration::secs(12),

--- a/tests/config/test-custom.toml
+++ b/tests/config/test-custom.toml
@@ -1,7 +1,6 @@
 log-level = "debug"
 log-file = "foo"
-
-[readpool]
+[readpool.storage]
 high-concurrency = 1
 normal-concurrency = 3
 low-concurrency = 7

--- a/tests/coprocessor/test_select.rs
+++ b/tests/coprocessor/test_select.rs
@@ -375,7 +375,7 @@ pub struct Store {
 
 impl Store {
     fn new(engine: Box<Engine>) -> Store {
-        let read_pool = ReadPool::new(&readpool::Config::default_for_test(), || {
+        let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
             || storage::ReadPoolContext::new(None)
         });
         Store {

--- a/tests/failpoints_cases/test_storage.rs
+++ b/tests/failpoints_cases/test_storage.rs
@@ -30,7 +30,7 @@ fn test_storage_1gc() {
     let snapshot_fp = "raftkv_async_snapshot_finish";
     let batch_snapshot_fp = "raftkv_async_batch_snapshot_finish";
     let (_cluster, engine, ctx) = new_raft_engine(3, "");
-    let read_pool = ReadPool::new(&readpool::Config::default_for_test(), || {
+    let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
         || storage::ReadPoolContext::new(None)
     });
     let config = Config::default();
@@ -75,7 +75,7 @@ fn test_scheduler_leader_change_twice() {
     let peers = region0.get_peers();
     cluster.must_transfer_leader(region0.get_id(), peers[0].clone());
     let config = Config::default();
-    let read_pool = ReadPool::new(&readpool::Config::default_for_test(), || {
+    let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
         || storage::ReadPoolContext::new(None)
     });
 
@@ -125,7 +125,7 @@ fn test_scheduler_leader_change_twice() {
         cluster.must_transfer_leader(region1.get_id(), peers[1].clone());
 
         let engine1 = cluster.sim.rl().storages[&peers[1].get_id()].clone();
-        let read_pool = ReadPool::new(&readpool::Config::default_for_test(), || {
+        let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
             || storage::ReadPoolContext::new(None)
         });
         let mut storage1 = Storage::from_engine(engine1, &config, read_pool).unwrap();

--- a/tests/raftstore/server.rs
+++ b/tests/raftstore/server.rs
@@ -121,7 +121,9 @@ impl Simulator for ServerCluster {
         let (engines, path) = create_test_engine(engines, store_sendch.clone(), &cfg);
 
         // Create storage.
-        let read_pool = ReadPool::new(&cfg.readpool, || || storage::ReadPoolContext::new(None));
+        let read_pool = ReadPool::new("readpool", &cfg.readpool.storage, || {
+            || storage::ReadPoolContext::new(None)
+        });
         let mut store = create_raft_storage(sim_router.clone(), &cfg.storage, read_pool).unwrap();
         store.start(&cfg.storage).unwrap();
         self.storages.insert(node_id, store.get_engine());

--- a/tests/raftstore/util.rs
+++ b/tests/raftstore/util.rs
@@ -30,12 +30,12 @@ use kvproto::eraftpb::ConfChangeType;
 use tikv::raftstore::store::*;
 use tikv::raftstore::{Error, Result};
 use tikv::server::Config as ServerConfig;
-use tikv::server::readpool::Config as ReadPoolConfig;
+use tikv::server::readpool::Config as ReadPoolInstanceConfig;
 use tikv::storage::{Config as StorageConfig, CF_DEFAULT};
 use tikv::util::escape;
 use tikv::util::rocksdb::{self, CompactionListener};
 use tikv::util::config::*;
-use tikv::config::TiKvConfig;
+use tikv::config::{ReadPoolConfig, TiKvConfig};
 use tikv::util::transport::SendCh;
 use tikv::raftstore::store::Msg as StoreMsg;
 
@@ -124,7 +124,9 @@ pub fn new_server_config(cluster_id: u64) -> ServerConfig {
 }
 
 pub fn new_readpool_cfg() -> ReadPoolConfig {
-    ReadPoolConfig::default_for_test()
+    ReadPoolConfig {
+        storage: ReadPoolInstanceConfig::default_for_test(),
+    }
 }
 
 pub fn new_tikv_config(cluster_id: u64) -> TiKvConfig {

--- a/tests/storage/assert_storage.rs
+++ b/tests/storage/assert_storage.rs
@@ -32,7 +32,7 @@ pub struct AssertionStorage {
 
 impl Default for AssertionStorage {
     fn default() -> AssertionStorage {
-        let read_pool = ReadPool::new(&readpool::Config::default_for_test(), || {
+        let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
             || storage::ReadPoolContext::new(None)
         });
         AssertionStorage {
@@ -67,7 +67,7 @@ impl AssertionStorage {
         self.ctx.set_region_id(region.get_id());
         self.ctx.set_region_epoch(region.get_region_epoch().clone());
         self.ctx.set_peer(leader.clone());
-        let read_pool = ReadPool::new(&readpool::Config::default_for_test(), || {
+        let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
             || storage::ReadPoolContext::new(None)
         });
         self.store = SyncStorage::from_engine(engine, &Config::default(), read_pool);

--- a/tests/storage/util.rs
+++ b/tests/storage/util.rs
@@ -40,7 +40,7 @@ pub fn new_raft_storage_with_store_count(
     count: usize,
     key: &str,
 ) -> (Cluster<ServerCluster>, SyncStorage, Context) {
-    let read_pool = ReadPool::new(&readpool::Config::default_for_test(), || {
+    let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
         || storage::ReadPoolContext::new(None)
     });
     let (cluster, engine, ctx) = new_raft_engine(count, key);

--- a/tests/storage_cases/test_storage.rs
+++ b/tests/storage_cases/test_storage.rs
@@ -862,7 +862,7 @@ fn bench_txn_store_rocksdb_put_x100(b: &mut Bencher) {
 fn test_conflict_commands_on_fault_engine() {
     let engine = EngineRocksdb::new(TEMP_DIR, ALL_CFS, None).unwrap();
     let box_engine = engine.clone();
-    let read_pool = ReadPool::new(&readpool::Config::default_for_test(), || {
+    let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
         || storage::ReadPoolContext::new(None)
     });
     let config = Default::default();


### PR DESCRIPTION
Since we will have different read pool instances for storage and coprocessor, config and thread name prefix should be separated.