### PR TITLE
Limit end-point-concurrency in coprocessor test.

### DIFF
--- a/tests/coprocessor/test_select.rs
+++ b/tests/coprocessor/test_select.rs
@@ -50,6 +50,13 @@ static ID_GENERATOR: AtomicUsize = AtomicUsize::new(1);
 const TYPE_VAR_CHAR: i32 = 1;
 const TYPE_LONG: i32 = 2;
 
+fn new_endpoint_test_config() -> Config {
+    Config {
+        end_point_concurrency: 2,
+        ..Config::default()
+    }
+}
+
 pub fn next_id() -> i64 {
     ID_GENERATOR.fetch_add(1, Ordering::Relaxed) as i64
 }
@@ -488,7 +495,7 @@ fn init_data_with_engine_and_commit(
     vals: &[(i64, Option<&str>, i64)],
     commit: bool,
 ) -> (Store, Worker<EndPointTask>) {
-    init_data_with_details(ctx, engine, tbl, vals, commit, Config::default())
+    init_data_with_details(ctx, engine, tbl, vals, commit, new_endpoint_test_config())
 }
 
 fn init_data_with_details(
@@ -817,7 +824,7 @@ fn test_batch_row_limit() {
     let product = ProductTable::new();
     let (_, mut end_point) = {
         let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
-        let mut cfg = Config::default();
+        let mut cfg = new_endpoint_test_config();
         cfg.end_point_batch_row_limit = batch_row_limit;
         init_data_with_details(Context::new(), engine, &product, &data, true, cfg)
     };
@@ -852,7 +859,7 @@ fn test_stream_batch_row_limit() {
     let stream_row_limit = 2;
     let (_, mut end_point) = {
         let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
-        let mut cfg = Config::default();
+        let mut cfg = new_endpoint_test_config();
         cfg.end_point_stream_batch_row_limit = stream_row_limit;
         init_data_with_details(Context::new(), engine, &product, &data, true, cfg)
     };


### PR DESCRIPTION
Init `endpoint::Host` with default config will spawn too many worker threads, which maybe cause `Resource temporary unavaliable`. This PR fix it by limit the `end-point-concurrency` to 2.