### PR TITLE
Rocksdb: update to fix rocksdb direct io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#50e370f10c47b6dcf848d39945a0e419aa21f67b"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#354332f84f7b7d215ff0d472ed445430f0346a3c"
 dependencies = [
  "bzip2-sys 0.1.6 (git+https://github.com/alexcrichton/bzip2-rs.git)",
  "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -901,7 +901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#50e370f10c47b6dcf848d39945a0e419aa21f67b"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#354332f84f7b7d215ff0d472ed445430f0346a3c"
 dependencies = [
  "crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
update rust-rocksdb to the latest version.