### PR TITLE
apply/merge: use `mark_merge_done`

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -46,8 +46,7 @@ use util::collections::{FlatMap, FlatMapValues as Values, HashSet};
 use pd::{PdTask, INVALID_ID};
 
 use super::store::{DestroyPeerJob, Store, StoreStat};
-use super::peer_storage::{mark_merge_done, write_peer_state, ApplySnapResult, InvokeContext,
-                          PeerStorage};
+use super::peer_storage::{write_peer_state, ApplySnapResult, InvokeContext, PeerStorage};
 use super::util::{self, Lease, LeaseState};
 use super::cmd_resp;
 use super::transport::Transport;
@@ -401,6 +400,7 @@ impl Peer {
     }
 
     pub fn destroy(&mut self, keep_data: bool) -> Result<()> {
+        fail_point!("raft_store_skip_destroy_peer", |_| Ok(()));
         let t = Instant::now();
 
         let region = self.get_store().get_region().clone();
@@ -410,11 +410,13 @@ impl Peer {
         let kv_wb = WriteBatch::new();
         let raft_wb = WriteBatch::new();
         self.mut_store().clear_meta(&kv_wb, &raft_wb)?;
-        if let Some(ref state) = self.pending_merge {
-            mark_merge_done(&self.kv_engine, &kv_wb, &region, state.get_target())?;
-        } else {
-            write_peer_state(&self.kv_engine, &kv_wb, &region, PeerState::Tombstone)?;
-        }
+        write_peer_state(
+            &self.kv_engine,
+            &kv_wb,
+            &region,
+            PeerState::Tombstone,
+            self.pending_merge.clone(),
+        )?;
         // write kv rocksdb first in case of restart happen between two write
         let mut write_opts = WriteOptions::new();
         write_opts.set_sync(self.cfg.sync_log);

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -827,7 +827,7 @@ impl PeerStorage {
             self.clear_meta(kv_wb, raft_wb)?;
         }
 
-        write_peer_state(&self.kv_engine, kv_wb, &region, PeerState::Applying)?;
+        write_peer_state(&self.kv_engine, kv_wb, &region, PeerState::Applying, None)?;
 
         let last_index = snap.get_metadata().get_index();
 
@@ -1343,41 +1343,21 @@ pub fn write_peer_state<T: Mutable>(
     kv_wb: &T,
     region: &metapb::Region,
     state: PeerState,
+    merge_state: Option<MergeState>,
 ) -> Result<()> {
     let region_id = region.get_id();
     let mut region_state = RegionLocalState::new();
     region_state.set_state(state);
     region_state.set_region(region.clone());
-    let handle = rocksdb::get_cf_handle(kv_engine, CF_RAFT)?;
-    kv_wb.put_msg_cf(handle, &keys::region_state_key(region_id), &region_state)?;
-    Ok(())
-}
-
-pub fn mark_merge_done<T: Mutable>(
-    kv_engine: &DB,
-    kv_wb: &T,
-    region: &metapb::Region,
-    target: &metapb::Region,
-) -> Result<()> {
-    let mut merge_state = MergeState::new();
-    merge_state.set_target(target.to_owned());
-    write_merge_state(kv_engine, kv_wb, region, PeerState::Tombstone, merge_state)
-}
-
-pub fn write_merge_state<T: Mutable>(
-    kv_engine: &DB,
-    kv_wb: &T,
-    region: &metapb::Region,
-    state: PeerState,
-    merge_state: MergeState,
-) -> Result<()> {
-    let region_id = region.get_id();
-    let mut region_state = RegionLocalState::new();
-    region_state.set_state(state);
-    region_state.set_region(region.clone());
-    region_state.set_merge_state(merge_state);
+    if let Some(state) = merge_state {
+        region_state.set_merge_state(state);
+    }
 
     let handle = rocksdb::get_cf_handle(kv_engine, CF_RAFT)?;
+    debug!(
+        "[region {}] writing merge state: {:?}",
+        region_id, region_state
+    );
     kv_wb.put_msg_cf(handle, &keys::region_state_key(region_id), &region_state)?;
     Ok(())
 }

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -1834,13 +1834,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
     fn on_ready_commit_merge(&mut self, region: metapb::Region, source: metapb::Region) {
         let source_peer = {
             let peer = self.region_peers.get_mut(&source.get_id()).unwrap();
-            // In some case, PrepareMerge entry may be carried by the dst region. So
-            // the peer is not in merging mode.
-            if peer.pending_merge.is_none() {
-                let mut state = MergeState::new();
-                state.set_target(region.clone());
-                peer.pending_merge = Some(state);
-            }
+            assert!(peer.pending_merge.is_some());
             peer.peer.clone()
         };
         self.destroy_peer(source.get_id(), source_peer, true);

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -57,7 +57,7 @@ use super::worker::{ApplyRunner, ApplyTask, ApplyTaskRes, CleanupSSTRunner, Clea
 use super::worker::apply::{ChangePeer, ExecResult};
 use super::{util, Msg, SignificantMsg, SnapKey, SnapManager, SnapshotDeleter, Tick};
 use super::keys::{self, data_end_key, data_key, enc_end_key, enc_start_key};
-use super::engine::{Iterable, Peekable, Snapshot as EngineSnapshot};
+use super::engine::{Iterable, Mutable, Peekable, Snapshot as EngineSnapshot};
 use super::config::Config;
 use super::peer::{self, ConsistencyState, Peer, ReadyContext, StaleState};
 use super::peer_storage::{self, ApplySnapResult, CacheQueryStats};
@@ -297,7 +297,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                     region,
                     self.store_id()
                 );
-                self.clear_stale_meta(&mut kv_wb, &mut raft_wb, region);
+                self.clear_stale_meta(&mut kv_wb, &mut raft_wb, &local_state);
                 return Ok(true);
             }
             if local_state.get_state() == PeerState::Applying {
@@ -384,8 +384,9 @@ impl<T, C> Store<T, C> {
         &mut self,
         kv_wb: &mut WriteBatch,
         raft_wb: &mut WriteBatch,
-        region: &metapb::Region,
+        origin_state: &RegionLocalState,
     ) {
+        let region = origin_state.get_region();
         let raft_key = keys::raft_state_key(region.get_id());
         let raft_state = match self.raft_engine.get_msg(&raft_key).unwrap() {
             // it has been cleaned up.
@@ -401,8 +402,9 @@ impl<T, C> Store<T, C> {
             region.get_id(),
             &raft_state,
         ).unwrap();
-        peer_storage::write_peer_state(&self.kv_engine, kv_wb, region, PeerState::Tombstone)
-            .unwrap();
+        let key = keys::region_state_key(region.get_id());
+        let handle = rocksdb::get_cf_handle(&self.kv_engine, CF_RAFT).unwrap();
+        kv_wb.put_msg_cf(handle, &key, origin_state).unwrap();
     }
 
     /// `clear_stale_data` clean up all possible garbage data.
@@ -963,6 +965,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                     local_state
                 ));
             }
+            debug!("[region {}] tombstone state: {:?}", region_id, local_state);
             let region = local_state.get_region();
             let region_epoch = region.get_region_epoch();
             if local_state.has_merge_state() {

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -1748,6 +1748,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             let min_index = peer.get_min_progress() + 1;
             let low = cmp::max(min_index, state.get_min_index());
             // TODO: move this into raft module.
+            // +1 to include the PrepareMerge proposal.
             let entries = if low >= state.get_commit() + 1 {
                 vec![]
             } else {
@@ -1819,7 +1820,8 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         }
 
         if merged {
-            // PrepareMerge is executed by CommitMerge.
+            // CommitMerge will try to catch up log for source region. If PrepareMerge is executed
+            // in the progress of catching up, there is no need to schedule merge again.
             return;
         }
 

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -612,7 +612,13 @@ fn set_region_tombstone(db: &DB, store_id: u64, region: Region, wb: &WriteBatch)
         return Err(box_err!("The peer is still in target peers"));
     }
 
-    box_try!(write_peer_state(db, wb, &region, PeerState::Tombstone));
+    box_try!(write_peer_state(
+        db,
+        wb,
+        &region,
+        PeerState::Tombstone,
+        None
+    ));
     Ok(())
 }
 

--- a/tests/raftstore_cases/test_merge.rs
+++ b/tests/raftstore_cases/test_merge.rs
@@ -99,10 +99,9 @@ fn test_node_base_merge() {
                 .unwrap()
                 .unwrap();
             if state.get_state() == PeerState::Tombstone {
-                let region = state.get_region();
-                if region.get_region_epoch().get_version() == version + 1 {
-                    assert_eq!(region.get_region_epoch().get_conf_ver(), conf_ver + 1);
-                }
+                let epoch = state.get_region().get_region_epoch();
+                assert_eq!(epoch.get_version(), version + 1);
+                assert_eq!(epoch.get_conf_ver(), conf_ver + 1);
                 continue 'outer;
             }
             thread::sleep(Duration::from_millis(500));


### PR DESCRIPTION
Otherwise, gc messages can be skipped when received a stale message, which will lead to orphan replica.