### PR TITLE
raftstore/config: support merge

### DIFF
--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -95,6 +95,11 @@ pub struct Config {
 
     pub allow_remove_leader: bool,
 
+    /// Max log gap allowed to propose merge.
+    pub max_merge_log_gap: u64,
+    // Interval to repropose merge.
+    pub merge_check_tick_interval: ReadableDuration,
+
     pub use_delete_range: bool,
 
     // Deprecated! These two configuration has been moved to Coprocessor.
@@ -149,6 +154,8 @@ impl Default for Config {
             raft_store_max_leader_lease: ReadableDuration::secs(9),
             right_derive_when_split: true,
             allow_remove_leader: false,
+            max_merge_log_gap: 10,
+            merge_check_tick_interval: ReadableDuration::secs(10),
             use_delete_range: false,
 
             // They are preserved for compatibility check.
@@ -205,6 +212,18 @@ impl Config {
                 election_timeout,
                 lease
             ));
+        }
+
+        if self.max_merge_log_gap >= self.raft_log_gc_count_limit {
+            return Err(box_err!(
+                "merge log gap {} should be less than log gc limit {}.",
+                self.max_merge_log_gap,
+                self.raft_log_gc_count_limit
+            ));
+        }
+
+        if self.merge_check_tick_interval.as_millis() == 0 {
+            return Err(box_err!("raftstore.merge-check-tick-interval can't be 0."));
         }
 
         let abnormal_leader_missing = self.abnormal_leader_missing_duration.as_millis() as u64;
