### PR TITLE
Cleanup import SST files periodically

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -162,6 +162,9 @@
 # Use delete range to drop a large number of continuous keys.
 # use-delete-range = true
 
+# Interval to cleanup import sst files.
+# cleanup-import-sst-interval = "10m"
+
 [coprocessor]
 # When it is true, it will try to split a region with table prefix if
 # that region crosses tables. It is recommended to turn off this option

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -103,6 +103,8 @@ pub struct Config {
 
     pub use_delete_range: bool,
 
+    pub cleanup_import_sst_interval: ReadableDuration,
+
     // Deprecated! These two configuration has been moved to Coprocessor.
     // They are preserved for compatibility check.
     #[doc(hidden)]
@@ -158,6 +160,7 @@ impl Default for Config {
             merge_max_log_gap: 10,
             merge_check_tick_interval: ReadableDuration::secs(10),
             use_delete_range: true,
+            cleanup_import_sst_interval: ReadableDuration::minutes(10),
 
             // They are preserved for compatibility check.
             region_max_size: ReadableSize(0),

--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -18,6 +18,7 @@ use std::fmt;
 use kvproto::raft_serverpb::RaftMessage;
 use kvproto::raft_cmdpb::{RaftCmdRequest, RaftCmdResponse};
 use kvproto::metapb::RegionEpoch;
+use kvproto::importpb::SSTMeta;
 
 use raft::SnapshotStatus;
 use util::escape;
@@ -107,6 +108,7 @@ pub enum Tick {
     CompactLockCf,
     ConsistencyCheck,
     CheckMerge,
+    CleanupImportSST,
 }
 
 #[derive(Debug, PartialEq)]
@@ -171,6 +173,8 @@ pub enum Msg {
     MergeFail {
         region_id: u64,
     },
+
+    ValidateSSTResult(Vec<SSTMeta>),
 }
 
 impl fmt::Debug for Msg {
@@ -207,6 +211,7 @@ impl fmt::Debug for Msg {
             ),
             Msg::CompactedEvent(ref event) => write!(fmt, "CompactedEvent cf {}", event.cf),
             Msg::MergeFail { region_id } => write!(fmt, "MergeFail region_id {}", region_id),
+            Msg::ValidateSSTResult(_) => write!(fmt, "Validate SST Result"),
         }
     }
 }

--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -174,7 +174,9 @@ pub enum Msg {
         region_id: u64,
     },
 
