### PR TITLE
 Add import-mode argument to tune configs for importing data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#fdd9bda07e37ae4fe76e8c3068229f40347ee853"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#7e21e222c8dcb9729a61222995dffc3e836194da"
 dependencies = [
  "bzip2-sys 0.1.6 (git+https://github.com/alexcrichton/bzip2-rs.git)",
  "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -898,7 +898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#fdd9bda07e37ae4fe76e8c3068229f40347ee853"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#7e21e222c8dcb9729a61222995dffc3e836194da"
 dependencies = [
  "crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -349,6 +349,10 @@ fn overwrite_config_with_cmd_args(config: &mut TiKvConfig, matches: &ArgMatches)
         });
         config.raft_store.capacity = capacity;
     }
+
+    if matches.is_present("import-mode") {
+        config.tune_for_import_mode();
+    }
 }
 
 // Set gRPC event engine to epollsig.
@@ -470,6 +474,11 @@ fn main() {
                     "Sets server labels. Uses `,` to separate kv pairs, like \
                      `zone=cn,disk=ssd`",
                 ),
+        )
+        .arg(
+            Arg::with_name("import-mode")
+                .long("import-mode")
+                .help("Run in import mode"),
         )
         .arg(
             Arg::with_name("print-sample-config")

--- a/src/config.rs
+++ b/src/config.rs
@@ -152,9 +152,9 @@ macro_rules! build_cf_opt {
 
 macro_rules! tune_for_import_mode_cf {
     ($opt:expr) => {{
-        // Use universal compaction here it can speed up file
-        // ingestion and range compaction. We may swith back to level
-        // compaction after we have solved these two problems.
+        // Use universal compaction here because it can speed up file
+        // ingestion and range compaction. We may switch back to level
+        // compaction after we have solved these the problems.
         $opt.compaction_style = DBCompactionStyle::Universal;
         // Disable compaction and rate limit.
         $opt.disable_auto_compactions = true;
@@ -828,15 +828,15 @@ impl TiKvConfig {
         let concurrency = sys_info::cpu_num().unwrap() as usize / 2;
         self.import.num_threads = cmp::max(self.import.num_threads, concurrency);
         self.server.grpc_concurrency = cmp::max(self.server.grpc_concurrency, concurrency);
-        // Turn off this to avoid unnecessary compactions.
+        // Turn off this to avoid unnecessary compaction.
         self.raft_store.region_compact_check_interval = ReadableDuration::secs(0);
-        // Tune RocksDB options.
+        // Increase these to speed up RocksDB compaction.
         self.rocksdb.max_background_jobs =
             cmp::max(self.rocksdb.max_background_jobs, concurrency as i32);
         self.rocksdb.max_sub_compactions =
             cmp::max(self.rocksdb.max_sub_compactions, concurrency as u32);
-        tune_for_import_mode_cf!(self.rocksdb.writecf);
         tune_for_import_mode_cf!(self.rocksdb.defaultcf);
+        tune_for_import_mode_cf!(self.rocksdb.writecf);
     }
 
     pub fn check_critical_cfg_with(&self, last_cfg: &Self) -> Result<(), Box<Error>> {

--- a/src/util/config.rs
+++ b/src/util/config.rs
@@ -281,6 +281,11 @@ numeric_enum_mod!{compaction_pri_serde CompactionPriority {
     MinOverlappingRatio = 3,
 }}
 
+numeric_enum_mod!{compaction_style_serde DBCompactionStyle {
+    Level = 0,
+    Universal = 1,
+}}
+
 numeric_enum_mod!{recovery_mode_serde DBRecoveryMode {
     TolerateCorruptedTailRecords = 0,
     AbsoluteConsistency = 1,

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -16,7 +16,7 @@ use std::io::Read;
 use std::fs::File;
 
 use log::LogLevelFilter;
-use rocksdb::{CompactionPriority, DBCompressionType, DBRecoveryMode};
+use rocksdb::{CompactionPriority, DBCompactionStyle, DBCompressionType, DBRecoveryMode};
 use tikv::pd::Config as PdConfig;
 use tikv::server::Config as ServerConfig;
 use tikv::server::readpool::Config as ReadPoolInstanceConfig;
@@ -196,6 +196,10 @@ fn test_serde_custom_tikv_config() {
             dynamic_level_bytes: true,
             num_levels: 4,
             max_bytes_for_level_multiplier: 8,
+            compaction_style: DBCompactionStyle::Universal,
+            disable_auto_compactions: true,
+            soft_pending_compaction_bytes_limit: ReadableSize::gb(12),
+            hard_pending_compaction_bytes_limit: ReadableSize::gb(12),
         },
         writecf: WriteCfConfig {
             block_size: ReadableSize::kb(12),
@@ -230,6 +234,10 @@ fn test_serde_custom_tikv_config() {
             dynamic_level_bytes: true,
             num_levels: 4,
             max_bytes_for_level_multiplier: 8,
+            compaction_style: DBCompactionStyle::Universal,
+            disable_auto_compactions: true,
+            soft_pending_compaction_bytes_limit: ReadableSize::gb(12),
+            hard_pending_compaction_bytes_limit: ReadableSize::gb(12),
         },
         lockcf: LockCfConfig {
             block_size: ReadableSize::kb(12),
@@ -264,6 +272,10 @@ fn test_serde_custom_tikv_config() {
             dynamic_level_bytes: true,
             num_levels: 4,
             max_bytes_for_level_multiplier: 8,
+            compaction_style: DBCompactionStyle::Universal,
+            disable_auto_compactions: true,
+            soft_pending_compaction_bytes_limit: ReadableSize::gb(12),
+            hard_pending_compaction_bytes_limit: ReadableSize::gb(12),
         },
         raftcf: RaftCfConfig {
             block_size: ReadableSize::kb(12),
@@ -298,6 +310,10 @@ fn test_serde_custom_tikv_config() {
             dynamic_level_bytes: true,
             num_levels: 4,
             max_bytes_for_level_multiplier: 8,
+            compaction_style: DBCompactionStyle::Universal,
+            disable_auto_compactions: true,
+            soft_pending_compaction_bytes_limit: ReadableSize::gb(12),
+            hard_pending_compaction_bytes_limit: ReadableSize::gb(12),
         },
     };
     value.raftdb = RaftDbConfig {
@@ -355,6 +371,10 @@ fn test_serde_custom_tikv_config() {
             dynamic_level_bytes: true,
             num_levels: 4,
             max_bytes_for_level_multiplier: 8,
+            compaction_style: DBCompactionStyle::Universal,
+            disable_auto_compactions: true,
+            soft_pending_compaction_bytes_limit: ReadableSize::gb(12),
+            hard_pending_compaction_bytes_limit: ReadableSize::gb(12),
         },
     };
     value.storage = StorageConfig {

--- a/tests/config/test-custom.toml
+++ b/tests/config/test-custom.toml
@@ -156,6 +156,10 @@ compaction-pri = 3
 dynamic-level-bytes = true
 num-levels = 4
 max-bytes-for-level-multiplier = 8
+compaction-style = 1
+disable-auto-compactions = true
+soft-pending-compaction-bytes-limit = "12GB"
+hard-pending-compaction-bytes-limit = "12GB"
 
 [rocksdb.writecf]
 block-size = "12KB"
@@ -190,6 +194,10 @@ compaction-pri = 3
 dynamic-level-bytes = true
 num-levels = 4
 max-bytes-for-level-multiplier = 8
+compaction-style = 1
+disable-auto-compactions = true
+soft-pending-compaction-bytes-limit = "12GB"
+hard-pending-compaction-bytes-limit = "12GB"
 
 [rocksdb.lockcf]
 block-size = "12KB"
@@ -224,6 +232,10 @@ compaction-pri = 3
 dynamic-level-bytes = true
 num-levels = 4
 max-bytes-for-level-multiplier = 8
+compaction-style = 1
+disable-auto-compactions = true
+soft-pending-compaction-bytes-limit = "12GB"
+hard-pending-compaction-bytes-limit = "12GB"
 
 [rocksdb.raftcf]
 block-size = "12KB"
@@ -258,6 +270,10 @@ compaction-pri = 3
 dynamic-level-bytes = true
 num-levels = 4
 max-bytes-for-level-multiplier = 8
+compaction-style = 1
+disable-auto-compactions = true
+soft-pending-compaction-bytes-limit = "12GB"
+hard-pending-compaction-bytes-limit = "12GB"
 
 [raftdb]
 wal-recovery-mode = 3
@@ -315,6 +331,10 @@ compaction-pri = 3
 dynamic-level-bytes = true
 num-levels = 4
 max-bytes-for-level-multiplier = 8
+compaction-style = 1
+disable-auto-compactions = true
+soft-pending-compaction-bytes-limit = "12GB"
+hard-pending-compaction-bytes-limit = "12GB"
 
 [security]
 ca-path = "invalid path"


### PR DESCRIPTION
Some of these configs may be tuned without restart, but some of them
are hard to be changed on the fly, this is the best we can do for now,
but we will explore the possibilities in the future.