@@ -266,6 +285,14 @@ mod tests {
         assert!(cfg.validate().is_err());
 
         cfg = Config::new();
+        cfg.raft_log_gc_count_limit = 100;
+        cfg.max_merge_log_gap = 110;
+        assert!(cfg.validate().is_err());
+
+        cfg = Config::new();
+        cfg.merge_check_tick_interval = ReadableDuration::secs(0);
+        assert!(cfg.validate().is_err());
+
         cfg.raft_base_tick_interval = ReadableDuration::secs(1);
         cfg.raft_election_timeout_ticks = 10;
         cfg.abnormal_leader_missing_duration = ReadableDuration::secs(5);

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -96,7 +96,7 @@ pub struct Config {
     pub allow_remove_leader: bool,
 
     /// Max log gap allowed to propose merge.
-    pub max_merge_log_gap: u64,
+    pub merge_max_log_gap: u64,
     // Interval to repropose merge.
     pub merge_check_tick_interval: ReadableDuration,
 
@@ -154,7 +154,7 @@ impl Default for Config {
             raft_store_max_leader_lease: ReadableDuration::secs(9),
             right_derive_when_split: true,
             allow_remove_leader: false,
-            max_merge_log_gap: 10,
+            merge_max_log_gap: 10,
             merge_check_tick_interval: ReadableDuration::secs(10),
             use_delete_range: false,
 
@@ -214,10 +214,10 @@ impl Config {
             ));
         }
 
-        if self.max_merge_log_gap >= self.raft_log_gc_count_limit {
+        if self.merge_max_log_gap >= self.raft_log_gc_count_limit {
             return Err(box_err!(
                 "merge log gap {} should be less than log gc limit {}.",
-                self.max_merge_log_gap,
+                self.merge_max_log_gap,
                 self.raft_log_gc_count_limit
             ));
         }
@@ -286,7 +286,7 @@ mod tests {
 
         cfg = Config::new();
         cfg.raft_log_gc_count_limit = 100;
-        cfg.max_merge_log_gap = 110;
+        cfg.merge_max_log_gap = 110;
         assert!(cfg.validate().is_err());
 
         cfg = Config::new();

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -97,7 +97,7 @@ pub struct Config {
 
     /// Max log gap allowed to propose merge.
     pub merge_max_log_gap: u64,
-    // Interval to repropose merge.
+    /// Interval to repropose merge.
     pub merge_check_tick_interval: ReadableDuration,
 
     pub use_delete_range: bool,

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -126,6 +126,8 @@ fn test_serde_custom_tikv_config() {
         raft_store_max_leader_lease: ReadableDuration::secs(12),
         right_derive_when_split: false,
         allow_remove_leader: true,
+        max_merge_log_gap: 3,
+        merge_check_tick_interval: ReadableDuration::secs(11),
         use_delete_range: true,
         region_max_size: ReadableSize(0),
         region_split_size: ReadableSize(0),

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -126,7 +126,7 @@ fn test_serde_custom_tikv_config() {
         raft_store_max_leader_lease: ReadableDuration::secs(12),
         right_derive_when_split: false,
         allow_remove_leader: true,
-        max_merge_log_gap: 3,
+        merge_max_log_gap: 3,
         merge_check_tick_interval: ReadableDuration::secs(11),
         use_delete_range: true,
         region_max_size: ReadableSize(0),

--- a/tests/config/test-custom.toml
+++ b/tests/config/test-custom.toml
@@ -85,7 +85,7 @@ report-region-flow-interval = "12m"
 raft-store-max-leader-lease = "12s"
 right-derive-when-split = false
 allow-remove-leader = true
-max-merge-log-gap = 3
+merge-max-log-gap = 3
 merge-check-tick-interval = "11s"
 use-delete-range = true
 

--- a/tests/config/test-custom.toml
+++ b/tests/config/test-custom.toml
@@ -85,6 +85,8 @@ report-region-flow-interval = "12m"
 raft-store-max-leader-lease = "12s"
 right-derive-when-split = false
 allow-remove-leader = true
+max-merge-log-gap = 3
+merge-check-tick-interval = "11s"
 use-delete-range = true
 
 [coprocessor]

--- a/tests/raftstore_cases/test_snap.rs
+++ b/tests/raftstore_cases/test_snap.rs
@@ -105,6 +105,7 @@ fn test_snap_gc<T: Simulator>(cluster: &mut Cluster<T>) {
     // truncate the log quickly so that we can force sending snapshot.
     cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::millis(20);
     cluster.cfg.raft_store.raft_log_gc_count_limit = 2;
+    cluster.cfg.raft_store.max_merge_log_gap = 1;
     cluster.cfg.raft_store.snap_mgr_gc_tick_interval = ReadableDuration::millis(50);
     cluster.cfg.raft_store.snap_gc_timeout = ReadableDuration::millis(2);
 
@@ -262,6 +263,7 @@ fn test_cf_snapshot<T: Simulator>(cluster: &mut Cluster<T>) {
     // truncate the log quickly so that we can force sending snapshot.
     cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::millis(20);
     cluster.cfg.raft_store.raft_log_gc_count_limit = 2;
+    cluster.cfg.raft_store.max_merge_log_gap = 1;
     cluster.cfg.raft_store.snap_mgr_gc_tick_interval = ReadableDuration::millis(50);
 
     cluster.run();
@@ -435,6 +437,7 @@ fn test_snapshot_with_append<T: Simulator>(cluster: &mut Cluster<T>) {
     // truncate the log quickly so that we can force sending snapshot.
     cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::millis(20);
     cluster.cfg.raft_store.raft_log_gc_count_limit = 2;
+    cluster.cfg.raft_store.max_merge_log_gap = 1;
     cluster.cfg.raft_store.snap_mgr_gc_tick_interval = ReadableDuration::millis(50);
 
     let pd_client = Arc::clone(&cluster.pd_client);

--- a/tests/raftstore_cases/test_snap.rs
+++ b/tests/raftstore_cases/test_snap.rs
@@ -30,6 +30,14 @@ use super::node::new_node_cluster;
 use super::server::new_server_cluster;
 use super::util::*;
 
+fn configure_for_snapshot<T: Simulator>(cluster: &mut Cluster<T>) {
+    // truncate the log quickly so that we can force sending snapshot.
+    cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::millis(20);
+    cluster.cfg.raft_store.raft_log_gc_count_limit = 2;
+    cluster.cfg.raft_store.merge_max_log_gap = 1;
+    cluster.cfg.raft_store.snap_mgr_gc_tick_interval = ReadableDuration::millis(50);
+}
+
 fn test_huge_snapshot<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.cfg.raft_store.raft_log_gc_count_limit = 1000;
     cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::millis(10);
@@ -102,11 +110,7 @@ fn test_server_huge_snapshot() {
 }
 
 fn test_snap_gc<T: Simulator>(cluster: &mut Cluster<T>) {
-    // truncate the log quickly so that we can force sending snapshot.
-    cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::millis(20);
-    cluster.cfg.raft_store.raft_log_gc_count_limit = 2;
-    cluster.cfg.raft_store.max_merge_log_gap = 1;
-    cluster.cfg.raft_store.snap_mgr_gc_tick_interval = ReadableDuration::millis(50);
+    configure_for_snapshot(cluster);
     cluster.cfg.raft_store.snap_gc_timeout = ReadableDuration::millis(2);
 
     let pd_client = Arc::clone(&cluster.pd_client);
@@ -260,11 +264,7 @@ fn test_server_concurrent_snap() {
 }
 
 fn test_cf_snapshot<T: Simulator>(cluster: &mut Cluster<T>) {
-    // truncate the log quickly so that we can force sending snapshot.
-    cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::millis(20);
-    cluster.cfg.raft_store.raft_log_gc_count_limit = 2;
-    cluster.cfg.raft_store.max_merge_log_gap = 1;
-    cluster.cfg.raft_store.snap_mgr_gc_tick_interval = ReadableDuration::millis(50);
+    configure_for_snapshot(cluster);
 
     cluster.run();
     let cf = "lock";
@@ -434,11 +434,7 @@ impl Filter<Msg> for SnapshotAppendFilter {
 }
 
 fn test_snapshot_with_append<T: Simulator>(cluster: &mut Cluster<T>) {
-    // truncate the log quickly so that we can force sending snapshot.
-    cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::millis(20);
-    cluster.cfg.raft_store.raft_log_gc_count_limit = 2;
-    cluster.cfg.raft_store.max_merge_log_gap = 1;
-    cluster.cfg.raft_store.snap_mgr_gc_tick_interval = ReadableDuration::millis(50);
+    configure_for_snapshot(cluster);
 
     let pd_client = Arc::clone(&cluster.pd_client);
     // Disable default max peer count check.

--- a/tests/raftstore_cases/test_split_region.rs
+++ b/tests/raftstore_cases/test_split_region.rs
@@ -431,7 +431,7 @@ fn test_apply_new_version_snapshot<T: Simulator>(cluster: &mut Cluster<T>) {
     // truncate the log quickly so that we can force sending snapshot.
     cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::millis(20);
     cluster.cfg.raft_store.raft_log_gc_count_limit = 5;
-    cluster.cfg.raft_store.max_merge_log_gap = 1;
+    cluster.cfg.raft_store.merge_max_log_gap = 1;
     cluster.cfg.raft_store.raft_log_gc_threshold = 5;
 
     // We use three nodes([1, 2, 3]) for this test.

--- a/tests/raftstore_cases/test_split_region.rs
+++ b/tests/raftstore_cases/test_split_region.rs
@@ -431,6 +431,7 @@ fn test_apply_new_version_snapshot<T: Simulator>(cluster: &mut Cluster<T>) {
     // truncate the log quickly so that we can force sending snapshot.
     cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::millis(20);
     cluster.cfg.raft_store.raft_log_gc_count_limit = 5;
+    cluster.cfg.raft_store.max_merge_log_gap = 1;
     cluster.cfg.raft_store.raft_log_gc_threshold = 5;
 
     // We use three nodes([1, 2, 3]) for this test.

--- a/tests/raftstore_cases/test_transfer_leader.rs
+++ b/tests/raftstore_cases/test_transfer_leader.rs
@@ -145,6 +145,7 @@ fn test_transfer_leader_during_snapshot<T: Simulator>(cluster: &mut Cluster<T>) 
     pd_client.disable_default_rule();
     cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::millis(20);
     cluster.cfg.raft_store.raft_log_gc_count_limit = 2;
+    cluster.cfg.raft_store.max_merge_log_gap = 1;
 
     let r1 = cluster.run_conf_change();
     pd_client.must_add_peer(r1, new_peer(2, 2));

--- a/tests/raftstore_cases/test_transfer_leader.rs
+++ b/tests/raftstore_cases/test_transfer_leader.rs
@@ -145,7 +145,7 @@ fn test_transfer_leader_during_snapshot<T: Simulator>(cluster: &mut Cluster<T>) 
     pd_client.disable_default_rule();
     cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::millis(20);
     cluster.cfg.raft_store.raft_log_gc_count_limit = 2;
-    cluster.cfg.raft_store.max_merge_log_gap = 1;
+    cluster.cfg.raft_store.merge_max_log_gap = 1;
 
     let r1 = cluster.run_conf_change();
     pd_client.must_add_peer(r1, new_peer(2, 2));


### PR DESCRIPTION
This pr adds configuration entries for merge. Actual implementation see #2502.