### PR TITLE
deny unknown fields when parse config files.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -388,8 +388,7 @@ impl RaftCfConfig {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 pub struct DbConfig {
     #[serde(with = "config::recovery_mode_serde")] pub wal_recovery_mode: DBRecoveryMode,
     pub wal_dir: String,
@@ -570,8 +569,7 @@ impl RaftDefaultCfConfig {
 // If we set same env parameter in different instance, we may overwrite other instance's config.
 // So we only set max_background_jobs in default rocksdb.
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 pub struct RaftDbConfig {
     #[serde(with = "config::recovery_mode_serde")] pub wal_recovery_mode: DBRecoveryMode,
     pub wal_dir: String,
@@ -673,8 +671,7 @@ impl RaftDbConfig {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 pub struct MetricConfig {
     pub interval: ReadableDuration,
     pub address: String,
@@ -704,8 +701,7 @@ pub enum LogLevel {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 pub struct ReadPoolConfig {
     pub storage: ReadPoolInstanceConfig,
 }
@@ -719,8 +715,7 @@ impl Default for ReadPoolConfig {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 pub struct TiKvConfig {
     #[serde(with = "LogLevel")] pub log_level: LogLevelFilter,
     pub log_file: String,
@@ -1031,5 +1026,13 @@ mod test {
         assert!(tikv_cfg.validate().is_err());
         tikv_cfg.server.grpc_keepalive_time = ReadableDuration(dur * 2);
         tikv_cfg.validate().unwrap();
+    }
+
+    #[test]
+    fn test_unknown_fields() {
+        let tikv_cfg = TiKvConfig::default();
+        let mut dump = toml::to_string_pretty(&tikv_cfg).unwrap();
+        dump += "\n\n[unknown]\nkey = \"value\"";
+        assert!(toml::from_str::<TiKvConfig>(&dump).is_err());
     }
 }

--- a/src/import/config.rs
+++ b/src/import/config.rs
@@ -15,8 +15,7 @@ use std::error::Error;
 use std::result::Result;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Config {
     pub import_dir: String,
     pub num_threads: usize,

--- a/src/pd/config.rs
+++ b/src/pd/config.rs
@@ -14,8 +14,7 @@
 use std::error::Error;
 
 #[derive(Clone, Serialize, Deserialize, Default, PartialEq, Debug)]
-#[serde(default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Config {
     pub endpoints: Vec<String>,
 }

--- a/src/raftstore/coprocessor/config.rs
+++ b/src/raftstore/coprocessor/config.rs
@@ -15,8 +15,7 @@ use util::config::ReadableSize;
 use super::Result;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Config {
     /// When it is true, it will try to split a region with table prefix if
     /// that region crosses tables.

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -20,8 +20,7 @@ use raftstore::{coprocessor, Result};
 use util::config::{ReadableDuration, ReadableSize};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Config {
     // true for high reliability, prevent data loss when power failure.
     pub sync_log: bool,

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -48,8 +48,7 @@ pub const DEFAULT_ENDPOINT_BATCH_ROW_LIMIT: usize = 64;
 pub const DEFAULT_ENDPOINT_STREAM_BATCH_ROW_LIMIT: usize = 128;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Config {
     #[serde(skip)] pub cluster_id: u64,
 

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -32,8 +32,7 @@ const DEFAULT_SCHED_CONCURRENCY: usize = 102400;
 const DEFAULT_SCHED_PENDING_WRITE_MB: u64 = 100;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Config {
     pub data_dir: String,
     pub gc_ratio_threshold: f64,

--- a/src/util/security.rs
+++ b/src/util/security.rs
@@ -20,8 +20,7 @@ use grpc::{Channel, ChannelBuilder, ChannelCredentialsBuilder, ServerBuilder,
            ServerCredentialsBuilder};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 pub struct SecurityConfig {
     pub ca_path: String,
     pub cert_path: String,


### PR DESCRIPTION
Priviously if we move some config entries in `tikv.toml` to other places (or just rename them), users maybe lost some custom things silently. This PR let TiKV exists when meets unknown configures so that user can know they need to update their `tikv.toml` after upgrades. 