### PR TITLE
logger: collect raft's log

### DIFF
--- a/src/util/logger.rs
+++ b/src/util/logger.rs
@@ -26,6 +26,7 @@ const ENABLED_TARGETS: &[&str] = &[
     "benches::",
     "integrations::",
     "failpoints::",
+    "raft::",
 ];
 
 pub fn init_log<W: LogWriter + Sync + Send + 'static>(


### PR DESCRIPTION
Since #2774, logger no longer collects raft's log. This PR brings them back. 