### PR TITLE
raftstore: relax abnormal leader missing check

### DIFF
--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -80,6 +80,7 @@ pub struct Config {
     /// Similar to the max_leader_missing_duration, instead it will log warnings and
     /// try to alert monitoring systems, if there is any.
     pub abnormal_leader_missing_duration: ReadableDuration,
+    pub peer_stale_state_check_interval: ReadableDuration,
 
     pub snap_apply_batch_size: ReadableSize,
 
@@ -144,7 +145,8 @@ impl Default for Config {
             messages_per_tick: 4096,
             max_peer_down_duration: ReadableDuration::minutes(5),
             max_leader_missing_duration: ReadableDuration::hours(2),
-            abnormal_leader_missing_duration: ReadableDuration::minutes(2),
+            abnormal_leader_missing_duration: ReadableDuration::minutes(10),
+            peer_stale_state_check_interval: ReadableDuration::minutes(5),
             snap_apply_batch_size: ReadableSize::mb(10),
             lock_cf_compact_interval: ReadableDuration::minutes(10),
             lock_cf_compact_bytes_threshold: ReadableSize::mb(256),
@@ -227,12 +229,21 @@ impl Config {
             return Err(box_err!("raftstore.merge-check-tick-interval can't be 0."));
         }
 
-        let abnormal_leader_missing = self.abnormal_leader_missing_duration.as_millis() as u64;
-        if abnormal_leader_missing < election_timeout * 2 {
+        let stale_state_check = self.peer_stale_state_check_interval.as_millis() as u64;
+        if stale_state_check < election_timeout * 2 {
             return Err(box_err!(
-                "abnormal leader missing {} ms is less than election timeout x2 {} ms",
-                abnormal_leader_missing,
+                "peer stale state check interval {} ms is less than election timeout x2 {} ms",
+                stale_state_check,
                 election_timeout * 2
+            ));
+        }
+
+        let abnormal_leader_missing = self.abnormal_leader_missing_duration.as_millis() as u64;
+        if abnormal_leader_missing < stale_state_check {
+            return Err(box_err!(
+                "abnormal leader missing {} ms is less than peer stale state check interval {} ms",
+                abnormal_leader_missing,
+                stale_state_check
             ));
         }
 
@@ -294,9 +305,15 @@ mod tests {
         cfg.merge_check_tick_interval = ReadableDuration::secs(0);
         assert!(cfg.validate().is_err());
 
+        cfg = Config::new();
         cfg.raft_base_tick_interval = ReadableDuration::secs(1);
         cfg.raft_election_timeout_ticks = 10;
-        cfg.abnormal_leader_missing_duration = ReadableDuration::secs(5);
+        cfg.peer_stale_state_check_interval = ReadableDuration::secs(5);
+        assert!(cfg.validate().is_err());
+
+        cfg = Config::new();
+        cfg.peer_stale_state_check_interval = ReadableDuration::minutes(2);
+        cfg.abnormal_leader_missing_duration = ReadableDuration::minutes(1);
         assert!(cfg.validate().is_err());
 
         cfg = Config::new();

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -232,7 +232,7 @@ impl Config {
         let stale_state_check = self.peer_stale_state_check_interval.as_millis() as u64;
         if stale_state_check < election_timeout * 2 {
             return Err(box_err!(
-                "peer stale state check interval {} ms is less than election timeout x2 {} ms",
+                "peer stale state check interval {} ms is less than election timeout x 2 {} ms",
                 stale_state_check,
                 election_timeout * 2
             ));

--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -107,6 +107,7 @@ pub enum Tick {
     CompactLockCf,
     ConsistencyCheck,
     CheckMerge,
+    CheckPeerStaleState,
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -539,6 +539,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         self.register_compact_lock_cf_tick(event_loop);
         self.register_consistency_check_tick(event_loop);
         self.register_merge_check_tick(event_loop);
+        self.register_check_peer_stale_state_tick(event_loop);
 
         let split_check_runner = SplitCheckRunner::new(
             Arc::clone(&self.kv_engine),
@@ -637,7 +638,6 @@ impl<T: Transport, C: PdClient> Store<T, C> {
 
     fn on_raft_base_tick(&mut self, event_loop: &mut EventLoop<Self>) {
         let timer = self.raft_metrics.process_tick.start_coarse_timer();
-        let mut leader_missing = 0;
         for peer in &mut self.region_peers.values_mut() {
             if peer.pending_remove {
                 continue;
@@ -654,51 +654,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             if peer.raft_group.tick() {
                 peer.mark_to_be_checked(&mut self.pending_raft_groups);
             }
-
-            // If this peer detects the leader is missing for a long long time,
-            // it should consider itself as a stale peer which is removed from
-            // the original cluster.
-            // This most likely happens in the following scenario:
-            // At first, there are three peer A, B, C in the cluster, and A is leader.
-            // Peer B gets down. And then A adds D, E, F into the cluster.
-            // Peer D becomes leader of the new cluster, and then removes peer A, B, C.
-            // After all these peer in and out, now the cluster has peer D, E, F.
-            // If peer B goes up at this moment, it still thinks it is one of the cluster
-            // and has peers A, C. However, it could not reach A, C since they are removed
-            // from the cluster or probably destroyed.
-            // Meantime, D, E, F would not reach B, since it's not in the cluster anymore.
-            // In this case, peer B would notice that the leader is missing for a long time,
-            // and it would check with pd to confirm whether it's still a member of the cluster.
-            // If not, it destroys itself as a stale peer which is removed out already.
-            match peer.check_stale_state() {
-                StaleState::Valid => (),
-                StaleState::LeaderMissing => {
-                    warn!(
-                        "{} leader missing longer than abnormal_leader_missing_duration {:?}",
-                        peer.tag, self.cfg.abnormal_leader_missing_duration.0,
-                    );
-                    leader_missing += 1;
-                }
-                StaleState::ToValidate => {
-                    // for peer B in case 1 above
-                    warn!(
-                        "{} leader missing longer than max_leader_missing_duration {:?}. \
-                         To check with pd whether it's still valid",
-                        peer.tag, self.cfg.max_leader_missing_duration.0,
-                    );
-                    let task = PdTask::ValidatePeer {
-                        peer: peer.peer.clone(),
-                        region: peer.region().clone(),
-                        merge_source: None,
-                    };
-                    if let Err(e) = self.pd_worker.schedule(task) {
-                        error!("{} failed to notify pd: {}", peer.tag, e)
-                    }
-                }
-            }
         }
-        self.raft_metrics.leader_missing = leader_missing;
-
         timer.observe_duration();
 
         self.raft_metrics.flush();
@@ -2745,6 +2701,74 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             error!("{} register compact cf-lock tick err: {:?}", self.tag, e);
         }
     }
+
+    fn on_check_peer_stale_state_tick(&mut self, event_loop: &mut EventLoop<Self>) {
+        let mut leader_missing = 0;
+        for peer in &mut self.region_peers.values_mut() {
+            if peer.pending_remove {
+                continue;
+            }
+
+            if peer.is_applying_snapshot() || peer.has_pending_snapshot() {
+                continue;
+            }
+
+            // If this peer detects the leader is missing for a long long time,
+            // it should consider itself as a stale peer which is removed from
+            // the original cluster.
+            // This most likely happens in the following scenario:
+            // At first, there are three peer A, B, C in the cluster, and A is leader.
+            // Peer B gets down. And then A adds D, E, F into the cluster.
+            // Peer D becomes leader of the new cluster, and then removes peer A, B, C.
+            // After all these peer in and out, now the cluster has peer D, E, F.
+            // If peer B goes up at this moment, it still thinks it is one of the cluster
+            // and has peers A, C. However, it could not reach A, C since they are removed
+            // from the cluster or probably destroyed.
+            // Meantime, D, E, F would not reach B, since it's not in the cluster anymore.
+            // In this case, peer B would notice that the leader is missing for a long time,
+            // and it would check with pd to confirm whether it's still a member of the cluster.
+            // If not, it destroys itself as a stale peer which is removed out already.
+            match peer.check_stale_state() {
+                StaleState::Valid => (),
+                StaleState::LeaderMissing => {
+                    warn!(
+                        "{} leader missing longer than abnormal_leader_missing_duration {:?}",
+                        peer.tag, self.cfg.abnormal_leader_missing_duration.0,
+                    );
+                    leader_missing += 1;
+                }
+                StaleState::ToValidate => {
+                    // for peer B in case 1 above
+                    warn!(
+                        "{} leader missing longer than max_leader_missing_duration {:?}. \
+                         To check with pd whether it's still valid",
+                        peer.tag, self.cfg.max_leader_missing_duration.0,
+                    );
+                    let task = PdTask::ValidatePeer {
+                        peer: peer.peer.clone(),
+                        region: peer.region().clone(),
+                        merge_source: None,
+                    };
+                    if let Err(e) = self.pd_worker.schedule(task) {
+                        error!("{} failed to notify pd: {}", peer.tag, e)
+                    }
+                }
+            }
+        }
+        self.raft_metrics.leader_missing = leader_missing;
+
+        self.register_check_peer_stale_state_tick(event_loop);
+    }
+
+    fn register_check_peer_stale_state_tick(&self, event_loop: &mut EventLoop<Self>) {
+        if let Err(e) = register_timer(
+            event_loop,
+            Tick::CheckPeerStaleState,
+            self.cfg.peer_stale_state_check_interval.as_millis(),
+        ) {
+            error!("{} register compact cf-lock tick err: {:?}", self.tag, e);
+        }
+    }
 }
 
 fn report_split_pd(
@@ -3108,6 +3132,7 @@ impl<T: Transport, C: PdClient> mio::Handler for Store<T, C> {
             Tick::CompactLockCf => self.on_compact_lock_cf(event_loop),
             Tick::ConsistencyCheck => self.on_consistency_check_tick(event_loop),
             Tick::CheckMerge => self.on_check_merge(event_loop),
+            Tick::CheckPeerStaleState => self.on_check_peer_stale_state_tick(event_loop),
         }
         slow_log!(t, "{} handle timeout {:?}", self.tag, timeout);
     }

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -121,6 +121,7 @@ fn test_serde_custom_tikv_config() {
         max_peer_down_duration: ReadableDuration::minutes(12),
         max_leader_missing_duration: ReadableDuration::hours(12),
         abnormal_leader_missing_duration: ReadableDuration::hours(6),
+        peer_stale_state_check_interval: ReadableDuration::hours(2),
         snap_apply_batch_size: ReadableSize::mb(12),
         lock_cf_compact_interval: ReadableDuration::minutes(12),
         lock_cf_compact_bytes_threshold: ReadableSize::mb(123),

--- a/tests/config/test-custom.toml
+++ b/tests/config/test-custom.toml
@@ -82,6 +82,7 @@ messages-per-tick = 12345
 max-peer-down-duration = "12m"
 max-leader-missing-duration = "12h"
 abnormal-leader-missing-duration = "6h"
+peer-stale-state-check-interval = "2h"
 snap-apply-batch-size = "12MB"
 consistency-check-interval = "12s"
 report-region-flow-interval = "12m"

--- a/tests/raftstore/util.rs
+++ b/tests/raftstore/util.rs
@@ -99,8 +99,11 @@ pub fn new_store_cfg() -> Config {
         // In production environment, the value of max_leader_missing_duration
         // should be configured far beyond the election timeout.
         max_leader_missing_duration: ReadableDuration::secs(3),
-        // Use a value of 2 seconds as abnormal_leader_missing_duration just for a valid config.
+        // To make a valid config, use a value of 2 seconds as
+        // abnormal_leader_missing_duration and set
+        // peer_stale_state_check_interval to 1 second.
         abnormal_leader_missing_duration: ReadableDuration::secs(2),
+        peer_stale_state_check_interval: ReadableDuration::secs(1),
         pd_heartbeat_tick_interval: ReadableDuration::millis(20),
         region_split_check_diff: ReadableSize(10000),
         report_region_flow_interval: ReadableDuration::millis(100),

--- a/tests/raftstore_cases/test_lease_read.rs
+++ b/tests/raftstore_cases/test_lease_read.rs
@@ -34,7 +34,7 @@ fn configure_for_lease_read<T: Simulator>(cluster: &mut Cluster<T>) {
     let base_tick = cluster.cfg.raft_store.raft_base_tick_interval.0;
     let election_timeout = base_tick * cluster.cfg.raft_store.raft_election_timeout_ticks as u32;
     // Use large peer check interval, abnormal and max leader missing duration to make a valid config,
-    // that is election timeout x2 < peer stale state check < abnormal < max leader missing duration.
+    // that is election timeout x 2 < peer stale state check < abnormal < max leader missing duration.
     cluster.cfg.raft_store.peer_stale_state_check_interval = ReadableDuration(election_timeout * 3);
     cluster.cfg.raft_store.abnormal_leader_missing_duration =
         ReadableDuration(election_timeout * 4);

--- a/tests/raftstore_cases/test_lease_read.rs
+++ b/tests/raftstore_cases/test_lease_read.rs
@@ -30,6 +30,17 @@ use super::node::new_node_cluster;
 use super::transport_simulate::*;
 use super::util::*;
 
+fn configure_for_lease_read<T: Simulator>(cluster: &mut Cluster<T>) {
+    let base_tick = cluster.cfg.raft_store.raft_base_tick_interval.0;
+    let election_timeout = base_tick * cluster.cfg.raft_store.raft_election_timeout_ticks as u32;
+    // Use large peer check interval, abnormal and max leader missing duration to make a valid config,
+    // that is election timeout x2 < peer stale state check < abnormal < max leader missing duration.
+    cluster.cfg.raft_store.peer_stale_state_check_interval = ReadableDuration(election_timeout * 3);
+    cluster.cfg.raft_store.abnormal_leader_missing_duration =
+        ReadableDuration(election_timeout * 4);
+    cluster.cfg.raft_store.max_leader_missing_duration = ReadableDuration(election_timeout * 5);
+}
+
 // A helper function for testing the lease reads and lease renewing.
 // The leader keeps a record of its leader lease, and uses the system's
 // monotonic raw clocktime to check whether its lease has expired.
@@ -50,10 +61,7 @@ fn test_renew_lease<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.cfg.raft_store.raft_base_tick_interval = ReadableDuration::millis(50);
     // Use large election timeout to make leadership stable.
     cluster.cfg.raft_store.raft_election_timeout_ticks = 10_000;
-    // Use large abnormal and max leader missing duration to make a valid config,
-    // that is election timeout x2 < abnormal < max leader missing duration.
-    cluster.cfg.raft_store.abnormal_leader_missing_duration = ReadableDuration::millis(1_000_100);
-    cluster.cfg.raft_store.max_leader_missing_duration = ReadableDuration::millis(1_001_000);
+    configure_for_lease_read(cluster);
 
     let max_lease = Duration::from_secs(2);
     cluster.cfg.raft_store.raft_store_max_leader_lease = ReadableDuration(max_lease);
@@ -146,13 +154,7 @@ fn test_lease_expired<T: Simulator>(cluster: &mut Cluster<T>) {
     // Increase the Raft tick interval to make this test case running reliably.
     // The election timeout is 25_000ms
     cluster.cfg.raft_store.raft_base_tick_interval = ReadableDuration::millis(50);
-    // Use large abnormal and max leader missing duration to make a valid config,
-    // that is election timeout x2 < abnormal < max leader missing duration.
-    let base_tick = cluster.cfg.raft_store.raft_base_tick_interval.0;
-    let election_timeout = base_tick * cluster.cfg.raft_store.raft_election_timeout_ticks as u32;
-    cluster.cfg.raft_store.abnormal_leader_missing_duration =
-        ReadableDuration(election_timeout * 3);
-    cluster.cfg.raft_store.max_leader_missing_duration = ReadableDuration(election_timeout * 4);
+    configure_for_lease_read(cluster);
 
     let election_timeout = cluster.cfg.raft_store.raft_base_tick_interval.0
         * cluster.cfg.raft_store.raft_election_timeout_ticks as u32;
@@ -202,14 +204,10 @@ fn test_lease_unsafe_during_leader_transfers<T: Simulator>(cluster: &mut Cluster
     cluster.cfg.raft_store.raft_log_gc_threshold = 100;
     // Increase the Raft tick interval to make this test case running reliably.
     cluster.cfg.raft_store.raft_base_tick_interval = ReadableDuration::millis(50);
+    configure_for_lease_read(cluster);
+
     let base_tick = cluster.cfg.raft_store.raft_base_tick_interval.0;
     let election_timeout = base_tick * cluster.cfg.raft_store.raft_election_timeout_ticks as u32;
-    // Use large abnormal and max leader missing duration to make a valid config,
-    // that is election timeout x2 < abnormal < max leader missing duration.
-    cluster.cfg.raft_store.abnormal_leader_missing_duration =
-        ReadableDuration(election_timeout * 3);
-    cluster.cfg.raft_store.max_leader_missing_duration = ReadableDuration(election_timeout * 4);
-
     cluster.cfg.raft_store.raft_store_max_leader_lease = ReadableDuration(election_timeout);
 
     let store_id = 1u64;


### PR DESCRIPTION
In the current implementation, we check peer stale state on every raft tick, which is a little aggressive, and may log a lot of `leader missing longer than max_leader_missing_duration`. It should be relaxed.