### PR TITLE
speedup SnapshotStore.get

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1334,7 +1334,7 @@ mod tests {
         rx.recv().unwrap();
         expect_error(
             |e| match e {
-                Error::Txn(txn::Error::Mvcc(mvcc::Error::Engine(EngineError::Other(..)))) => (),
+                Error::Txn(txn::Error::Mvcc(mvcc::Error::Engine(EngineError::Request(..)))) => (),
                 e => panic!("unexpected error chain: {:?}", e),
             },
             storage.async_get(Context::new(), make_key(b"x"), 1).wait(),

--- a/src/storage/mvcc/reader.rs
+++ b/src/storage/mvcc/reader.rs
@@ -163,7 +163,7 @@ impl MvccReader {
         if self.scan_mode.is_some() {
             if self.write_cursor.is_none() {
                 let iter_opt = if self.use_prefix_seek {
-                    IterOption::default()
+                    IterOption::new(None, None, self.fill_cache)
                         .use_prefix_seek()
                         .set_prefix_same_as_start(true)
                 } else {

--- a/src/storage/mvcc/reader.rs
+++ b/src/storage/mvcc/reader.rs
@@ -38,6 +38,8 @@ pub struct MvccReader {
     lower_bound: Option<Vec<u8>>,
     upper_bound: Option<Vec<u8>>,
     isolation_level: IsolationLevel,
+    // set on when this reader is used for only one key and scan_mode is some.
+    use_prefix_seek: bool,
 }
 
 impl MvccReader {
@@ -48,6 +50,7 @@ impl MvccReader {
         lower_bound: Option<Vec<u8>>,
         upper_bound: Option<Vec<u8>>,
         isolation_level: IsolationLevel,
+        use_prefix_seek: bool,
     ) -> MvccReader {
         MvccReader {
             snapshot: snapshot,
@@ -61,6 +64,7 @@ impl MvccReader {
             fill_cache: fill_cache,
             lower_bound: lower_bound,
             upper_bound: upper_bound,
+            use_prefix_seek: use_prefix_seek,
         }
     }
 
@@ -158,7 +162,13 @@ impl MvccReader {
     ) -> Result<Option<(u64, Write)>> {
         if self.scan_mode.is_some() {
             if self.write_cursor.is_none() {
-                let iter_opt = IterOption::new(None, None, self.fill_cache);
+                let iter_opt = if self.use_prefix_seek {
+                    IterOption::default()
+                        .use_prefix_seek()
+                        .set_prefix_same_as_start(true)
+                } else {
+                    IterOption::new(None, None, self.fill_cache)
+                };
                 let iter = self.snapshot
                     .iter_cf(CF_WRITE, iter_opt, self.get_scan_mode(false))?;
                 self.write_cursor = Some(iter);
@@ -698,7 +708,15 @@ mod tests {
         need_gc: bool,
     ) -> Option<MvccProperties> {
         let snap = RegionSnapshot::from_raw(Arc::clone(&db), region.clone());
-        let reader = MvccReader::new(Box::new(snap), None, false, None, None, IsolationLevel::SI);
+        let reader = MvccReader::new(
+            Box::new(snap),
+            None,
+            false,
+            None,
+            None,
+            IsolationLevel::SI,
+            false,
+        );
         assert_eq!(reader.need_gc(safe_point, 1.0), need_gc);
         reader.get_mvcc_properties(safe_point)
     }

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -458,6 +458,7 @@ fn process_read(
                 None,
                 None,
                 ctx.get_isolation_level(),
+                true,
             );
             let res = match find_mvcc_infos_by_key(&mut reader, key, u64::MAX) {
                 Ok((lock, writes, values)) => ProcessResult::MvccKey {
@@ -480,6 +481,7 @@ fn process_read(
                 None,
                 None,
                 ctx.get_isolation_level(),
+                false,
             );
             let res = match reader.seek_ts(start_ts).map_err(StorageError::from) {
                 Err(e) => ProcessResult::Failed { err: e },
@@ -518,6 +520,7 @@ fn process_read(
                 None,
                 None,
                 ctx.get_isolation_level(),
+                false,
             );
             let res = reader
                 .scan_lock(start_key.take(), |lock| lock.ts <= max_ts, limit)
@@ -556,6 +559,7 @@ fn process_read(
                 None,
                 None,
                 ctx.get_isolation_level(),
+                false,
             );
             let res = reader
                 .scan_lock(
@@ -603,6 +607,7 @@ fn process_read(
                 None,
                 None,
                 ctx.get_isolation_level(),
+                false,
             );
             // scan_key is used as start_key here,and Range start gc with scan_key=none.
             let is_range_start_gc = scan_key.is_none();

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -335,6 +335,9 @@ mod test {
         let snapshot_store = store.store();
         let mut statistics = Statistics::default();
         let data = snapshot_store.get(&make_key(k), &mut statistics).unwrap();
+        assert_eq!(statistics.write.processed, 4);
+        assert_eq!(statistics.write.seek, 1);
+        assert_eq!(statistics.write.next, 3);
         assert_eq!(data.unwrap(), v1);
     }
 

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -311,7 +311,7 @@ mod test {
     }
 
     #[test]
-    fn test_snapshot_store_get_multiple_versions() {
+    fn test_snapshot_store_get_with_multi_rollback() {
         let mut store = TestStore::new(1);
         let k = b"k";
         let (v1, v2, v3, v4) = (b"v1", b"v2", b"v3", b"v4");

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -41,7 +41,7 @@ impl SnapshotStore {
     pub fn get(&self, key: &Key, statistics: &mut Statistics) -> Result<Option<Value>> {
         let mut reader = MvccReader::new(
             self.snapshot.clone(),
-            None,
+            Some(ScanMode::Forward),
             self.fill_cache,
             None,
             None,
@@ -177,7 +177,7 @@ mod test {
     use super::SnapshotStore;
     use storage::mvcc::MvccTxn;
     use storage::{make_key, KvPair, Mutation, Options, ScanMode, Statistics, Value, ALL_CFS};
-    use storage::engine::{self, Engine, Snapshot, TEMP_DIR};
+    use storage::engine::{self, Engine, Modify, Snapshot, TEMP_DIR};
 
     const KEY_PREFIX: &str = "key_prefix";
     const START_TS: u64 = 10;
@@ -230,7 +230,7 @@ mod test {
                         &Options::default(),
                     ).unwrap();
                 }
-                self.engine.write(&self.ctx, txn.into_modifies()).unwrap();
+                self.write(txn.into_modifies());
             }
             self.refresh_snapshot();
             // do commit
@@ -246,7 +246,7 @@ mod test {
                     let key = key.as_bytes();
                     txn.commit(&make_key(key), COMMIT_TS).unwrap();
                 }
-                self.engine.write(&self.ctx, txn.into_modifies()).unwrap();
+                self.write(txn.into_modifies());
             }
             self.refresh_snapshot();
         }
@@ -264,6 +264,37 @@ mod test {
                 true,
             )
         }
+
+        fn must_prewrite_put(&mut self, key: &[u8], value: &[u8], pk: &[u8], ts: u64) {
+            let snapshot = self.engine.snapshot(&self.ctx).unwrap();
+            let mut txn = MvccTxn::new(snapshot, ts, None, IsolationLevel::SI, true);
+            txn.prewrite(
+                Mutation::Put((make_key(key), value.to_vec())),
+                pk,
+                &Options::default(),
+            ).unwrap();
+            self.write(txn.into_modifies());
+        }
+
+        fn must_commit(&mut self, key: &[u8], start_ts: u64, commit_ts: u64) {
+            let snapshot = self.engine.snapshot(&self.ctx).unwrap();
+            let mut txn = MvccTxn::new(snapshot, start_ts, None, IsolationLevel::SI, true);
+            txn.commit(&make_key(key), commit_ts).unwrap();
+            self.write(txn.into_modifies());
+        }
+
+        fn must_rollback(&mut self, key: &[u8], start_ts: u64) {
+            let snapshot = self.engine.snapshot(&self.ctx).unwrap();
+            let mut txn = MvccTxn::new(snapshot, start_ts, None, IsolationLevel::SI, true);
+            txn.rollback(&make_key(key)).unwrap();
+            self.write(txn.into_modifies());
+        }
+
+        fn write(&mut self, modifies: Vec<Modify>) {
+            if !modifies.is_empty() {
+                self.engine.write(&self.ctx, modifies).unwrap();
+            }
+        }
     }
 
     #[test]
@@ -277,6 +308,31 @@ mod test {
             let data = snapshot_store.get(&make_key(key), &mut statistics).unwrap();
             assert!(data.is_some(), "{:?} expect some, but got none", key);
         }
+    }
+
+    #[test]
+    fn test_snapshot_store_get_multiple_versions() {
+        let mut store = TestStore::new(1);
+        let k = b"k";
+        let (v1, v2, v3, v4) = (b"v1", b"v2", b"v3", b"v4");
+        // put k/v1 start_ts = 1, commit_ts = 2
+        store.must_prewrite_put(k, v1, k, 1);
+        store.must_commit(k, 1, 2);
+
+        // generate several rollback in write cf.
+        store.must_prewrite_put(k, v2, k, 3);
+        store.must_rollback(k, 3);
+        store.must_prewrite_put(k, v3, k, 5);
+        store.must_rollback(k, 5);
+        store.must_prewrite_put(k, v4, k, 7);
+        store.must_rollback(k, 7);
+
+        // use start_ts = 21 to get, travel all rollback marks and get committed value v1.
+        store.refresh_snapshot();
+        let snapshot_store = store.store();
+        let mut statistics = Statistics::default();
+        let data = snapshot_store.get(&make_key(k), &mut statistics).unwrap();
+        assert_eq!(data.unwrap(), v1);
     }
 
     #[test]

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -46,6 +46,7 @@ impl SnapshotStore {
             None,
             None,
             self.isolation_level,
+            true,
         );
         let v = reader.get(key, self.start_ts)?;
         statistics.add(reader.get_statistics());
@@ -65,6 +66,7 @@ impl SnapshotStore {
             None,
             None,
             self.isolation_level,
+            false,
         );
         let mut results = Vec::with_capacity(keys.len());
         for k in keys {
@@ -90,6 +92,7 @@ impl SnapshotStore {
             lower_bound,
             upper_bound,
             self.isolation_level,
+            false,
         );
         reader.set_key_only(key_only);
         Ok(StoreScanner {


### PR DESCRIPTION
In contentious case, many many rollbacks may exist for a single key. The commit informations for this key is like that:
```
k vn rollback ts = n
…
k v2 rollback ts = 2
k v1 commit ts = 1
```
When use ts = n+1 to get k, currently we will create iterator and call seek for each version. 
In this case actually we only need create one iterator and use next to iterate all versions.

I test `SnapshotStore.get` on a key with 10000 rollbacks and 1 commit version, the cost time reduced by nearly 80%. I have to remind that in the above test all contents are in RocksDB's Memtable, if the dataset is larger, the positive effect of this pr is much more huge.
```
branch: txn get elapsed Duration { secs: 0, nanos: 44372872 }
master: txn get elapsed Duration { secs: 0, nanos: 209389204 }
```

BTW, 3 LGTM is needed.