### PR TITLE
tests: use mock FutureScheduler in tests instead of Option<FutureSche…

### DIFF
--- a/benches/bin/mvcc.rs
+++ b/benches/bin/mvcc.rs
@@ -32,8 +32,7 @@ use super::print_result;
 fn bench_tombstone_scan() -> BenchSamples {
     let (tx, _) = unbounded();
     let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-        || storage::ReadPoolContext::new(FutureScheduler::new("test future scheduler",
-                                                              tx.clone()))
+        || storage::ReadPoolContext::new(FutureScheduler::new("test future scheduler", tx.clone()))
     });
     let store = SyncStorage::new(&Default::default(), read_pool);
     let mut ts_generator = 1..;

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -196,7 +196,7 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
     let pd_sender = pd_worker.scheduler();
     let storage_read_pool = ReadPool::new("store-read", &cfg.readpool.storage, || {
         let pd_sender = pd_sender.clone();
-        move || storage::ReadPoolContext::new(Some(pd_sender.clone()))
+        move || storage::ReadPoolContext::new(pd_sender.clone())
     });
     let mut storage = create_raft_storage(raft_router.clone(), &cfg.storage, storage_read_pool)
         .unwrap_or_else(|e| fatal!("failed to create raft stroage: {:?}", e));

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -196,11 +196,13 @@ mod tests {
     use std::sync::atomic::*;
 
     use super::*;
+
     use super::super::{Config, Result};
     use super::super::transport::RaftStoreRouter;
     use super::super::resolve::{Callback as ResolveCallback, StoreAddrResolver};
     use storage::{self, Config as StorageConfig, Storage};
     use kvproto::raft_serverpb::RaftMessage;
+    use futures::sync::mpsc::unbounded;
     use raftstore::Result as RaftStoreResult;
     use raftstore::store::Msg as StoreMsg;
     use raftstore::store::*;
@@ -265,8 +267,10 @@ mod tests {
         let storage_cfg = StorageConfig::default();
         cfg.addr = "127.0.0.1:0".to_owned();
 
+        let (tx, _) = unbounded();
         let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-            || storage::ReadPoolContext::new(None)
+            || storage::ReadPoolContext::new(FutureScheduler::new("test future scheduler",
+                                                                  tx.clone()))
         });
         let mut storage = Storage::new(&storage_cfg, read_pool).unwrap();
         storage.start(&storage_cfg).unwrap();

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -269,8 +269,12 @@ mod tests {
 
         let (tx, _) = unbounded();
         let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-            || storage::ReadPoolContext::new(FutureScheduler::new("test future scheduler",
-                                                                  tx.clone()))
+            || {
+                storage::ReadPoolContext::new(FutureScheduler::new(
+                    "test future scheduler",
+                    tx.clone(),
+                ))
+            }
         });
         let mut storage = Storage::new(&storage_cfg, read_pool).unwrap();
         storage.start(&storage_cfg).unwrap();

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1186,7 +1186,9 @@ mod tests {
     use super::*;
     use std::sync::mpsc::{channel, Sender};
     use kvproto::kvrpcpb::Context;
+    use futures::sync::mpsc::unbounded;
     use util::config::ReadableSize;
+    use util::worker::FutureScheduler;
 
     fn expect_none(x: Result<Option<Value>>) {
         assert_eq!(x.unwrap(), None);
@@ -1242,8 +1244,10 @@ mod tests {
     }
 
     fn new_read_pool() -> ReadPool<ReadPoolContext> {
+        let (tx, _) = unbounded();
         ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-            || ReadPoolContext::new(None)
+            || ReadPoolContext::new(FutureScheduler::new("test future scheduler",
+                                                         tx.clone()))
         })
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1186,9 +1186,8 @@ mod tests {
     use super::*;
     use std::sync::mpsc::{channel, Sender};
     use kvproto::kvrpcpb::Context;
-    use futures::sync::mpsc::unbounded;
     use util::config::ReadableSize;
-    use util::worker::FutureScheduler;
+    use util::worker::FutureWorker;
 
     fn expect_none(x: Result<Option<Value>>) {
         assert_eq!(x.unwrap(), None);
@@ -1244,9 +1243,9 @@ mod tests {
     }
 
     fn new_read_pool() -> ReadPool<ReadPoolContext> {
-        let (tx, _) = unbounded();
+        let pd_worker = FutureWorker::new("test future worker");
         ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-            || ReadPoolContext::new(FutureScheduler::new("test future scheduler", tx.clone()))
+            || ReadPoolContext::new(pd_worker.scheduler())
         })
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1246,8 +1246,7 @@ mod tests {
     fn new_read_pool() -> ReadPool<ReadPoolContext> {
         let (tx, _) = unbounded();
         ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-            || ReadPoolContext::new(FutureScheduler::new("test future scheduler",
-                                                         tx.clone()))
+            || ReadPoolContext::new(FutureScheduler::new("test future scheduler", tx.clone()))
         })
     }
 

--- a/src/storage/readpool_context.rs
+++ b/src/storage/readpool_context.rs
@@ -132,7 +132,8 @@ impl futurepool::Context for Context {
         if !self.read_flow_stats.is_empty() {
             let mut read_stats = HashMap::default();
             mem::swap(&mut read_stats, &mut self.read_flow_stats);
-            let result = self.pd_sender.schedule(pd::PdTask::ReadStats { read_stats });
+            let result = self.pd_sender
+                .schedule(pd::PdTask::ReadStats { read_stats });
             if let Err(e) = result {
                 error!("Failed to send readpool read flow statistics: {:?}", e);
             }

--- a/src/util/worker/future.rs
+++ b/src/util/worker/future.rs
@@ -55,7 +55,7 @@ pub struct Scheduler<T> {
 }
 
 impl<T: Display> Scheduler<T> {
-    fn new<S: Into<String>>(name: S, sender: UnboundedSender<Option<T>>) -> Scheduler<T> {
+    pub fn new<S: Into<String>>(name: S, sender: UnboundedSender<Option<T>>) -> Scheduler<T> {
         Scheduler {
             name: Arc::new(name.into()),
             sender: sender,

--- a/src/util/worker/future.rs
+++ b/src/util/worker/future.rs
@@ -55,7 +55,7 @@ pub struct Scheduler<T> {
 }
 
 impl<T: Display> Scheduler<T> {
-    pub fn new<S: Into<String>>(name: S, sender: UnboundedSender<Option<T>>) -> Scheduler<T> {
+    fn new<S: Into<String>>(name: S, sender: UnboundedSender<Option<T>>) -> Scheduler<T> {
         Scheduler {
             name: Arc::new(name.into()),
             sender: sender,

--- a/tests/failpoints_cases/test_storage.rs
+++ b/tests/failpoints_cases/test_storage.rs
@@ -23,8 +23,7 @@ use tikv::util::HandyRwLock;
 use raftstore::server::new_server_cluster;
 use storage::util::new_raft_engine;
 use tikv::server::readpool::{self, ReadPool};
-use tikv::util::worker::FutureScheduler;
-use futures::sync::mpsc::unbounded;
+use tikv::util::worker::FutureWorker;
 
 #[test]
 fn test_storage_1gc() {
@@ -32,9 +31,9 @@ fn test_storage_1gc() {
     let snapshot_fp = "raftkv_async_snapshot_finish";
     let batch_snapshot_fp = "raftkv_async_batch_snapshot_finish";
     let (_cluster, engine, ctx) = new_raft_engine(3, "");
-    let (tx, _) = unbounded();
+    let pd_worker = FutureWorker::new("test future worker");
     let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-        || storage::ReadPoolContext::new(FutureScheduler::new("test future scheduler", tx.clone()))
+        || storage::ReadPoolContext::new(pd_worker.scheduler())
     });
     let config = Config::default();
     let mut storage = Storage::from_engine(engine.clone(), &config, read_pool).unwrap();
@@ -78,9 +77,9 @@ fn test_scheduler_leader_change_twice() {
     let peers = region0.get_peers();
     cluster.must_transfer_leader(region0.get_id(), peers[0].clone());
     let config = Config::default();
-    let (tx, _) = unbounded();
+    let pd_worker = FutureWorker::new("test future worker");
     let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-        || storage::ReadPoolContext::new(FutureScheduler::new("test future scheduler", tx.clone()))
+        || storage::ReadPoolContext::new(pd_worker.scheduler())
     });
 
     let engine0 = cluster.sim.rl().storages[&peers[0].get_id()].clone();
@@ -129,14 +128,9 @@ fn test_scheduler_leader_change_twice() {
         cluster.must_transfer_leader(region1.get_id(), peers[1].clone());
 
         let engine1 = cluster.sim.rl().storages[&peers[1].get_id()].clone();
-        let (tx, _) = unbounded();
+        let pd_worker = FutureWorker::new("test future worker");
         let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-            || {
-                storage::ReadPoolContext::new(FutureScheduler::new(
-                    "test future scheduler",
-                    tx.clone(),
-                ))
-            }
+            || storage::ReadPoolContext::new(pd_worker.scheduler())
         });
         let mut storage1 = Storage::from_engine(engine1, &config, read_pool).unwrap();
         storage1.start(&config).unwrap();

--- a/tests/failpoints_cases/test_storage.rs
+++ b/tests/failpoints_cases/test_storage.rs
@@ -34,8 +34,7 @@ fn test_storage_1gc() {
     let (_cluster, engine, ctx) = new_raft_engine(3, "");
     let (tx, _) = unbounded();
     let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-        || storage::ReadPoolContext::new(FutureScheduler::new("test future scheduler",
-                                                              tx.clone()))
+        || storage::ReadPoolContext::new(FutureScheduler::new("test future scheduler", tx.clone()))
     });
     let config = Config::default();
     let mut storage = Storage::from_engine(engine.clone(), &config, read_pool).unwrap();
@@ -81,8 +80,7 @@ fn test_scheduler_leader_change_twice() {
     let config = Config::default();
     let (tx, _) = unbounded();
     let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-        || storage::ReadPoolContext::new(FutureScheduler::new("test future scheduler",
-                                                              tx.clone()))
+        || storage::ReadPoolContext::new(FutureScheduler::new("test future scheduler", tx.clone()))
     });
 
     let engine0 = cluster.sim.rl().storages[&peers[0].get_id()].clone();
@@ -133,8 +131,12 @@ fn test_scheduler_leader_change_twice() {
         let engine1 = cluster.sim.rl().storages[&peers[1].get_id()].clone();
         let (tx, _) = unbounded();
         let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-            || storage::ReadPoolContext::new(FutureScheduler::new("test future scheduler",
-                                                                  tx.clone()))
+            || {
+                storage::ReadPoolContext::new(FutureScheduler::new(
+                    "test future scheduler",
+                    tx.clone(),
+                ))
+            }
         });
         let mut storage1 = Storage::from_engine(engine1, &config, read_pool).unwrap();
         storage1.start(&config).unwrap();

--- a/tests/storage/assert_storage.rs
+++ b/tests/storage/assert_storage.rs
@@ -36,8 +36,12 @@ impl Default for AssertionStorage {
     fn default() -> AssertionStorage {
         let (tx, _) = unbounded();
         let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-            || storage::ReadPoolContext::new(FutureScheduler::new("test future scheduler",
-                                                                  tx.clone()))
+            || {
+                storage::ReadPoolContext::new(FutureScheduler::new(
+                    "test future scheduler",
+                    tx.clone(),
+                ))
+            }
         });
         AssertionStorage {
             ctx: Context::new(),
@@ -73,7 +77,12 @@ impl AssertionStorage {
         self.ctx.set_peer(leader.clone());
         let (tx, _) = unbounded();
         let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-            || storage::ReadPoolContext::new(FutureScheduler::new("test future scheduler", tx.clone()))
+            || {
+                storage::ReadPoolContext::new(FutureScheduler::new(
+                    "test future scheduler",
+                    tx.clone(),
+                ))
+            }
         });
         self.store = SyncStorage::from_engine(engine, &Config::default(), read_pool);
     }

--- a/tests/storage/assert_storage.rs
+++ b/tests/storage/assert_storage.rs
@@ -23,8 +23,7 @@ use super::util::new_raft_storage_with_store_count;
 use tikv::storage::config::Config;
 use tikv::storage::engine;
 use tikv::server::readpool::{self, ReadPool};
-use tikv::util::worker::FutureScheduler;
-use futures::sync::mpsc::unbounded;
+use tikv::util::worker::FutureWorker;
 
 #[derive(Clone)]
 pub struct AssertionStorage {
@@ -34,14 +33,9 @@ pub struct AssertionStorage {
 
 impl Default for AssertionStorage {
     fn default() -> AssertionStorage {
-        let (tx, _) = unbounded();
+        let pd_worker = FutureWorker::new("test future worker");
         let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-            || {
-                storage::ReadPoolContext::new(FutureScheduler::new(
-                    "test future scheduler",
-                    tx.clone(),
-                ))
-            }
+            || storage::ReadPoolContext::new(pd_worker.scheduler())
         });
         AssertionStorage {
             ctx: Context::new(),
@@ -75,14 +69,9 @@ impl AssertionStorage {
         self.ctx.set_region_id(region.get_id());
         self.ctx.set_region_epoch(region.get_region_epoch().clone());
         self.ctx.set_peer(leader.clone());
-        let (tx, _) = unbounded();
+        let pd_worker = FutureWorker::new("test future worker");
         let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-            || {
-                storage::ReadPoolContext::new(FutureScheduler::new(
-                    "test future scheduler",
-                    tx.clone(),
-                ))
-            }
+            || storage::ReadPoolContext::new(pd_worker.scheduler())
         });
         self.store = SyncStorage::from_engine(engine, &Config::default(), read_pool);
     }

--- a/tests/storage/util.rs
+++ b/tests/storage/util.rs
@@ -18,9 +18,8 @@ use raftstore::cluster::Cluster;
 use raftstore::server::ServerCluster;
 use raftstore::server::new_server_cluster;
 use tikv::util::HandyRwLock;
-use tikv::util::worker::FutureScheduler;
 use tikv::server::readpool::{self, ReadPool};
-use futures::sync::mpsc::unbounded;
+use tikv::util::worker::FutureWorker;
 use super::sync_storage::SyncStorage;
 
 pub fn new_raft_engine(count: usize, key: &str) -> (Cluster<ServerCluster>, Box<Engine>, Context) {
@@ -42,9 +41,9 @@ pub fn new_raft_storage_with_store_count(
     count: usize,
     key: &str,
 ) -> (Cluster<ServerCluster>, SyncStorage, Context) {
-    let (tx, _) = unbounded();
+    let pd_worker = FutureWorker::new("test future worker");
     let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-        || storage::ReadPoolContext::new(FutureScheduler::new("test future scheduler", tx.clone()))
+        || storage::ReadPoolContext::new(pd_worker.scheduler())
     });
     let (cluster, engine, ctx) = new_raft_engine(count, key);
     (

--- a/tests/storage_cases/test_storage.rs
+++ b/tests/storage_cases/test_storage.rs
@@ -24,6 +24,8 @@ use tikv::storage::engine::{Engine, EngineRocksdb, TEMP_DIR};
 use tikv::storage::txn::{GC_BATCH_SIZE, RESOLVE_LOCK_BATCH_SIZE};
 use tikv::storage::mvcc::MAX_TXN_WRITE_SIZE;
 use tikv::server::readpool::{self, ReadPool};
+use tikv::util::worker::FutureScheduler;
+use futures::sync::mpsc::unbounded;
 
 use super::assert_storage::AssertionStorage;
 use std::u64;
@@ -862,8 +864,9 @@ fn bench_txn_store_rocksdb_put_x100(b: &mut Bencher) {
 fn test_conflict_commands_on_fault_engine() {
     let engine = EngineRocksdb::new(TEMP_DIR, ALL_CFS, None).unwrap();
     let box_engine = engine.clone();
+    let (tx, _) = unbounded();
     let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-        || storage::ReadPoolContext::new(None)
+        || storage::ReadPoolContext::new(FutureScheduler::new("test future scheduler", tx.clone()))
     });
     let config = Default::default();
     let mut store = SyncStorage::prepare(box_engine, &config, read_pool);


### PR DESCRIPTION
New to the project and making an attempt at #2886.

Avoids using an `Option<FutureScheduler>` in `Storage::ReadPoolContext`, which was done only for testing purposes. When tests create a read pool, they use a test `FutureScheduler` instead of `None`.