### PR TITLE
tests: improve merge tests

### DIFF
--- a/tests/failpoints_cases/test_merge.rs
+++ b/tests/failpoints_cases/test_merge.rs
@@ -17,7 +17,6 @@ use std::sync::Arc;
 use fail;
 use futures::Future;
 use kvproto::raft_serverpb::{PeerState, RegionLocalState};
-use tikv::util::config::*;
 use tikv::pd::PdClient;
 use tikv::raftstore::store::keys;
 use tikv::storage::CF_RAFT;
@@ -32,7 +31,7 @@ use raftstore::util::*;
 fn test_node_merge_rollback() {
     let _guard = ::setup();
     let mut cluster = new_node_cluster(0, 3);
-    cluster.cfg.raft_store.merge_check_tick_interval = ReadableDuration::millis(100);
+    configure_for_merge(&mut cluster);
     let pd_client = Arc::clone(&cluster.pd_client);
     pd_client.disable_default_operator();
 
@@ -117,7 +116,7 @@ fn test_node_merge_rollback() {
 fn test_node_merge_restart() {
     let _guard = ::setup();
     let mut cluster = new_node_cluster(0, 3);
-    cluster.cfg.raft_store.merge_check_tick_interval = ReadableDuration::millis(100);
+    configure_for_merge(&mut cluster);
     cluster.run();
 
     let pd_client = Arc::clone(&cluster.pd_client);
@@ -192,8 +191,9 @@ fn test_node_merge_restart() {
 fn test_node_merge_recover_snapshot() {
     let _guard = ::setup();
     let mut cluster = new_node_cluster(0, 3);
+    configure_for_merge(&mut cluster);
+    cluster.cfg.raft_store.raft_log_gc_threshold = 12;
     cluster.cfg.raft_store.raft_log_gc_count_limit = 12;
-    cluster.cfg.raft_store.merge_check_tick_interval = ReadableDuration::millis(100);
     let pd_client = Arc::clone(&cluster.pd_client);
     pd_client.disable_default_operator();
 

--- a/tests/raftstore/util.rs
+++ b/tests/raftstore/util.rs
@@ -458,9 +458,18 @@ pub fn create_test_engine(
 }
 
 pub fn configure_for_snapshot<T: Simulator>(cluster: &mut Cluster<T>) {
-    // truncate the log quickly so that we can force sending snapshot.
+    // Truncate the log quickly so that we can force sending snapshot.
     cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::millis(20);
     cluster.cfg.raft_store.raft_log_gc_count_limit = 2;
     cluster.cfg.raft_store.merge_max_log_gap = 1;
     cluster.cfg.raft_store.snap_mgr_gc_tick_interval = ReadableDuration::millis(50);
+}
+
+pub fn configure_for_merge<T: Simulator>(cluster: &mut Cluster<T>) {
+    // Avoid log compaction which will prevent merge.
+    cluster.cfg.raft_store.raft_log_gc_threshold = 1000;
+    cluster.cfg.raft_store.raft_log_gc_count_limit = 1000;
+    cluster.cfg.raft_store.raft_log_gc_size_limit = ReadableSize::mb(20);
+    // Make merge check resume quickly.
+    cluster.cfg.raft_store.merge_check_tick_interval = ReadableDuration::millis(100);
 }

--- a/tests/raftstore_cases/test_merge.rs
+++ b/tests/raftstore_cases/test_merge.rs
@@ -19,7 +19,6 @@ use std::iter::*;
 use kvproto::raft_serverpb::{PeerState, RegionLocalState};
 use tikv::pd::PdClient;
 use tikv::raftstore::store::keys;
-use tikv::util::config::*;
 use tikv::storage::CF_RAFT;
 use tikv::raftstore::store::Peekable;
 
@@ -32,6 +31,7 @@ use raftstore::transport_simulate::*;
 #[test]
 fn test_node_base_merge() {
     let mut cluster = new_node_cluster(0, 3);
+    configure_for_merge(&mut cluster);
 
     cluster.run();
 
@@ -118,9 +118,7 @@ fn test_node_base_merge() {
 fn test_node_merge_prerequisites_check() {
     // ::util::init_log();
     let mut cluster = new_node_cluster(0, 3);
-    cluster.cfg.raft_store.raft_log_gc_count_limit = 100;
-    cluster.cfg.raft_store.raft_log_gc_threshold = 500;
-    cluster.cfg.raft_store.raft_log_gc_size_limit = ReadableSize::mb(20);
+    configure_for_merge(&mut cluster);
     let pd_client = Arc::clone(&cluster.pd_client);
 
     cluster.run();
@@ -190,8 +188,7 @@ fn test_node_merge_prerequisites_check() {
 fn test_node_check_merged_message() {
     // ::util::init_log();
     let mut cluster = new_node_cluster(0, 4);
-    cluster.cfg.raft_store.raft_log_gc_count_limit = 100;
-    cluster.cfg.raft_store.raft_log_gc_threshold = 100;
+    configure_for_merge(&mut cluster);
     let pd_client = Arc::clone(&cluster.pd_client);
     pd_client.disable_default_operator();
 
@@ -273,8 +270,7 @@ fn test_node_check_merged_message() {
 fn test_node_merge_dist_isolation() {
     // ::util::init_log();
     let mut cluster = new_node_cluster(0, 3);
-    cluster.cfg.raft_store.raft_log_gc_count_limit = 12;
-    cluster.cfg.raft_store.merge_check_tick_interval = ReadableDuration::millis(100);
+    configure_for_merge(&mut cluster);
     let pd_client = Arc::clone(&cluster.pd_client);
     pd_client.disable_default_operator();
 
@@ -348,9 +344,9 @@ fn test_node_merge_dist_isolation() {
 fn test_node_merge_brain_split() {
     // ::util::init_log();
     let mut cluster = new_node_cluster(0, 3);
+    configure_for_merge(&mut cluster);
     cluster.cfg.raft_store.raft_log_gc_threshold = 12;
     cluster.cfg.raft_store.raft_log_gc_count_limit = 12;
-    cluster.cfg.raft_store.merge_check_tick_interval = ReadableDuration::millis(100);
 
     cluster.run();
 


### PR DESCRIPTION
Compact log can stop peer from merging, this pr ensures compaction won't get in the way when merge is tested.