### PR TITLE
tests: make merge rollback tests more stable

### DIFF
--- a/tests/failpoints_cases/test_merge.rs
+++ b/tests/failpoints_cases/test_merge.rs
@@ -75,6 +75,7 @@ fn test_node_merge_rollback() {
     // After rollback, version becomes 3 + 1 = 4;
     region.mut_region_epoch().set_version(4);
     for i in 1..3 {
+        must_get_equal(&cluster.get_engine(i), b"k11", b"v11");
         let state_key = keys::region_state_key(region.get_id());
         let state: RegionLocalState = cluster
             .get_engine(i)
@@ -101,6 +102,7 @@ fn test_node_merge_rollback() {
     // After premerge and rollback, version becomes 4 + 2 = 6;
     region.mut_region_epoch().set_version(4);
     for i in 1..3 {
+        must_get_equal(&cluster.get_engine(i), b"k12", b"v12");
         let state_key = keys::region_state_key(region.get_id());
         let state: RegionLocalState = cluster
             .get_engine(i)


### PR DESCRIPTION
Synchronize apply result to make sure rollback check always work.