### PR TITLE
[DNM] support unsafe_cleanup_range command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,7 +461,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git#340ba9feaf29e9be3404be5b891999746330f677"
+source = "git+https://github.com/zhangjinpeng1987/kvproto.git?branch=unsafe_clean_range#21827c58d062c260754c8b991d271a1162aabbe0"
 dependencies = [
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1141,7 +1141,7 @@ dependencies = [
  "grpcio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)",
- "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto 0.0.1 (git+https://github.com/zhangjinpeng1987/kvproto.git?branch=unsafe_clean_range)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1456,7 +1456,7 @@ dependencies = [
 "checksum jemalloc-sys 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)" = "<none>"
+"checksum kvproto 0.0.1 (git+https://github.com/zhangjinpeng1987/kvproto.git?branch=unsafe_clean_range)" = "<none>"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,8 @@ git = "https://github.com/pingcap/murmur3.git"
 git = "https://github.com/pingcap/rust-rocksdb.git"
 
 [dependencies.kvproto]
-git = "https://github.com/pingcap/kvproto.git"
+git = "https://github.com/zhangjinpeng1987/kvproto.git"
+branch = "unsafe_clean_range"
 
 [dependencies.tipb]
 git = "https://github.com/pingcap/tipb.git"

--- a/src/raftstore/store/keys.rs
+++ b/src/raftstore/store/keys.rs
@@ -47,6 +47,11 @@ pub const REGION_META_PREFIX_KEY: &[u8] = &[LOCAL_PREFIX, REGION_META_PREFIX];
 pub const REGION_META_MIN_KEY: &[u8] = &[LOCAL_PREFIX, REGION_META_PREFIX];
 pub const REGION_META_MAX_KEY: &[u8] = &[LOCAL_PREFIX, REGION_META_PREFIX + 1];
 
+// Unsafe cleanup range tasks.
+pub const UNSAFE_CLEANUP_RANGE_PREFIX: u8 = 0x04;
+pub const UNSAFE_CLEANUP_RANGE_MIN_KEY: &[u8] = &[LOCAL_PREFIX, UNSAFE_CLEANUP_RANGE_PREFIX];
+pub const UNSAFE_CLEANUP_RANGE_MAX_KEY: &[u8] = &[LOCAL_PREFIX, UNSAFE_CLEANUP_RANGE_PREFIX + 1];
+
 // Following are the suffix after the local prefix.
 // For region id
 pub const RAFT_LOG_SUFFIX: u8 = 0x01;
@@ -215,6 +220,25 @@ pub fn data_end_key(region_end_key: &[u8]) -> Vec<u8> {
         DATA_MAX_KEY.to_vec()
     } else {
         data_key(region_end_key)
+    }
+}
+
+pub fn unsafe_cleanup_range_key(key: &[u8]) -> Vec<u8> {
+    let mut vec = Vec::with_capacity(UNSAFE_CLEANUP_RANGE_MIN_KEY.len() + key.len());
+    vec.extend_from_slice(UNSAFE_CLEANUP_RANGE_MIN_KEY);
+    vec.extend_from_slice(key);
+    vec
+}
+
+pub fn decode_unsafe_cleanup_range_key(key: &[u8]) -> Result<Vec<u8>> {
+    let prefix_len = UNSAFE_CLEANUP_RANGE_MIN_KEY.len();
+    if key.len() >= prefix_len && &key[..prefix_len] == UNSAFE_CLEANUP_RANGE_MIN_KEY {
+        Ok(key[prefix_len..].to_vec())
+    } else {
+        Err(box_err!(
+            "Invalid unsafe_cleanup_range key {:?}",
+            escape(key)
+        ))
     }
 }
 

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -1152,9 +1152,11 @@ impl Peer {
         for r in req.get_requests() {
             match r.get_cmd_type() {
                 CmdType::Get | CmdType::Snap => is_read = true,
-                CmdType::Delete | CmdType::Put | CmdType::DeleteRange | CmdType::IngestSST => {
-                    is_write = true
-                }
+                CmdType::Delete
+                | CmdType::Put
+                | CmdType::DeleteRange
+                | CmdType::UnsafeCleanupRange
+                | CmdType::IngestSST => is_write = true,
                 CmdType::Prewrite | CmdType::Invalid => {
                     return Err(box_err!(
                         "invalid cmd type {:?}, message maybe currupted",
@@ -1791,6 +1793,7 @@ impl Peer {
                 | CmdType::Put
                 | CmdType::Delete
                 | CmdType::DeleteRange
+                | CmdType::UnsafeCleanupRange
                 | CmdType::IngestSST
                 | CmdType::Invalid => unreachable!(),
             };

--- a/src/raftstore/store/worker/mod.rs
+++ b/src/raftstore/store/worker/mod.rs
@@ -51,6 +51,7 @@ mod raftlog_gc;
 mod metrics;
 mod consistency_check;
 mod cleanup_sst;
+mod unsafe_cleanup_range;
 pub mod apply;
 
 pub use self::region::{Runner as RegionRunner, Task as RegionTask};
@@ -59,5 +60,6 @@ pub use self::compact::{Runner as CompactRunner, Task as CompactTask};
 pub use self::raftlog_gc::{Runner as RaftlogGcRunner, Task as RaftlogGcTask};
 pub use self::consistency_check::{Runner as ConsistencyCheckRunner, Task as ConsistencyCheckTask};
 pub use self::cleanup_sst::{Runner as CleanupSSTRunner, Task as CleanupSSTTask};
+pub use self::unsafe_cleanup_range::{Runner as UnsafeCleanupRangeRunner, UNSAFE_CLEANUP_INTERVAL};
 pub use self::apply::{Apply, ApplyMetrics, ApplyRes, Proposal, RegionProposal, Registration,
                       Runner as ApplyRunner, Task as ApplyTask, TaskRes as ApplyTaskRes};

--- a/src/raftstore/store/worker/unsafe_cleanup_range.rs
+++ b/src/raftstore/store/worker/unsafe_cleanup_range.rs
@@ -1,0 +1,132 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use rocksdb::{ReadOptions, SeekKey, Writable, DB};
+
+use util::escape;
+use util::timer::Timer;
+use util::worker::{Runnable, RunnableWithTimer};
+use raftstore::store::{keys, util};
+use storage::{decode_cf, encode_cf, CF_DEFAULT};
+use util::rocksdb::get_cf_handle;
+
+pub const UNSAFE_CLEANUP_INTERVAL: u64 = 5_000; // milliseconds
+
+pub struct Runner {
+    engine: Arc<DB>,
+    use_delete_range: bool,
+}
+
+pub fn encode_task_key(cf: &str, start_key: &[u8]) -> Vec<u8> {
+    let mut vec = keys::unsafe_cleanup_range_key(start_key);
+    vec.push(encode_cf(cf));
+    vec
+}
+
+fn decode_task_key(key: &[u8]) -> (&'static str, Vec<u8>) {
+    let len = key.len();
+    assert!(len >= keys::UNSAFE_CLEANUP_RANGE_MIN_KEY.len() + 1);
+    let cf = decode_cf(key[len - 1]);
+    let start_key = keys::decode_unsafe_cleanup_range_key(&key[..len - 1])
+        .unwrap_or_else(|e| panic!("decode key failed: {:?}", e));
+    (cf, start_key)
+}
+
+impl Runner {
+    pub fn new(engine: Arc<DB>, use_delete_range: bool) -> Runner {
+        Runner {
+            engine: engine,
+            use_delete_range: use_delete_range,
+        }
+    }
+
+    fn unsafe_cleanup_range(&self, cf: &str, start_key: &[u8], end_key: &[u8]) {
+        let handle = get_cf_handle(&self.engine, cf).unwrap();
+
+        // Use delete_files_in_range to drop as many sst files as possible, this
+        // is a way to reclaim disk space quickly after drop a table/index.
+        self.engine
+            .delete_files_in_range_cf(handle, start_key, end_key, /* include_end */ false)
+            .unwrap_or_else(|e| {
+                panic!(
+                    "failed to delete files in range [{}, {}): {:?}",
+                    escape(start_key),
+                    escape(end_key),
+                    e
+                )
+            });
+
+        // Delete all remaining keys.
+        util::delete_all_in_range_cf(&self.engine, cf, start_key, end_key, self.use_delete_range)
+            .unwrap_or_else(|e| {
+                panic!(
+                    "failed to delete all in range [{}, {}), cf: {}, err: {:?}",
+                    escape(start_key),
+                    escape(end_key),
+                    cf,
+                    e
+                );
+            });
+    }
+
+    fn pop_task(&self, task_key: &[u8]) {
+        let handle = get_cf_handle(&self.engine, CF_DEFAULT)
+            .unwrap_or_else(|e| panic!("get cf default failed, error {:?}", e));
+        self.engine
+            .delete_cf(handle, task_key)
+            .unwrap_or_else(|e| panic!("write to db failed, error {:?}", e));
+    }
+
+    fn unsafe_cleanup_ranges(&self) {
+        let t = Instant::now();
+        let mut read_options = ReadOptions::default();
+        read_options.fill_cache(false);
+        read_options.set_iterate_lower_bound(keys::UNSAFE_CLEANUP_RANGE_MIN_KEY);
+        read_options.set_iterate_upper_bound(keys::UNSAFE_CLEANUP_RANGE_MAX_KEY);
+        let mut iter = self.engine.iter_opt(read_options);
+        iter.seek(SeekKey::Start);
+        while iter.valid() {
+            let (cf, start_key) = decode_task_key(iter.key());
+
+            // Cleanup the range.
+            self.unsafe_cleanup_range(cf, &start_key, iter.value());
+
+            // Pop the task after range have been cleanup.
+            self.pop_task(iter.key());
+
+            // If there are too many ranges need to cleanup, it will takes a long long
+            // while to finish. In that situation if we don't limit the total time of
+            // this function, shutdown will wait a long long time.
+            if t.elapsed() > Duration::from_millis(UNSAFE_CLEANUP_INTERVAL) {
+                break;
+            }
+
+            iter.next();
+        }
+    }
+}
+
+impl Runnable<i32> for Runner {
+    fn run(&mut self, _: i32) {}
+}
+
+impl RunnableWithTimer<i32, ()> for Runner {
+    fn on_timeout(&mut self, timer: &mut Timer<()>, _: ()) {
+        self.unsafe_cleanup_ranges();
+
+        timer.add_task(Duration::from_millis(UNSAFE_CLEANUP_INTERVAL), ());
+    }
+}

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -75,6 +75,7 @@ struct Metrics {
     kv_resolve_lock: Histogram,
     kv_gc: Histogram,
     kv_delete_range: Histogram,
+    kv_unsafe_cleanup_range: Histogram,
     raw_get: Histogram,
     raw_scan: Histogram,
     raw_put: Histogram,
@@ -100,6 +101,8 @@ impl Metrics {
             kv_resolve_lock: GRPC_MSG_HISTOGRAM_VEC.with_label_values(&["kv_resolve_lock"]),
             kv_gc: GRPC_MSG_HISTOGRAM_VEC.with_label_values(&["kv_gc"]),
             kv_delete_range: GRPC_MSG_HISTOGRAM_VEC.with_label_values(&["kv_delete_range"]),
+            kv_unsafe_cleanup_range: GRPC_MSG_HISTOGRAM_VEC
+                .with_label_values(&["kv_unsafe_cleanup_range"]),
             raw_get: GRPC_MSG_HISTOGRAM_VEC.with_label_values(&["raw_get"]),
             raw_scan: GRPC_MSG_HISTOGRAM_VEC.with_label_values(&["raw_scan"]),
             raw_put: GRPC_MSG_HISTOGRAM_VEC.with_label_values(&["raw_put"]),
@@ -607,6 +610,48 @@ impl<T: RaftStoreRouter + 'static> tikvpb_grpc::Tikv for Service<T> {
             .map_err(Error::from)
             .map(|v| {
                 let mut resp = DeleteRangeResponse::new();
+                if let Some(err) = extract_region_error(&v) {
+                    resp.set_region_error(err);
+                } else if let Err(e) = v {
+                    resp.set_error(format!("{}", e));
+                }
+                resp
+            })
+            .and_then(|res| sink.success(res).map_err(Error::from))
+            .map(|_| timer.observe_duration())
+            .map_err(move |e| {
+                debug!("{} failed: {:?}", LABEL, e);
+                GRPC_MSG_FAIL_COUNTER.with_label_values(&[LABEL]).inc();
+            });
+
+        ctx.spawn(future);
+    }
+
+    fn kv_unsafe_cleanup_range(
+        &self,
+        ctx: RpcContext,
+        mut req: UnsafeCleanupRangeRequest,
+        sink: UnarySink<UnsafeCleanupRangeResponse>,
+    ) {
+        const LABEL: &str = "kv_unsafe_cleanup_range";
+        let timer = self.metrics.kv_unsafe_cleanup_range.start_coarse_timer();
+
+        let (cb, future) = paired_future_callback();
+        let res = self.storage.async_unsafe_cleanup_range(
+            req.take_context(),
+            Key::from_raw(req.get_start_key()),
+            Key::from_raw(req.get_end_key()),
+            cb,
+        );
+        if let Err(e) = res {
+            self.send_fail_status(ctx, sink, Error::from(e), RpcStatusCode::ResourceExhausted);
+            return;
+        }
+
+        let future = future
+            .map_err(Error::from)
+            .map(|v| {
+                let mut resp = UnsafeCleanupRangeResponse::new();
                 if let Some(err) = extract_region_error(&v) {
                     resp.set_region_error(err);
                 } else if let Err(e) = v {

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -67,6 +67,7 @@ pub enum Modify {
     Delete(CfName, Key),
     Put(CfName, Key, Value),
     DeleteRange(CfName, Key, Key),
+    UnsafeCleanupRange(CfName, Key, Key),
 }
 
 pub trait Engine: Send + Debug {

--- a/src/storage/engine/raftkv.rs
+++ b/src/storage/engine/raftkv.rs
@@ -17,7 +17,8 @@ use std::time::Duration;
 use std::result;
 
 use kvproto::raft_cmdpb::{CmdType, DeleteRangeRequest, DeleteRequest, PutRequest, RaftCmdRequest,
-                          RaftCmdResponse, RaftRequestHeader, Request, Response};
+                          RaftCmdResponse, RaftRequestHeader, Request, Response,
+                          UnsafeCleanupRangeRequest};
 use kvproto::errorpb;
 use kvproto::kvrpcpb::Context;
 use protobuf::RepeatedField;
@@ -329,6 +330,14 @@ impl<S: RaftStoreRouter> Engine for RaftKv<S> {
                     delete_range.set_end_key(end_key.encoded().to_owned());
                     req.set_cmd_type(CmdType::DeleteRange);
                     req.set_delete_range(delete_range);
+                }
+                Modify::UnsafeCleanupRange(cf, start_key, end_key) => {
+                    let mut unsafe_cleanup_range = UnsafeCleanupRangeRequest::new();
+                    unsafe_cleanup_range.set_cf(cf.to_string());
+                    unsafe_cleanup_range.set_start_key(start_key.encoded().to_owned());
+                    unsafe_cleanup_range.set_end_key(end_key.encoded().to_owned());
+                    req.set_cmd_type(CmdType::UnsafeCleanupRange);
+                    req.set_unsafe_cleanup_range(unsafe_cleanup_range);
                 }
             }
             reqs.push(req);

--- a/src/storage/engine/rocksdb.rs
+++ b/src/storage/engine/rocksdb.rs
@@ -160,6 +160,16 @@ fn write_modifies(db: &DB, modifies: Vec<Modify>) -> Result<()> {
                 let handle = rocksdb::get_cf_handle(db, cf)?;
                 wb.delete_range_cf(handle, start_key.encoded(), end_key.encoded())
             }
+            Modify::UnsafeCleanupRange(cf, start_key, end_key) => {
+                trace!(
+                    "EngineRocksdb: unsafe_cleanup_range_cf {}, {}, {}",
+                    cf,
+                    escape(start_key.encoded()),
+                    escape(end_key.encoded())
+                );
+                let handle = rocksdb::get_cf_handle(db, cf)?;
+                wb.delete_range_cf(handle, start_key.encoded(), end_key.encoded())
+            }
         };
         if let Err(msg) = res {
             return Err(Error::RocksDb(msg));

--- a/src/storage/mvcc/reader.rs
+++ b/src/storage/mvcc/reader.rs
@@ -637,7 +637,7 @@ mod tests {
                         let handle = rocksdb_util::get_cf_handle(db, cf).unwrap();
                         wb.delete_cf(handle, &k).unwrap();
                     }
-                    Modify::DeleteRange(cf, k1, k2) => {
+                    Modify::DeleteRange(cf, k1, k2) | Modify::UnsafeCleanupRange(cf, k1, k2) => {
                         let k1 = keys::data_key(k1.encoded());
                         let k2 = keys::data_key(k2.encoded());
                         let handle = rocksdb_util::get_cf_handle(db, cf).unwrap();

--- a/tests/raftstore/util.rs
+++ b/tests/raftstore/util.rs
@@ -339,9 +339,11 @@ pub fn make_cb(cmd: &RaftCmdRequest) -> (Callback, mpsc::Receiver<RaftCmdRespons
     for req in cmd.get_requests() {
         match req.get_cmd_type() {
             CmdType::Get | CmdType::Snap => is_read = true,
-            CmdType::Put | CmdType::Delete | CmdType::DeleteRange | CmdType::IngestSST => {
-                is_write = true
-            }
+            CmdType::Put
+            | CmdType::Delete
+            | CmdType::DeleteRange
+            | CmdType::UnsafeCleanupRange
+            | CmdType::IngestSST => is_write = true,
             CmdType::Invalid | CmdType::Prewrite => panic!("Invalid RaftCmdRequest: {:?}", cmd),
         }
     }


### PR DESCRIPTION
1) Support unsafe-cleanup-range command. unsafe-cleanup-range means cleanup a range and this range will never be used, for example a table/index have been dropped.
2) Use a individual worker to run unsafe-cleanup-range command, so it will not block apply worker.