-    ValidateSSTResult(Vec<SSTMeta>),
+    ValidateSSTResult {
+        invalid_ssts: Vec<SSTMeta>,
+    },
 }
 
 impl fmt::Debug for Msg {
@@ -211,7 +213,7 @@ impl fmt::Debug for Msg {
             ),
             Msg::CompactedEvent(ref event) => write!(fmt, "CompactedEvent cf {}", event.cf),
             Msg::MergeFail { region_id } => write!(fmt, "MergeFail region_id {}", region_id),
-            Msg::ValidateSSTResult(_) => write!(fmt, "Validate SST Result"),
+            Msg::ValidateSSTResult { .. } => write!(fmt, "Validate SST Result"),
         }
     }
 }

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -2968,9 +2968,8 @@ impl<T: Transport, C: PdClient> Store<T, C> {
     }
 
     fn on_validate_sst_result(&mut self, ssts: Vec<SSTMeta>) {
-        // Even if an SST doesn't belong to this store now, a stale
-        // peer can still ingest the SST before it is destroyed. So we
-        // need to make sure that no stale peer exists.
+        // A stale peer can still ingest a stale SST before it is
+        // destroyed. We need to make sure that no stale peer exists.
         let mut delete_ssts = Vec::new();
         for sst in ssts {
             if !self.region_peers.contains_key(&sst.get_region_id()) {

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -2968,9 +2968,9 @@ impl<T: Transport, C: PdClient> Store<T, C> {
     }
 
     fn on_validate_sst_result(&mut self, ssts: Vec<SSTMeta>) {
-        // Even if an SST don't belong to this store now, a stale peer
-        // can still ingest the SST before it is destroyed. So we need
-        // to make sure that no stale peer exists.
+        // Even if an SST doesn't belong to this store now, a stale
+        // peer can still ingest the SST before it is destroyed. So we
+        // need to make sure that no stale peer exists.
         let mut delete_ssts = Vec::new();
         for sst in ssts {
             if !self.region_peers.contains_key(&sst.get_region_id()) {

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -539,6 +539,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         self.register_compact_lock_cf_tick(event_loop);
         self.register_consistency_check_tick(event_loop);
         self.register_merge_check_tick(event_loop);
+        self.register_cleanup_import_sst_tick(event_loop);
 
         let split_check_runner = SplitCheckRunner::new(
             Arc::clone(&self.kv_engine),
@@ -577,7 +578,12 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                 .start(consistency_check_runner)
         );
 
-        let cleanup_sst_runner = CleanupSSTRunner::new(Arc::clone(&self.importer));
+        let cleanup_sst_runner = CleanupSSTRunner::new(
+            self.store_id(),
+            self.sendch.clone(),
+            Arc::clone(&self.importer),
+            Arc::clone(&self.pd_client),
+        );
         box_try!(self.cleanup_sst_worker.start(cleanup_sst_runner));
 
         let (tx, rx) = mpsc::channel();
@@ -2948,15 +2954,82 @@ impl<T: Transport, C: PdClient> Store<T, C> {
     }
 
     fn on_ingest_sst_result(&mut self, ssts: Vec<SSTMeta>) {
-        for sst in ssts {
+        for sst in &ssts {
             let region_id = sst.get_region_id();
             if let Some(region) = self.region_peers.get_mut(&region_id) {
                 region.size_diff_hint += sst.get_length();
             }
-            let task = CleanupSSTTask::DeleteSST { sst };
-            if let Err(e) = self.cleanup_sst_worker.schedule(task) {
-                error!("[region {}] schedule delete sst: {:?}", region_id, e);
+        }
+
+        let task = CleanupSSTTask::DeleteSST { ssts };
+        if let Err(e) = self.cleanup_sst_worker.schedule(task) {
+            error!("schedule to delete ssts: {:?}", e);
+        }
+    }
+
+    fn on_validate_sst_result(&mut self, ssts: Vec<SSTMeta>) {
+        // Even if an SST don't belong to this store now, a stale peer
+        // can still ingest the SST before it is destroyed. So we need
+        // to make sure that no stale peer exists.
+        let mut delete_ssts = Vec::new();
+        for sst in ssts {
+            if !self.region_peers.contains_key(&sst.get_region_id()) {
+                delete_ssts.push(sst);
             }
+        }
+
+        let task = CleanupSSTTask::DeleteSST { ssts: delete_ssts };
+        if let Err(e) = self.cleanup_sst_worker.schedule(task) {
+            error!("schedule to delete ssts: {:?}", e);
+        }
+    }
+
+    fn on_cleanup_import_sst(&mut self) -> Result<()> {
+        let mut delete_ssts = Vec::new();
+        let mut validate_ssts = Vec::new();
+
+        let ssts = box_try!(self.importer.list_ssts());
+        for sst in ssts {
+            if let Some(peer) = self.region_peers.get(&sst.get_region_id()) {
+                let region_epoch = peer.region().get_region_epoch();
+                if util::is_epoch_stale(sst.get_region_epoch(), region_epoch) {
+                    // If the SST epoch is stale, it will not be ingested anymore.
+                    delete_ssts.push(sst);
+                }
+            } else {
+                // If the peer doesn't exist, we need to validate the SST through PD.
+                validate_ssts.push(sst);
+            }
+        }
+
+        let task = CleanupSSTTask::DeleteSST { ssts: delete_ssts };
+        if let Err(e) = self.cleanup_sst_worker.schedule(task) {
+            error!("schedule to delete ssts: {:?}", e);
+        }
+        let task = CleanupSSTTask::ValidateSST {
+            ssts: validate_ssts,
+        };
+        if let Err(e) = self.cleanup_sst_worker.schedule(task) {
+            error!("schedule to validate ssts: {:?}", e);
+        }
+
+        Ok(())
+    }
+
+    fn on_cleanup_import_sst_tick(&mut self, event_loop: &mut EventLoop<Self>) {
+        if let Err(e) = self.on_cleanup_import_sst() {
+            error!("{} failed to cleanup import sst: {:?}", self.tag, e);
+        }
+        self.register_cleanup_import_sst_tick(event_loop);
+    }
+
+    fn register_cleanup_import_sst_tick(&self, event_loop: &mut EventLoop<Self>) {
+        if let Err(e) = register_timer(
+            event_loop,
+            Tick::CleanupImportSST,
+            self.cfg.cleanup_import_sst_interval.as_millis(),
+        ) {
+            error!("{} register cleanup import sst tick err: {:?}", self.tag, e);
         }
     }
 }
@@ -3092,6 +3165,7 @@ impl<T: Transport, C: PdClient> mio::Handler for Store<T, C> {
             } => self.on_approximate_region_size(region_id, region_size),
             Msg::CompactedEvent(event) => self.on_compaction_finished(event),
             Msg::MergeFail { region_id } => self.on_merge_fail(region_id),
+            Msg::ValidateSSTResult(ssts) => self.on_validate_sst_result(ssts),
         }
     }
 
@@ -3108,6 +3182,7 @@ impl<T: Transport, C: PdClient> mio::Handler for Store<T, C> {
             Tick::CompactLockCf => self.on_compact_lock_cf(event_loop),
             Tick::ConsistencyCheck => self.on_consistency_check_tick(event_loop),
             Tick::CheckMerge => self.on_check_merge(event_loop),
+            Tick::CleanupImportSST => self.on_cleanup_import_sst_tick(event_loop),
         }
         slow_log!(t, "{} handle timeout {:?}", self.tag, timeout);
     }

--- a/src/raftstore/store/worker/cleanup_sst.rs
+++ b/src/raftstore/store/worker/cleanup_sst.rs
@@ -14,46 +14,116 @@
 use std::fmt;
 use std::sync::Arc;
 
-use uuid::Uuid;
+use futures::Future;
+use kvproto::metapb::Region;
 use kvproto::importpb::SSTMeta;
 
+use pd::PdClient;
 use import::SSTImporter;
+use raftstore::store::Msg;
+use raftstore::store::util::is_epoch_stale;
+use util::transport::SendCh;
 use util::worker::Runnable;
 
 pub enum Task {
-    DeleteSST { sst: SSTMeta },
+    DeleteSST { ssts: Vec<SSTMeta> },
+    ValidateSST { ssts: Vec<SSTMeta> },
 }
 
 impl fmt::Display for Task {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Task::DeleteSST { ref sst } => match Uuid::from_bytes(sst.get_uuid()) {
-                Ok(uuid) => write!(f, "Delete SST {}", uuid),
-                Err(e) => write!(f, "Delete SST {:?}", e),
-            },
+            Task::DeleteSST { ref ssts } => write!(f, "Delete {} ssts", ssts.len()),
+            Task::ValidateSST { ref ssts } => write!(f, "Validate {} ssts", ssts.len()),
         }
     }
 }
 
-pub struct Runner {
+pub struct Runner<C> {
+    store_id: u64,
+    store_ch: SendCh<Msg>,
     importer: Arc<SSTImporter>,
+    pd_client: Arc<C>,
 }
 
-impl Runner {
-    pub fn new(importer: Arc<SSTImporter>) -> Runner {
-        Runner { importer: importer }
+impl<C: PdClient> Runner<C> {
+    pub fn new(
+        store_id: u64,
+        store_ch: SendCh<Msg>,
+        importer: Arc<SSTImporter>,
+        pd_client: Arc<C>,
+    ) -> Runner<C> {
+        Runner {
+            store_id: store_id,
+            store_ch: store_ch,
+            importer: importer,
+            pd_client: pd_client,
+        }
     }
 
-    fn handle_delete_sst(&self, sst: SSTMeta) {
-        let _ = self.importer.delete(&sst);
+    fn handle_delete_sst(&self, ssts: Vec<SSTMeta>) {
+        for sst in &ssts {
+            let _ = self.importer.delete(sst);
+        }
+    }
+
+    fn handle_validate_sst(&self, ssts: Vec<SSTMeta>) {
+        let store_id = self.store_id;
+        // Get region info from PD, then check if the SST still belongs to the store.
+        let f = &|sst: SSTMeta, res: Result<Option<Region>, _>| {
+            match res {
+                Ok(Some(region)) => {
+                    if is_epoch_stale(region.get_region_epoch(), sst.get_region_epoch()) {
+                        // Region has not been updated.
+                        return Ok(None);
+                    }
+                    if region
+                        .get_peers()
+                        .into_iter()
+                        .any(|p| p.get_store_id() == store_id)
+                    {
+                        // The SST still belongs to the store.
+                        return Ok(None);
+                    }
+                    Ok(Some(sst))
+                }
+                Ok(None) => {
+                    // TODO: handle merge
+                    Ok(None)
+                }
+                Err(e) => {
+                    error!("get region {} failed {:?}", sst.get_region_id(), e);
+                    Err(e)
+                }
+            }
+        };
+
+        let mut results = Vec::new();
+        for sst in ssts {
+            let sst = self.pd_client
+                .get_region_by_id(sst.get_region_id())
+                .then(move |res| f(sst, res))
+                .wait();
+            if let Ok(Some(sst)) = sst {
+                results.push(sst);
+            }
+        }
+
+        let msg = Msg::ValidateSSTResult(results);
+        if let Err(e) = self.store_ch.try_send(msg) {
+            error!("send validate sst result: {:?}", e);
+        }
     }
 }
 
-impl Runnable<Task> for Runner {
+impl<C: PdClient> Runnable<Task> for Runner<C> {
     fn run(&mut self, task: Task) {
         match task {
-            Task::DeleteSST { sst } => {
-                self.handle_delete_sst(sst);
+            Task::DeleteSST { ssts } => {
+                self.handle_delete_sst(ssts);
+            }
+            Task::ValidateSST { ssts } => {
+                self.handle_validate_sst(ssts);
             }
         }
     }

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -131,7 +131,8 @@ fn test_serde_custom_tikv_config() {
         allow_remove_leader: true,
         merge_max_log_gap: 3,
         merge_check_tick_interval: ReadableDuration::secs(11),
-        use_delete_range: false,
+        use_delete_range: true,
+        cleanup_import_sst_interval: ReadableDuration::minutes(12),
         region_max_size: ReadableSize(0),
         region_split_size: ReadableSize(0),
     };

--- a/tests/config/test-custom.toml
+++ b/tests/config/test-custom.toml
@@ -90,7 +90,8 @@ right-derive-when-split = false
 allow-remove-leader = true
 merge-max-log-gap = 3
 merge-check-tick-interval = "11s"
-use-delete-range = false
+use-delete-range = true
+cleanup-import-sst-interval = "12m"
 
 [coprocessor]
 split-region-on-table = true

--- a/tests/import/sst_service.rs
+++ b/tests/import/sst_service.rs
@@ -69,7 +69,7 @@ fn new_cluster_and_tikv_import_client(
 
 #[test]
 fn test_upload_sst() {
-    let (_cluster, _, _, import) = new_cluster_and_tikv_import_client();
+    let (_cluster, ctx, _, import) = new_cluster_and_tikv_import_client();
 
     let data = vec![1; 1024];
     let crc32 = calc_data_crc32(&data);
@@ -88,7 +88,9 @@ fn test_upload_sst() {
     upload.set_meta(meta);
     assert!(send_upload_sst(&import, &upload).is_err());
 
-    let meta = new_sst_meta(crc32, length);
+    let mut meta = new_sst_meta(crc32, length);
+    meta.set_region_id(ctx.get_region_id());
+    meta.set_region_epoch(ctx.get_region_epoch().clone());
     upload.set_meta(meta);
     send_upload_sst(&import, &upload).unwrap();
 


### PR DESCRIPTION
The import SST process is divided into two steps:

  1. Upload an SST file to all peers of a region
  2. Ingest the SST file to the region with a Raft command

However, since these two steps are not atomic, a lot of reasons can
stop a client from ingesting an uploaded SST file to the region. In
that case, the uploaded SST file will remain in the import
directory. So we need a way to clean up these obsoleted SST files.

Before we can delete an uploaded SST file, we need to make sure that
the SST file will not be ingested anymore.
We need to guarantee one of these:

  1. The epoch of the SST is staler than the local region peer
  2. The region information from PD shows that the SST does not belong
  to the store, and there is no stale peer of that region in the store too.