### PR TITLE
add lock on `get_fs_info`.

### DIFF
--- a/src/util/config.rs
+++ b/src/util/config.rs
@@ -749,6 +749,7 @@ mod check_data_dir {
     use std::io::Read;
     use std::ffi::{CStr, CString};
     use std::path::Path;
+    use std::sync::Mutex;
     use libc;
 
     use super::{canonicalize_path, ConfigError};
@@ -762,12 +763,19 @@ mod check_data_dir {
     }
 
     fn get_fs_info(path: &str, mnt_file: &str) -> Result<FsInfo, ConfigError> {
+        lazy_static! {
+            // According `man 3 getmntent`, The pointer returned by `getmntent` points
+            // to a static area of memory which is overwritten by subsequent calls.
+            // So we use a lock to protect it in order to avoid `make dev` fail.
+            static ref GETMNTENT_LOCK: Mutex<()> = Mutex::new(());
+        }
         unsafe {
             let profile = CString::new(mnt_file).unwrap();
             let retype = CString::new("r").unwrap();
             let afile = libc::setmntent(profile.as_ptr(), retype.as_ptr());
             let mut fs = FsInfo::default();
             loop {
+                let _ = GETMNTENT_LOCK.lock().unwrap();
                 let ent = libc::getmntent(afile);
                 if ent.is_null() {
                     break;

--- a/src/util/config.rs
+++ b/src/util/config.rs
@@ -769,13 +769,15 @@ mod check_data_dir {
             // So we use a lock to protect it in order to avoid `make dev` fail.
             static ref GETMNTENT_LOCK: Mutex<()> = Mutex::new(());
         }
+
         unsafe {
+            let _lock = GETMNTENT_LOCK.lock().unwrap();
+
             let profile = CString::new(mnt_file).unwrap();
             let retype = CString::new("r").unwrap();
             let afile = libc::setmntent(profile.as_ptr(), retype.as_ptr());
             let mut fs = FsInfo::default();
             loop {
-                let _ = GETMNTENT_LOCK.lock().unwrap();
                 let ent = libc::getmntent(afile);
                 if ent.is_null() {
                     break;


### PR DESCRIPTION
According `man 3 getmntent`, The pointer returned by `getmntent` points to a static area of memory which is overwritten by subsequent calls. So we use a lock to protect it in order to avoid `make dev` fail.

`libc` doesn't have `getmntent_r`, so we need a explicitly lock.