### PR TITLE
CI: cache build temporary result

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -58,7 +58,9 @@ dependencies:
   post:
     # check format first
     - make format && git diff-index --quiet HEAD -- || (git diff; echo please make format and run tests before creating a PR!; exit 1)
-
+    # only update cache when dependency changes or ci configuration changes
+    - git diff-index --quiet HEAD~ Cargo.lock circle.yml ci-build || env SKIP_TESTS=true make trace_test:
+        timeout: 1800
 
 test:
   override:


### PR DESCRIPTION
Cache is saved before tests start on circleci, so everytime tests are run, compilation has to start from scratch. This pr adds build temporary result to cache to speed up ci check.