### PR TITLE
fix coprocessor metrics collect bug.

### DIFF
--- a/src/coprocessor/dag/executor/index_scan.rs
+++ b/src/coprocessor/dag/executor/index_scan.rs
@@ -248,10 +248,10 @@ impl Executor for IndexScanExecutor {
     }
 
     fn collect_metrics_into(&mut self, metrics: &mut ExecutorMetrics) {
-        metrics.merge(&mut self.metrics);
         if let Some(scanner) = self.scanner.as_mut() {
             scanner.collect_statistics_into(&mut self.metrics.cf_stats);
         }
+        metrics.merge(&mut self.metrics);
         if self.first_collect {
             metrics.executor_count.index_scan += 1;
             self.first_collect = false;

--- a/src/coprocessor/dag/executor/index_scan.rs
+++ b/src/coprocessor/dag/executor/index_scan.rs
@@ -248,10 +248,10 @@ impl Executor for IndexScanExecutor {
     }
 
     fn collect_metrics_into(&mut self, metrics: &mut ExecutorMetrics) {
-        if let Some(scanner) = self.scanner.as_mut() {
-            scanner.collect_statistics_into(&mut self.metrics.cf_stats);
-        }
         metrics.merge(&mut self.metrics);
+        if let Some(scanner) = self.scanner.as_mut() {
+            scanner.collect_statistics_into(&mut metrics.cf_stats);
+        }
         if self.first_collect {
             metrics.executor_count.index_scan += 1;
             self.first_collect = false;

--- a/src/coprocessor/dag/executor/table_scan.rs
+++ b/src/coprocessor/dag/executor/table_scan.rs
@@ -201,10 +201,10 @@ impl Executor for TableScanExecutor {
     }
 
     fn collect_metrics_into(&mut self, metrics: &mut ExecutorMetrics) {
-        metrics.merge(&mut self.metrics);
         if let Some(scanner) = self.scanner.as_mut() {
             scanner.collect_statistics_into(&mut metrics.cf_stats);
         }
+        metrics.merge(&mut self.metrics);
         if self.first_collect {
             metrics.executor_count.table_scan += 1;
             self.first_collect = false;

--- a/src/coprocessor/dag/executor/table_scan.rs
+++ b/src/coprocessor/dag/executor/table_scan.rs
@@ -201,10 +201,10 @@ impl Executor for TableScanExecutor {
     }
 
     fn collect_metrics_into(&mut self, metrics: &mut ExecutorMetrics) {
+        metrics.merge(&mut self.metrics);
         if let Some(scanner) = self.scanner.as_mut() {
             scanner.collect_statistics_into(&mut metrics.cf_stats);
         }
-        metrics.merge(&mut self.metrics);
         if self.first_collect {
             metrics.executor_count.table_scan += 1;
             self.first_collect = false;

--- a/tests/coprocessor/test_select.rs
+++ b/tests/coprocessor/test_select.rs
@@ -952,7 +952,7 @@ fn test_scan_detail() {
     let (_, mut end_point) = {
         let engine = engine::new_local_engine(TEMP_DIR, ALL_CFS).unwrap();
         let mut cfg = new_endpoint_test_config();
-        cfg.end_point_batch_row_limit = 100;
+        cfg.end_point_batch_row_limit = 50;
         init_data_with_details(Context::new(), engine, &product, &data, true, cfg)
     };
 
@@ -961,7 +961,7 @@ fn test_scan_detail() {
         DAGSelect::from_index(&product.table, product.name).build(),
     ];
 
-    for mut req in reqs.into_iter() {
+    for mut req in reqs {
         req.mut_context().set_scan_detail(true);
         req.mut_context().set_handle_time(true);
 


### PR DESCRIPTION
There was a bug when collecting coprocessor metrics. The bug would
cause TiKV print wrong logs and return coprocessor Response with
bad `exec_detail`.