### PR TITLE
util/panic_hook, test: panics as aborts

### DIFF
--- a/src/bin/tikv-importer.rs
+++ b/src/bin/tikv-importer.rs
@@ -120,7 +120,7 @@ fn main() {
     initial_metric(&config.metric, None);
 
     util::print_tikv_info();
-    panic_hook::set_exit_hook();
+    panic_hook::set_exit_hook(false);
     configure_grpc_poll_strategy();
 
     run_import_server(&config);

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -396,7 +396,7 @@ fn main() {
     // Print version information.
     util::print_tikv_info();
 
-    panic_hook::set_exit_hook();
+    panic_hook::set_exit_hook(false);
 
     config.compatible_adjust();
     if let Err(e) = config.validate() {

--- a/src/util/panic_hook.rs
+++ b/src/util/panic_hook.rs
@@ -63,7 +63,7 @@ fn track_hook(p: &PanicInfo) {
 }
 
 /// Exit the whole process when panic.
-pub fn set_exit_hook() {
+pub fn set_exit_hook(panic_abort: bool) {
     // HACK! New a backtrace ahead for caching necessary elf sections of this
     // tikv-server, in case it can not open more files during panicking
     // which leads to no stack info (0x5648bdfe4ff2 - <no info>).
@@ -104,6 +104,10 @@ pub fn set_exit_hook() {
         } else {
             orig_hook(info);
         }
-        process::exit(1);
+        if panic_abort {
+            process::abort();
+        } else {
+            process::exit(1);
+        }
     })
 }

--- a/tests/failpoints.rs
+++ b/tests/failpoints.rs
@@ -71,7 +71,8 @@ lazy_static! {
             self::util::init_log();
         }
         if env::var("PANIC_ABORT").is_ok() {
-            // Panics as aborts, it's helpful for debug, but also stops tests immediately.
+            // Panics as aborts, it's helpful for debugging,
+            // but also stops tests immediately.
             tikv::util::panic_hook::set_exit_hook(true);
         }
 

--- a/tests/failpoints.rs
+++ b/tests/failpoints.rs
@@ -70,6 +70,10 @@ lazy_static! {
         if env::var("CI").is_ok() && env::var("LOG_FILE").is_ok() {
             self::util::init_log();
         }
+        if env::var("PANIC_ABORT").is_ok() {
+            // Panics as aborts, it's helpful for debug, but also stops tests immediately.
+            tikv::util::panic_hook::set_exit_hook(true);
+        }
 
         Mutex::new(())
     };

--- a/tests/failpoints.rs
+++ b/tests/failpoints.rs
@@ -58,7 +58,7 @@ mod storage;
 mod util;
 
 use std::sync::*;
-use std::{env, thread};
+use std::{thread};
 
 use tikv::util::panic_hook;
 
@@ -66,16 +66,7 @@ lazy_static! {
     /// Failpoints are global structs, hence rules set in different cases
     /// may affect each other. So use a global lock to synchronize them.
     static ref LOCK: Mutex<()> = {
-        // Set up ci test fail case log.
-        if env::var("CI").is_ok() && env::var("LOG_FILE").is_ok() {
-            self::util::init_log();
-        }
-        if env::var("PANIC_ABORT").is_ok() {
-            // Panics as aborts, it's helpful for debugging,
-            // but also stops tests immediately.
-            tikv::util::panic_hook::set_exit_hook(true);
-        }
-
+        util::ci_setup();
         Mutex::new(())
     };
 }

--- a/tests/integrations.rs
+++ b/tests/integrations.rs
@@ -66,7 +66,8 @@ fn _0_ci_setup() {
         self::util::init_log();
     }
     if env::var("PANIC_ABORT").is_ok() {
-        // Panics as aborts, it's helpful for debug, but also stops tests immediately.
+        // Panics as aborts, it's helpful for debugging,
+        // but also stops tests immediately.
         tikv::util::panic_hook::set_exit_hook(true);
     }
 }

--- a/tests/integrations.rs
+++ b/tests/integrations.rs
@@ -65,6 +65,10 @@ fn _0_ci_setup() {
     if env::var("CI").is_ok() && env::var("LOG_FILE").is_ok() {
         self::util::init_log();
     }
+    if env::var("PANIC_ABORT").is_ok() {
+        // Panics as aborts, it's helpful for debug, but also stops tests immediately.
+        tikv::util::panic_hook::set_exit_hook(true);
+    }
 }
 
 #[test]

--- a/tests/integrations.rs
+++ b/tests/integrations.rs
@@ -56,20 +56,10 @@ mod storage;
 mod storage_cases;
 mod util;
 
-use std::env;
-
+// The prefix "_" here is to guarantee running this case first.
 #[test]
 fn _0_ci_setup() {
-    // Set up ci test fail case log.
-    // The prefix "_" here is to guarantee running this case first.
-    if env::var("CI").is_ok() && env::var("LOG_FILE").is_ok() {
-        self::util::init_log();
-    }
-    if env::var("PANIC_ABORT").is_ok() {
-        // Panics as aborts, it's helpful for debugging,
-        // but also stops tests immediately.
-        tikv::util::panic_hook::set_exit_hook(true);
-    }
+    util::ci_setup();
 }
 
 #[test]


### PR DESCRIPTION
Panics as aborts, it's helpful for debug. There is a feature `panic=abort` in rust, but unfortunately it does work in tests.