### PR TITLE
Implement checksum push down request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,7 +1094,7 @@ dependencies = [
 [[package]]
 name = "tipb"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/tipb.git#b7be7b8a36454b0361b5b2ffc539a0b8f11cde07"
+source = "git+https://github.com/pingcap/tipb.git#a4cb837b2f797f54d3b2bbb3da47dd15af14de7d"
 dependencies = [
  "protobuf 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/coprocessor/checksum.rs
+++ b/src/coprocessor/checksum.rs
@@ -1,0 +1,119 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::vec::IntoIter;
+
+use crc::crc64::{self, Digest, Hasher64};
+use protobuf::Message;
+use kvproto::coprocessor::{KeyRange, Response};
+use tipb::checksum::{ChecksumAlgorithm, ChecksumRequest, ChecksumResponse, ChecksumScanOn};
+
+use storage::{Snapshot, SnapshotStore};
+
+use super::{Error, Result};
+use super::endpoint::ReqContext;
+use super::dag::executor::{ScanOn, Scanner};
+
+// `ChecksumContext` is used to handle `ChecksumRequest`
+pub struct ChecksumContext {
+    req: ChecksumRequest,
+    store: SnapshotStore,
+    ranges: IntoIter<KeyRange>,
+    scanner: Option<Scanner>,
+}
+
+impl ChecksumContext {
+    pub fn new(
+        req: ChecksumRequest,
+        ranges: Vec<KeyRange>,
+        snap: Box<Snapshot>,
+        ctx: &ReqContext,
+    ) -> ChecksumContext {
+        let store = SnapshotStore::new(
+            snap,
+            req.get_start_ts(),
+            ctx.isolation_level,
+            ctx.fill_cache,
+        );
+        ChecksumContext {
+            req: req,
+            store: store,
+            ranges: ranges.into_iter(),
+            scanner: None,
+        }
+    }
+
+    pub fn handle_request(mut self) -> Result<Response> {
+        let algorithm = self.req.get_algorithm();
+        if algorithm != ChecksumAlgorithm::Crc64_Xor {
+            return Err(box_err!("unknown checksum algorithm {:?}", algorithm));
+        }
+
+        let mut checksum = 0;
+        let mut total_kvs = 0;
+        let mut total_bytes = 0;
+        while let Some((k, v)) = self.next_row()? {
+            checksum = checksum_crc64_xor(checksum, &k, &v);
+            total_kvs += 1;
+            total_bytes += k.len() + v.len();
+        }
+
+        let mut resp = ChecksumResponse::new();
+        resp.set_checksum(checksum);
+        resp.set_total_kvs(total_kvs);
+        resp.set_total_bytes(total_bytes as u64);
+        let data = box_try!(resp.write_to_bytes());
+
+        let mut resp = Response::new();
+        resp.set_data(data);
+        Ok(resp)
+    }
+
+    fn new_scanner(&self, range: KeyRange) -> Result<Scanner> {
+        let scan_on = match self.req.get_scan_on() {
+            ChecksumScanOn::Table => ScanOn::Table,
+            ChecksumScanOn::Index => ScanOn::Index,
+        };
+        Scanner::new(&self.store, scan_on, false, false, range).map_err(Error::from)
+    }
+
+    fn next_row(&mut self) -> Result<Option<(Vec<u8>, Vec<u8>)>> {
+        loop {
+            if let Some(scanner) = self.scanner.as_mut() {
+                if let Some(row) = scanner.next_row()? {
+                    return Ok(Some(row));
+                }
+            }
+
+            if let Some(range) = self.ranges.next() {
+                self.scanner = match self.scanner.take() {
+                    Some(mut scanner) => {
+                        box_try!(scanner.reset_range(range, &self.store));
+                        Some(scanner)
+                    }
+                    None => Some(self.new_scanner(range)?),
+                };
+                continue;
+            }
+
+            return Ok(None);
+        }
+    }
+}
+
+fn checksum_crc64_xor(checksum: u64, k: &[u8], v: &[u8]) -> u64 {
+    let mut digest = Digest::new(crc64::ECMA);
+    digest.write(k);
+    digest.write(v);
+    checksum ^ digest.sum64()
+}

--- a/src/coprocessor/dag/mod.rs
+++ b/src/coprocessor/dag/mod.rs
@@ -10,7 +10,10 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 pub mod executor;
 pub mod dag;
 pub mod expr;
+
 pub use self::dag::DAGContext;
+pub use self::executor::{ScanOn, Scanner};

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -15,6 +15,7 @@ mod endpoint;
 mod metrics;
 mod dag;
 mod statistics;
+mod checksum;
 pub mod local_metrics;
 pub mod codec;
 
@@ -87,4 +88,6 @@ impl From<txn::Error> for Error {
 }
 
 pub use self::endpoint::{Host as EndPointHost, RequestTask, Task as EndPointTask,
-                         DEFAULT_REQUEST_MAX_HANDLE_SECS, REQ_TYPE_DAG, SINGLE_GROUP};
+                         DEFAULT_REQUEST_MAX_HANDLE_SECS, REQ_TYPE_CHECKSUM, REQ_TYPE_DAG,
+                         SINGLE_GROUP};
+pub use self::dag::{ScanOn, Scanner};

--- a/tests/coprocessor/mod.rs
+++ b/tests/coprocessor/mod.rs
@@ -13,3 +13,4 @@
 
 mod test_select;
 mod test_analyze;
+mod test_checksum;

--- a/tests/coprocessor/test_checksum.rs
+++ b/tests/coprocessor/test_checksum.rs
@@ -62,7 +62,7 @@ fn test_checksum() {
             (range, ChecksumScanOn::Index)
         };
         let request = new_checksum_request(range.clone(), scan_on);
-        let expected = checksum_crc64_xor(&store, range, scan_on);
+        let expected = reversed_checksum_crc64_xor(&store, range, scan_on);
 
         let response = handle_request(&end_point, request);
         let mut resp = ChecksumResponse::new();
@@ -72,7 +72,7 @@ fn test_checksum() {
     }
 }
 
