### PR TITLE
src/util/logger.rs: Use a dedicated logging thread

### DIFF
--- a/src/util/file_log.rs
+++ b/src/util/file_log.rs
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt::Arguments;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Write};
 use std::path::Path;
@@ -121,12 +120,12 @@ impl RotatingFileLogger {
 }
 
 impl LogWriter for RotatingFileLogger {
-    fn write(&self, args: Arguments) {
+    fn write(&self, args: String) {
         let mut core = self.core.lock().unwrap();
         if core.should_rollover() {
             core.do_rollover()
         };
-        let _ = core.file.write_fmt(args);
+        let _ = core.file.write(args.as_bytes());
     }
 }
 

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -13,7 +13,6 @@
 
 use rand::{self, Rng, ThreadRng};
 use std::env;
-use std::fmt::Arguments;
 use std::fs::File;
 use std::io::{self, Write};
 use std::path::PathBuf;
@@ -67,7 +66,7 @@ struct CaseTraceLogger {
 }
 
 impl LogWriter for CaseTraceLogger {
-    fn write(&self, args: Arguments) {
+    fn write(&self, args: String) {
         let tag = util::get_tag_from_thread_name().unwrap_or_else(|| "".into());
         let _ = if let Some(ref out) = self.f {
             let mut w = out.lock().unwrap();


### PR DESCRIPTION
This pull request offloads the act of logging onto a dedicated thread.

## Rationale

We noticed that in some cases logging was taking up a considerable amount of time. This is due to the fact that the `Logger` acts in a syncronous way.

## Implementation details

As part of this the `LogWriter` now recieves a plain `String` when logging instead of an `Arguements`. This is because `Arguements` does not want to cross thread boundaries.

We also ensure that if the `Logger` is dropped we wait for remaining logs to write, then correctly join the thread.

## Future Work

In the future we will explore using `slog` and `slog-async` to do our logging as it allows us to do async in a robust and flexible way.