### PR TITLE
Avoid passing CpuPool into OnResponse

### DIFF
--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -707,7 +707,7 @@ impl Runnable<Task> for Host {
                     if let Err(e) = req.check_outdated() {
                         let resp = err_resp(e, &mut self.basic_local_metrics);
                         req.on_resp.respond(resp);
-                        return;
+                        continue;
                     }
                     let key = req.get_request_key();
                     grouped_reqs.entry(key).or_insert_with(Vec::new).push(req);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -57,7 +57,8 @@ impl<T: Send + Debug + 'static> OnResponse<T> {
                 let _ = sender.send(resp);
             }
             OnResponse::Streaming(sender) => {
-                // `stream::once` never blocks so that we can safely `wait()` here.
+                // `stream::once` never blocks, and our sender is a mpsc::channel::Sender so
+                // that we can safely `wait()` here.
                 let _ = sender.send_all(stream::once(Ok(resp))).wait();
             }
         }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -57,6 +57,7 @@ impl<T: Send + Debug + 'static> OnResponse<T> {
                 let _ = sender.send(resp);
             }
             OnResponse::Streaming(sender) => {
+                // `stream::once` never blocks so that we can safely `wait()` here.
                 let _ = sender.send_all(stream::once(Ok(resp))).wait();
             }
         }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -92,7 +92,6 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver + 'static> Server<T, S> {
             raft_router.clone(),
             snap_worker.scheduler(),
             cfg.end_point_recursion_limit,
-            cfg.end_point_stream_channel_size,
         );
         let addr = SocketAddr::from_str(&cfg.addr)?;
         info!("listening on {}", addr);

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -92,6 +92,7 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver + 'static> Server<T, S> {
             raft_router.clone(),
             snap_worker.scheduler(),
             cfg.end_point_recursion_limit,
+            cfg.end_point_stream_channel_size,
         );
         let addr = SocketAddr::from_str(&cfg.addr)?;
         info!("listening on {}", addr);

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -131,7 +131,7 @@ impl<T: RaftStoreRouter + 'static> Service<T> {
             token: Arc::new(AtomicUsize::new(1)),
             recursion_limit: recursion_limit,
             metrics: Metrics::new(),
-            stream_channel_size,
+            stream_channel_size: stream_channel_size,
         }
     }
 
@@ -878,7 +878,6 @@ impl<T: RaftStoreRouter + 'static> tikvpb_grpc::Tikv for Service<T> {
 
         let future = sink.send_all(stream)
             .map(|_| timer.observe_duration())
-            .map_err(Error::from)
             .map_err(move |e| {
                 debug!("{} failed: {:?}", label, e);
                 GRPC_MSG_FAIL_COUNTER.with_label_values(&[label]).inc();

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -60,7 +60,6 @@ pub struct Service<T: RaftStoreRouter + 'static> {
     snap_scheduler: Scheduler<SnapTask>,
     token: Arc<AtomicUsize>, // TODO: remove it.
     recursion_limit: u32,
-    stream_channel_size: usize,
     metrics: Metrics,
 }
 
@@ -123,7 +122,6 @@ impl<T: RaftStoreRouter + 'static> Service<T> {
         ch: T,
         snap_scheduler: Scheduler<SnapTask>,
         recursion_limit: u32,
-        stream_channel_size: usize,
     ) -> Service<T> {
         Service {
             storage: storage,
@@ -132,7 +130,6 @@ impl<T: RaftStoreRouter + 'static> Service<T> {
             snap_scheduler: snap_scheduler,
             token: Arc::new(AtomicUsize::new(1)),
             recursion_limit: recursion_limit,
-            stream_channel_size: stream_channel_size,
             metrics: Metrics::new(),
         }
     }

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::boxed::FnBox;
-use std::fmt::Debug;
 use std::io::Write;
 use std::iter::{self, FromIterator};
 use std::sync::Arc;

--- a/tests/coprocessor/test_select.rs
+++ b/tests/coprocessor/test_select.rs
@@ -19,15 +19,14 @@ use std::i64;
 use std::thread;
 use std::time::Duration;
 use futures::{Future, Stream};
-use futures::sync::mpsc as futures_mpsc;
-use futures_cpupool::CpuPool;
 
 use tikv::coprocessor::*;
 use kvproto::kvrpcpb::Context;
 use tikv::coprocessor::codec::{datum, table, Datum};
 use tikv::coprocessor::codec::datum::DatumDecoder;
+use tikv::util;
 use tikv::util::codec::number::*;
-use tikv::server::{Config, CopStream, OnResponse};
+use tikv::server::{Config, OnResponse};
 use tikv::server::readpool::{self, ReadPool};
 use tikv::storage::{self, Key, Mutation, ALL_CFS};
 use tikv::storage::engine::{self, Engine, TEMP_DIR};
@@ -1501,19 +1500,13 @@ fn handle_streaming_select<F>(
 where
     F: FnMut(&Response) + Send + 'static,
 {
-    let (ftx, frx) = futures_mpsc::channel(16);
-    let callback = box move |s: CopStream<Response>, executor: Option<CpuPool>| {
-        let f = s.forward(ftx);
-        if let Some(executor) = executor {
-            return executor.spawn(f).forget();
-        }
-        f.wait().unwrap();
-    };
+    let (callback, stream_future) = util::future::paired_future_callback();
     let req = RequestTask::new(req, OnResponse::Streaming(callback), 100).unwrap();
     end_point.schedule(EndPointTask::Request(req)).unwrap();
 
     let (tx, rx) = mpsc::channel();
-    for resp in frx.wait() {
+    let stream = stream_future.wait().unwrap();
+    for resp in stream.wait() {
         let resp = resp.unwrap();
         check_range(&resp);
         assert!(!resp.get_data().is_empty());


### PR DESCRIPTION
In PR #2827 I attempted to replace CpuPools with a ReadPool (recall that ReadPool is a collection of FuturePools with different priorities).

Because CpuPool is passed from endpoint into outside currently, PR #2827 has to extract the FuturePool from ReadPool for passing out, which is bad because it breaks the encapsulation.

This PR avoids leaking CpuPool out of `endpoint`. Basically the idea behind is to simplify the OnResponse callback. Now `OnResponse::Streaming` is a callback for a `Stream` **which is ready to poll** in Grpc threads. In other words, `OnResponse::Streaming` can be used to build `Stream<Item=Future<Item=T>>` (`OnResponse::Unary` can be used to build `Future<Item=T>`).

@hicqu PTAL