-fn checksum_crc64_xor(store: &Store, range: KeyRange, scan_on: ChecksumScanOn) -> u64 {
+fn reversed_checksum_crc64_xor(store: &Store, range: KeyRange, scan_on: ChecksumScanOn) -> u64 {
     use crc::crc64::{self, Digest, Hasher64};
 
     let ctx = Context::new();

--- a/tests/coprocessor/test_checksum.rs
+++ b/tests/coprocessor/test_checksum.rs
@@ -1,0 +1,105 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::u64;
+
+use protobuf::Message;
+use kvproto::coprocessor::{KeyRange, Request};
+use kvproto::kvrpcpb::{Context, IsolationLevel};
+use tipb::checksum::{ChecksumAlgorithm, ChecksumRequest, ChecksumResponse, ChecksumScanOn};
+
+use tikv::coprocessor::*;
+use tikv::storage::SnapshotStore;
+
+use super::test_select::*;
+
+fn new_checksum_request(range: KeyRange, scan_on: ChecksumScanOn) -> Request {
+    let mut ctx = Context::new();
+    ctx.set_isolation_level(IsolationLevel::SI);
+
+    let mut checksum = ChecksumRequest::new();
+    checksum.set_start_ts(u64::MAX);
+    checksum.set_scan_on(scan_on);
+    checksum.set_algorithm(ChecksumAlgorithm::Crc64_Xor);
+
+    let mut req = Request::new();
+    req.set_context(ctx);
+    req.set_tp(REQ_TYPE_CHECKSUM);
+    req.set_data(checksum.write_to_bytes().unwrap());
+    req.mut_ranges().push(range);
+    req
+}
+
+#[test]
+fn test_checksum() {
+    let data = vec![
+        (1, Some("name:1"), 1),
+        (2, Some("name:2"), 2),
+        (3, Some("name:3"), 3),
+        (4, Some("name:4"), 4),
+    ];
+
+    let product = ProductTable::new();
+    let (store, end_point) = init_data_with_commit(&product, &data, true);
+
+    for column in &[product.id, product.name, product.count] {
+        assert!(column.index >= 0);
+        let (range, scan_on) = if column.index == 0 {
+            let range = product.table.get_select_range();
+            (range, ChecksumScanOn::Table)
+        } else {
+            let range = product.table.get_index_range(column.index);
+            (range, ChecksumScanOn::Index)
+        };
+        let request = new_checksum_request(range.clone(), scan_on);
+        let expected = checksum_crc64_xor(&store, range, scan_on);
+
+        let response = handle_request(&end_point, request);
+        let mut resp = ChecksumResponse::new();
+        resp.merge_from_bytes(response.get_data()).unwrap();
+        assert_eq!(resp.get_checksum(), expected);
+        assert_eq!(resp.get_total_kvs(), data.len() as u64);
+    }
+}
+
+fn checksum_crc64_xor(store: &Store, range: KeyRange, scan_on: ChecksumScanOn) -> u64 {
+    use crc::crc64::{self, Digest, Hasher64};
+
+    let ctx = Context::new();
+    let snap = SnapshotStore::new(
+        store.get_engine().snapshot(&ctx).unwrap(),
+        u64::MAX,
+        IsolationLevel::SI,
+        true,
+    );
+    let scan_on = match scan_on {
+        ChecksumScanOn::Table => ScanOn::Table,
+        ChecksumScanOn::Index => ScanOn::Index,
+    };
+    let mut scanner = Scanner::new(
+        &snap,
+        scan_on,
+        true, // Scan in reversed order.
+        false,
+        range,
+    ).unwrap();
+
+    let mut checksum = 0;
+    while let Some((k, v)) = scanner.next_row().unwrap() {
+        let mut digest = Digest::new(crc64::ECMA);
+        digest.write(&k);
+        digest.write(&v);
+        checksum ^= digest.sum64();
+    }
+    checksum
+}

--- a/tests/coprocessor/test_select.rs
+++ b/tests/coprocessor/test_select.rs
@@ -388,7 +388,7 @@ impl Store {
         }
     }
 
-    fn get_engine(&self) -> Box<Engine> {
+    pub fn get_engine(&self) -> Box<Engine> {
         self.store.get_engine()
     }
 
@@ -445,7 +445,7 @@ fn build_row_key(table_id: i64, id: i64) -> Vec<u8> {
 
 /// An example table for test purpose.
 pub struct ProductTable {
-    id: Column,
+    pub id: Column,
     pub name: Column,
     pub count: Column,
     pub table: Table,

--- a/tests/integrations.rs
+++ b/tests/integrations.rs
@@ -24,6 +24,7 @@
 #![allow(needless_pass_by_value)]
 #![allow(unreadable_literal)]
 
+extern crate crc;
 extern crate futures;
 extern crate futures_cpupool;
 extern crate grpcio as grpc;


### PR DESCRIPTION
TiDB will support a new command "ADMIN CHECKSUM TABLE tablename", and push down the checksum calculation to TiKV.
The current implementation uses a simple order-independent algorithm to calculate a checksum from all key-values from a table, including records and indices. For every key-value, we first calculate a CRC64 checksum from (key + value), then we XOR all the CRC64 checksums together to get the final checksum.