### PR TITLE
*: Use slog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -92,7 +92,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
-version = "1.0.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -105,7 +105,7 @@ name = "bytes"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -125,7 +125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -208,6 +208,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,7 +228,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -235,7 +240,7 @@ name = "crossbeam-utils"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -415,6 +420,17 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "isatty"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -647,7 +663,7 @@ name = "murmur3"
 version = "0.4.0"
 source = "git+https://github.com/pingcap/murmur3.git#4af9e1a8f2d4206d90d81f11e513fb03c87208bf"
 dependencies = [
- "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -655,7 +671,7 @@ name = "net2"
 version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -677,7 +693,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -786,7 +802,7 @@ name = "prometheus"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1026,6 +1042,54 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "slog"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "slog-async"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "slog 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "slog-scope"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "slog-stdlog"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-scope 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "slog-term"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "isatty 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "smallvec"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,11 +1156,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "tempdir"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "term"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1175,6 +1253,11 @@ dependencies = [
  "serde_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-scope 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-stdlog 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sys-info 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1440,12 +1523,12 @@ dependencies = [
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum byteorder 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e4ca3a1755927e5b00c3fe43250053b957b5c074d9f17782b88ef7aa0fb4dfe2"
-"checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
+"checksum byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b5bdfe7ee3ad0b99c9801d58807a9dbc9e09196365b0203853b99889ab3c87"
 "checksum bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c129aff112dcc562970abb69e2508b40850dd24c274761bb50fb8a0067ba6c27"
 "checksum bytes 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "46112a0060ae15e3a3f9a445428a53e082b91215b744fa27a1948842f4a64b96"
 "checksum bzip2-sys 0.1.6 (git+https://github.com/alexcrichton/bzip2-rs.git)" = "<none>"
 "checksum cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a9b13a57efd6b30ecd6598ebdb302cca617930b5470647570468a65d12ef9719"
-"checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
+"checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
 "checksum clap 2.23.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f57e9b63057a545ad2ecd773ea61e49422ed1b1d63d74d5da5ecaee55b3396cd"
 "checksum clippy 0.0.192 (registry+https://github.com/rust-lang/crates.io-index)" = "6d5b9c448ab03cade9cf3c15b80ebb282c996eade63a4e0eadb06dd3ca08168e"
@@ -1453,6 +1536,7 @@ dependencies = [
 "checksum cmake 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "e14cd15a7cbc2c6a905677e54b831ee91af2ff43b352010f6133236463b65cac"
 "checksum cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e3d6405328b6edb412158b3b7710e2634e23f3614b9bb1c412df7952489a626"
 "checksum crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "541a7a4936092a4dac8b3a1dc1abc264372e0ce1e7ab712dfe0484374f5a2b7b"
+"checksum crossbeam 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "bd66663db5a988098a89599d4857919b3acf7f61402e61365acfd3919857b9be"
 "checksum crossbeam-channel 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9d7b07a3084d8718d95338443d5a46aab38ce16d5f991d4027a0906b369f70a3"
 "checksum crossbeam-epoch 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9898f21d6d647793e163c804944941fb19aecd1f4a1a4c254bbb0bee15ccdea5"
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
@@ -1479,6 +1563,7 @@ dependencies = [
 "checksum if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "61bb90bdd39e3af69b0172dfc6130f6cd6332bf040fbb9bdd4401d37adbd48b8"
 "checksum indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08173ba1e906efb6538785a8844dd496f5d34f0a2d88038e95195172fc667220"
 "checksum iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29d062ee61fccdf25be172e70f34c9f6efc597e1fb8f6526e8437b2046ab26be"
+"checksum isatty 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a118a53ba42790ef25c82bb481ecf36e2da892646cccd361e69a6bb881e19398"
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2f404fbc66fd9aac13e998248505e7ecb2ad8e44ab6388684c5fb11c6c251c"
 "checksum jemalloc-sys 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
@@ -1556,6 +1641,11 @@ dependencies = [
 "checksum signal 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "02c898841abd05cbb780652c6cdad8840f50357ea806c147403419f140c6088a"
 "checksum slab 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d807fd58c4181bbabed77cb3b891ba9748241a552bcc5be698faaebefc54f46e"
 "checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
+"checksum slog 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2f7bfce6405155042d42ec0e645efe43eddedd7be280063ce0623b120014e7f9"
+"checksum slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e544d16c6b230d84c866662fe55e31aacfca6ae71e6fc49ae9a311cb379bfc2f"
+"checksum slog-scope 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "053344c94c0e2b22da6305efddb698d7c485809427cf40555dc936085f67a9df"
+"checksum slog-stdlog 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ac42f8254ae996cc7d640f9410d3b048dcdf8887a10df4d5d4c44966de24c4a8"
+"checksum slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5951a808c40f419922ee014c15b6ae1cd34d963538b57d8a4778b9ca3fff1e0b"
 "checksum smallvec 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44db0ecb22921ef790d17ae13a3f6d15784183ff5f2a01aa32098c7498d2b4b9"
 "checksum snappy-sys 0.1.0 (git+https://github.com/busyjay/rust-snappy.git?branch=static-link)" = "<none>"
 "checksum solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "172382bac9424588d7840732b250faeeef88942e37b6e35317dce98cafdd75b2"
@@ -1565,7 +1655,9 @@ dependencies = [
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum sys-info 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6e0c80518e54ce6bd40e8262b386395f2154dcfaf22ff8102380dc5c7bed3683"
+"checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 "checksum tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0b62933a3f96cd559700662c34f8bab881d9e3540289fb4f368419c7f13a5aa9"
+"checksum term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561"
 "checksum term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b6b55df3198cc93372e85dd2ed817f0e38ce8cc0f22eb32391bfad9c4bf209"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,12 @@ name = "tikv-fail"
 name = "tikv-importer"
 
 [dependencies]
-log = "0.3"
+log = "0.3.6"
+slog = "2.2"
+slog-async = "2.3"
+slog-scope = "4.0"
+slog-stdlog = "3.0"
+slog-term = "2.4"
 byteorder = "0.5"
 rand = "0.3"
 quick-error = "0.2"

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -20,11 +20,17 @@
 
 extern crate kvproto;
 extern crate log;
+#[macro_use(slog_o, slog_kv)]
+extern crate slog;
 extern crate mio;
 extern crate protobuf;
 extern crate raft;
 extern crate rand;
 extern crate rocksdb;
+extern crate slog_async;
+extern crate slog_scope;
+extern crate slog_stdlog;
+extern crate slog_term;
 extern crate tempdir;
 extern crate test;
 extern crate tikv;

--- a/benches/bin/bench-tikv.rs
+++ b/benches/bin/bench-tikv.rs
@@ -30,12 +30,19 @@ extern crate grpcio as grpc;
 extern crate kvproto;
 #[macro_use]
 extern crate log;
+#[macro_use(slog_o, slog_kv)]
+extern crate slog;
 extern crate protobuf;
 extern crate raft;
 extern crate rand;
 extern crate rocksdb;
+extern crate slog_async;
+extern crate slog_scope;
+extern crate slog_stdlog;
+extern crate slog_term;
 extern crate tempdir;
 extern crate test;
+extern crate time;
 #[macro_use]
 extern crate tikv;
 extern crate tokio_timer;

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -5,7 +5,7 @@
 #   Time(based on ms): ms, s, m, h
 #    e.g.: 78_000 = "1.3m"
 
-# log level: trace, debug, info, warn, error, off.
+# log level: trace, debug, info, warning, error, critical.
 # log-level = "info"
 # file to store log, write to stderr if it's empty.
 # log-file = ""

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -6,7 +6,9 @@
 #    e.g.: 78_000 = "1.3m"
 
 # log level: trace, debug, info, warning, error, critical.
+# Note that `debug` and `trace` are only available in development builds.
 # log-level = "info"
+
 # file to store log, write to stderr if it's empty.
 # log-file = ""
 

--- a/src/bin/setup.rs
+++ b/src/bin/setup.rs
@@ -50,13 +50,15 @@ pub fn init_log(config: &TiKvConfig) {
             fatal!("failed to initialize log: {:?}", e);
         });
     } else {
-        let drain = RotatingFileLogger::new(&config.log_file).unwrap_or_else(|e| {
+        let logger = RotatingFileLogger::new(&config.log_file).unwrap_or_else(|e| {
             fatal!(
                 "failed to initialize log with file {:?}: {:?}",
                 config.log_file,
                 e
             );
         });
+        let decorator = slog_term::PlainDecorator::new(logger);
+        let drain = slog_term::FullFormat::new(decorator).build().fuse();
         let drain = slog_async::Async::new(drain).build().fuse();
         let logger = slog::Logger::root_typed(drain, slog_o!());
         logger::init_log(logger, config.log_level).unwrap_or_else(|e| {

--- a/src/bin/setup.rs
+++ b/src/bin/setup.rs
@@ -45,7 +45,7 @@ pub fn init_log(config: &TiKvConfig) {
         let decorator = slog_term::TermDecorator::new().build();
         let drain = slog_term::FullFormat::new(decorator).build().fuse();
         let drain = slog_async::Async::new(drain).build().fuse();
-        let logger = slog::Logger::root(drain, slog_o!());
+        let logger = slog::Logger::root_typed(drain, slog_o!());
         logger::init_log(logger, config.log_level).unwrap_or_else(|e| {
             fatal!("failed to initialize log: {:?}", e);
         });
@@ -58,7 +58,7 @@ pub fn init_log(config: &TiKvConfig) {
             );
         });
         let drain = slog_async::Async::new(drain).build().fuse();
-        let logger = slog::Logger::root(drain, slog_o!());
+        let logger = slog::Logger::root_typed(drain, slog_o!());
         logger::init_log(logger, config.log_level).unwrap_or_else(|e| {
             fatal!("failed to initialize log: {:?}", e);
         });

--- a/src/bin/setup.rs
+++ b/src/bin/setup.rs
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use slog::{self, Drain};
-use slog_async;
-use slog_term;
+use slog::{Drain, Logger};
+use slog_async::Async;
+use slog_term::{FullFormat, PlainDecorator, TermDecorator};
 use std::env;
 use std::process;
 use std::sync::atomic::{AtomicBool, Ordering, ATOMIC_BOOL_INIT};
@@ -42,10 +42,10 @@ macro_rules! fatal {
 
 pub fn init_log(config: &TiKvConfig) {
     if config.log_file.is_empty() {
-        let decorator = slog_term::TermDecorator::new().build();
-        let drain = slog_term::FullFormat::new(decorator).build().fuse();
-        let drain = slog_async::Async::new(drain).build().fuse();
-        let logger = slog::Logger::root_typed(drain, slog_o!());
+        let decorator = TermDecorator::new().build();
+        let drain = FullFormat::new(decorator).build().fuse();
+        let drain = Async::new(drain).build().fuse();
+        let logger = Logger::root_typed(drain, slog_o!());
         logger::init_log(logger, config.log_level).unwrap_or_else(|e| {
             fatal!("failed to initialize log: {:?}", e);
         });
@@ -57,10 +57,10 @@ pub fn init_log(config: &TiKvConfig) {
                 e
             );
         });
-        let decorator = slog_term::PlainDecorator::new(logger);
-        let drain = slog_term::FullFormat::new(decorator).build().fuse();
-        let drain = slog_async::Async::new(drain).build().fuse();
-        let logger = slog::Logger::root_typed(drain, slog_o!());
+        let decorator = PlainDecorator::new(logger);
+        let drain = FullFormat::new(decorator).build().fuse();
+        let drain = Async::new(drain).build().fuse();
+        let logger = Logger::root_typed(drain, slog_o!());
         logger::init_log(logger, config.log_level).unwrap_or_else(|e| {
             fatal!("failed to initialize log: {:?}", e);
         });

--- a/src/bin/setup.rs
+++ b/src/bin/setup.rs
@@ -88,7 +88,7 @@ pub fn initial_metric(cfg: &MetricConfig, node_id: Option<u64>) {
 
 pub fn overwrite_config_with_cmd_args(config: &mut TiKvConfig, matches: &ArgMatches) {
     if let Some(level) = matches.value_of("log-level") {
-        config.log_level = logger::get_level_by_string(level);
+        config.log_level = logger::get_level_by_string(level).unwrap();
     }
 
     if let Some(file) = matches.value_of("log-file") {

--- a/src/bin/tikv-importer.rs
+++ b/src/bin/tikv-importer.rs
@@ -28,6 +28,8 @@ extern crate jemallocator;
 extern crate libc;
 #[macro_use]
 extern crate log;
+#[macro_use(slog_o, slog_kv)]
+extern crate slog;
 #[cfg(unix)]
 extern crate nix;
 extern crate prometheus;
@@ -35,6 +37,10 @@ extern crate rocksdb;
 extern crate serde_json;
 #[cfg(unix)]
 extern crate signal;
+extern crate slog_async;
+extern crate slog_scope;
+extern crate slog_stdlog;
+extern crate slog_term;
 extern crate tikv;
 extern crate toml;
 

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -28,6 +28,8 @@ extern crate jemallocator;
 extern crate libc;
 #[macro_use]
 extern crate log;
+#[macro_use(slog_o, slog_kv)]
+extern crate slog;
 #[cfg(unix)]
 extern crate nix;
 extern crate prometheus;
@@ -35,6 +37,10 @@ extern crate rocksdb;
 extern crate serde_json;
 #[cfg(unix)]
 extern crate signal;
+extern crate slog_async;
+extern crate slog_scope;
+extern crate slog_stdlog;
+extern crate slog_term;
 extern crate tikv;
 extern crate toml;
 

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -308,7 +308,9 @@ fn main() {
                 .alias("log")
                 .takes_value(true)
                 .value_name("LEVEL")
-                .possible_values(&["trace", "debug", "info", "warn", "error", "off"])
+                .possible_values(&[
+                    "trace", "debug", "info", "warn", "warning", "error", "critical"
+                ])
                 .help("Sets log level"),
         )
         .arg(

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,9 +23,9 @@ use std::io::{Read, Write};
 use std::path::Path;
 use std::usize;
 
-use log::LogLevelFilter;
 use rocksdb::{BlockBasedOptions, ColumnFamilyOptions, CompactionPriority, DBCompactionStyle,
               DBCompressionType, DBOptions, DBRecoveryMode};
+use slog::Level;
 use sys_info;
 
 use import::Config as ImportConfig;
@@ -696,15 +696,15 @@ impl Default for MetricConfig {
 }
 
 #[derive(Serialize, Deserialize)]
-#[serde(remote = "LogLevelFilter")]
+#[serde(remote = "Level")]
 #[serde(rename_all = "kebab-case")]
 pub enum LogLevel {
-    Info,
-    Trace,
-    Debug,
-    Warn,
+    Critical,
     Error,
-    Off,
+    Warning,
+    Info,
+    Debug,
+    Trace,
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
@@ -737,7 +737,7 @@ impl ReadPoolConfig {
 #[serde(rename_all = "kebab-case")]
 pub struct TiKvConfig {
     #[serde(with = "LogLevel")]
-    pub log_level: LogLevelFilter,
+    pub log_level: Level,
     pub log_file: String,
     pub readpool: ReadPoolConfig,
     pub server: ServerConfig,
@@ -756,7 +756,7 @@ pub struct TiKvConfig {
 impl Default for TiKvConfig {
     fn default() -> TiKvConfig {
         TiKvConfig {
-            log_level: LogLevelFilter::Info,
+            log_level: Level::Info,
             log_file: "".to_owned(),
             readpool: ReadPoolConfig::default(),
             server: ServerConfig::default(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -713,7 +713,7 @@ pub mod log_level_serde {
     where
         S: Serializer,
     {
-        format!("{}", get_string_by_level(value)).serialize(serializer)
+        get_string_by_level(value).serialize(serializer)
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -713,7 +713,7 @@ pub mod log_level_serde {
     where
         S: Serializer,
     {
-        format!("{}", get_string_by_level(value).to_lowercase()).serialize(serializer)
+        format!("{}", get_string_by_level(value)).serialize(serializer)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,12 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
+#[macro_use(slog_o, slog_kv)]
+extern crate slog;
+extern crate slog_async;
+extern crate slog_scope;
+extern crate slog_stdlog;
+extern crate slog_term;
 extern crate sys_info;
 extern crate tempdir;
 #[cfg(test)]

--- a/src/util/file_log.rs
+++ b/src/util/file_log.rs
@@ -18,8 +18,6 @@ use std::sync::Mutex;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use time::{self, Timespec, Tm};
 
-use slog::{self, Drain, OwnedKVList, Record};
-
 const ONE_DAY_SECONDS: u64 = 60 * 60 * 24;
 
 fn systemtime_to_tm(t: SystemTime) -> Tm {
@@ -119,30 +117,21 @@ impl RotatingFileLogger {
     }
 }
 
-impl Drain for RotatingFileLogger {
-    type Ok = ();
-    type Err = slog::Never;
-
-    fn log(&self, record: &Record, values: &OwnedKVList) -> Result<Self::Ok, Self::Err> {
+impl Write for RotatingFileLogger {
+    fn write(&mut self, bytes: &[u8]) -> Result<usize, ::std::io::Error> {
         let mut core = self.core.lock().unwrap();
         if core.should_rollover() {
             core.do_rollover()
         };
+        core.file.write(bytes)
+    }
 
-        let t = time::now();
-        let time_str = time::strftime("%y/%m/%d %H:%M:%S.%f", &t).unwrap();
-        // todo allow formatter to be configurable.
-        let _ = write!(
-            core.file,
-            "{} {}:{}: [{}] {} {:?}\n",
-            &time_str[..time_str.len() - 6],
-            record.file().rsplit('/').nth(0).unwrap(),
-            record.line(),
-            record.level(),
-            record.msg(),
-            values,
-        );
-        Ok(())
+    fn flush(&mut self) -> Result<(), ::std::io::Error> {
+        let mut core = self.core.lock().unwrap();
+        if core.should_rollover() {
+            core.do_rollover()
+        };
+        core.file.flush()
     }
 }
 

--- a/src/util/file_log.rs
+++ b/src/util/file_log.rs
@@ -128,10 +128,11 @@ impl Write for RotatingFileLogger {
 
     fn flush(&mut self) -> Result<(), ::std::io::Error> {
         let mut core = self.core.lock().unwrap();
+        core.file.flush()?;
         if core.should_rollover() {
-            core.do_rollover()
+            core.do_rollover();
         };
-        core.file.flush()
+        Ok(())
     }
 }
 

--- a/src/util/logger.rs
+++ b/src/util/logger.rs
@@ -58,28 +58,29 @@ where
     init_log(filtered, level)
 }
 
-pub fn get_level_by_string(lv: &str) -> Level {
+pub fn get_level_by_string(lv: &str) -> Option<Level> {
     match &*lv.to_owned().to_lowercase() {
-        "critical" => Level::Critical,
-        "error" => Level::Error,
+        "critical" => Some(Level::Critical),
+        "error" => Some(Level::Error),
         // We support `warn` due to legacy.
-        "warning" | "warn" => Level::Warning,
-        "debug" => Level::Debug,
-        "trace" => Level::Trace,
-        "info" | _ => Level::Info,
+        "warning" | "warn" => Some(Level::Warning),
+        "debug" => Some(Level::Debug),
+        "trace" => Some(Level::Trace),
+        "info" => Some(Level::Info),
+        _ => None,
     }
 }
 
 #[test]
 fn test_get_level_by_string() {
     // Ensure UPPER, Capitalized, and lower case all map over.
-    assert_eq!(Level::Trace, get_level_by_string("TRACE"));
-    assert_eq!(Level::Trace, get_level_by_string("Trace"));
-    assert_eq!(Level::Trace, get_level_by_string("trace"));
+    assert_eq!(Some(Level::Trace), get_level_by_string("TRACE"));
+    assert_eq!(Some(Level::Trace), get_level_by_string("Trace"));
+    assert_eq!(Some(Level::Trace), get_level_by_string("trace"));
     // Due to legacy we need to ensure that `warn` maps to `Warning`.
-    assert_eq!(Level::Warning, get_level_by_string("warn"));
-    assert_eq!(Level::Warning, get_level_by_string("warning"));
+    assert_eq!(Some(Level::Warning), get_level_by_string("warn"));
+    assert_eq!(Some(Level::Warning), get_level_by_string("warning"));
     // Ensure that all non-defined values map to `Info`.
-    assert_eq!(Level::Info, get_level_by_string("Off"));
-    assert_eq!(Level::Info, get_level_by_string("definitely not an option"));
+    assert_eq!(None, get_level_by_string("Off"));
+    assert_eq!(None, get_level_by_string("definitely not an option"));
 }

--- a/src/util/logger.rs
+++ b/src/util/logger.rs
@@ -71,6 +71,19 @@ pub fn get_level_by_string(lv: &str) -> Option<Level> {
     }
 }
 
+// The `to_string()` function of `slog::Level` produces values like `erro` and `trce` instead of
+// the full words. This produces the full word.
+pub fn get_string_by_level(lv: &Level) -> &'static str {
+    match lv {
+        Level::Critical => "Critical",
+        Level::Error => "Error",
+        Level::Warning => "Warning",
+        Level::Debug => "Debug",
+        Level::Trace => "Trace",
+        Level::Info => "Info",
+    }
+}
+
 #[test]
 fn test_get_level_by_string() {
     // Ensure UPPER, Capitalized, and lower case all map over.

--- a/src/util/logger.rs
+++ b/src/util/logger.rs
@@ -53,7 +53,7 @@ where
     let filtered = drain.filter(|record| {
         ENABLED_TARGETS
             .iter()
-            .all(|target| !record.module().starts_with(target))
+            .any(|target| record.module().starts_with(target))
     });
     init_log(filtered, level)
 }

--- a/src/util/logger.rs
+++ b/src/util/logger.rs
@@ -75,12 +75,12 @@ pub fn get_level_by_string(lv: &str) -> Option<Level> {
 // the full words. This produces the full word.
 pub fn get_string_by_level(lv: &Level) -> &'static str {
     match lv {
-        Level::Critical => "Critical",
-        Level::Error => "Error",
-        Level::Warning => "Warning",
-        Level::Debug => "Debug",
-        Level::Trace => "Trace",
-        Level::Info => "Info",
+        Level::Critical => "critical",
+        Level::Error => "error",
+        Level::Warning => "warning",
+        Level::Debug => "debug",
+        Level::Trace => "trace",
+        Level::Info => "info",
     }
 }
 

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -15,8 +15,8 @@ use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
 
-use log::LogLevelFilter;
 use rocksdb::{CompactionPriority, DBCompactionStyle, DBCompressionType, DBRecoveryMode};
+use slog::Level;
 use tikv::config::*;
 use tikv::import::Config as ImportConfig;
 use tikv::pd::Config as PdConfig;
@@ -53,7 +53,7 @@ fn read_file_in_project_dir(path: &str) -> String {
 #[test]
 fn test_serde_custom_tikv_config() {
     let mut value = TiKvConfig::default();
-    value.log_level = LogLevelFilter::Debug;
+    value.log_level = Level::Debug;
     value.log_file = "foo".to_owned();
     value.server = ServerConfig {
         cluster_id: 0, // KEEP IT ZERO, it is skipped by serde.

--- a/tests/failpoints.rs
+++ b/tests/failpoints.rs
@@ -36,14 +36,21 @@ extern crate kvproto;
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
+#[macro_use(slog_o, slog_kv)]
+extern crate slog;
 extern crate protobuf;
 extern crate raft;
 extern crate rand;
 extern crate rocksdb;
+extern crate slog_async;
+extern crate slog_scope;
+extern crate slog_stdlog;
+extern crate slog_term;
 extern crate tempdir;
 extern crate test;
 #[macro_use]
 extern crate tikv;
+extern crate time;
 extern crate tipb;
 extern crate tokio_timer;
 extern crate toml;

--- a/tests/integrations.rs
+++ b/tests/integrations.rs
@@ -33,14 +33,21 @@ extern crate jemallocator;
 extern crate kvproto;
 #[macro_use]
 extern crate log;
+#[macro_use(slog_o, slog_kv)]
+extern crate slog;
 extern crate protobuf;
 extern crate raft;
 extern crate rand;
 extern crate rocksdb;
+extern crate slog_async;
+extern crate slog_scope;
+extern crate slog_stdlog;
+extern crate slog_term;
 extern crate tempdir;
 extern crate test;
 #[macro_use]
 extern crate tikv;
+extern crate time;
 extern crate tipb;
 extern crate tokio_timer;
 extern crate toml;

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -116,7 +116,7 @@ fn init_log() {
     // we don't mind set it multiple times.
     let drain = CaseTraceLogger { f: writer };
     let drain = slog_async::Async::new(drain).build().fuse();
-    let logger = slog::Logger::root(drain, slog_o!());
+    let logger = slog::Logger::root_typed(drain, slog_o!());
     let _ = logger::init_log_for_tikv_only(logger, level);
 }
 

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -110,8 +110,8 @@ impl Drop for CaseTraceLogger {
 // A help function to initial logger.
 fn init_log() {
     let output = env::var("LOG_FILE").ok();
-    let level =
-        logger::get_level_by_string(&env::var("LOG_LEVEL").unwrap_or_else(|_| "debug".to_owned()));
+    let level = logger::get_level_by_string(&env::var("LOG_LEVEL").unwrap_or_else(|_| "debug".to_owned()))
+        .unwrap();
     let writer = output.map(|f| Mutex::new(File::create(f).unwrap()));
     // we don't mind set it multiple times.
     let drain = CaseTraceLogger { f: writer };


### PR DESCRIPTION
After speaking with @siddontang we think this is a better option than https://github.com/pingcap/tikv/pull/2997.

## Motivation

We noted with some users that logging was taking a considerable amount of time during system operation. This is due to the fact that the `log` crate operates syncronously. We noted when exploring #2997 that moving to asyncronous logging was measurably faster.

During our discussion it was decided that `slog` was a good alternative that offered built in asyncronous logging capabilities. It offers other benefits as well, such as structured logging and fancy terminal output.

## Implementation

This PR moves us to using `slog` via the `slog_stdlog` crate which essentially adapts the `log` based macros to use `slog`. In the future we can place work into migrating to the `slog` based logging macros which offer the option for structure data.

With this PR it was possible to completely remove the `StdErrLogger` and use the provided `slog_term` terminal logger. The `RotatingFileLogger` was altered so it simply implements `Write` and can be called from the `slog` decorators. Additionally the distinction between the Logger and the LoggerCore was removed, as well as the mutex which was involved.

A future PR will implement file rotation by size.

## Benchmarks

On **master**:

```
Begin to run: raftstore
benching Set on raft cluster (channel), nodes: 1, value len:    8       ...     29,214 ns/iter (+/- 5,149)
benching Set on raft cluster (channel), nodes: 1, value len:  128       ...     41,056 ns/iter (+/- 7,479)
benching Set on raft cluster (channel), nodes: 1, value len: 1024       ...     45,485 ns/iter (+/- 12,575)
benching Set on raft cluster (channel), nodes: 1, value len: 4096       ...     63,040 ns/iter (+/- 35,221)
benching Get on raft cluster (channel), nodes: 1        ...     16,488 ns/iter (+/- 872)
benching Delete on raft cluster (channel),      nodes: 1        ...     38,510 ns/iter (+/- 9,025)
benching Set on raft cluster (channel), nodes: 3, value len:    8       ...     87,967 ns/iter (+/- 12,569)
benching Set on raft cluster (channel), nodes: 3, value len:  128       ...     88,835 ns/iter (+/- 12,777)
benching Set on raft cluster (channel), nodes: 3, value len: 1024       ...    100,263 ns/iter (+/- 14,892)
benching Set on raft cluster (channel), nodes: 3, value len: 4096       ...    121,325 ns/iter (+/- 51,883)
benching Get on raft cluster (channel), nodes: 3        ...     15,778 ns/iter (+/- 1,064)
benching Delete on raft cluster (channel),      nodes: 3        ...     89,725 ns/iter (+/- 12,090)
benching Set on raft cluster (channel), nodes: 5, value len:    8       ...    110,969 ns/iter (+/- 8,464)
benching Set on raft cluster (channel), nodes: 5, value len:  128       ...    113,681 ns/iter (+/- 9,638)
benching Set on raft cluster (channel), nodes: 5, value len: 1024       ...    123,668 ns/iter (+/- 12,713)
benching Set on raft cluster (channel), nodes: 5, value len: 4096       ...    149,208 ns/iter (+/- 76,215)
benching Get on raft cluster (channel), nodes: 5        ...     16,907 ns/iter (+/- 1,410)
benching Delete on raft cluster (channel),      nodes: 5        ...    110,360 ns/iter (+/- 11,433)
benching Set on raft cluster (tcp),     nodes: 1, value len:    8       ...     37,840 ns/iter (+/- 8,776)
benching Set on raft cluster (tcp),     nodes: 1, value len:  128       ...     39,376 ns/iter (+/- 12,806)
benching Set on raft cluster (tcp),     nodes: 1, value len: 1024       ...     45,441 ns/iter (+/- 11,976)
benching Set on raft cluster (tcp),     nodes: 1, value len: 4096       ...     68,510 ns/iter (+/- 15,056)
benching Get on raft cluster (tcp),     nodes: 1        ...     16,730 ns/iter (+/- 1,119)
benching Delete on raft cluster (tcp),  nodes: 1        ...     36,457 ns/iter (+/- 12,851)
benching Set on raft cluster (tcp),     nodes: 3, value len:    8       ...    214,640 ns/iter (+/- 18,331)
benching Set on raft cluster (tcp),     nodes: 3, value len:  128       ...    216,273 ns/iter (+/- 23,011)
benching Set on raft cluster (tcp),     nodes: 3, value len: 1024       ...    226,920 ns/iter (+/- 32,660)
benching Set on raft cluster (tcp),     nodes: 3, value len: 4096       ...    167,235 ns/iter (+/- 17,127)
benching Get on raft cluster (tcp),     nodes: 3        ...     17,650 ns/iter (+/- 1,727)
benching Delete on raft cluster (tcp),  nodes: 3        ...    221,035 ns/iter (+/- 25,323)
benching Set on raft cluster (tcp),     nodes: 5, value len:    8       ...    329,054 ns/iter (+/- 12,363)
benching Set on raft cluster (tcp),     nodes: 5, value len:  128       ...    331,151 ns/iter (+/- 25,594)
benching Set on raft cluster (tcp),     nodes: 5, value len: 1024       ...    343,870 ns/iter (+/- 24,609)
benching Set on raft cluster (tcp),     nodes: 5, value len: 4096       ...    375,979 ns/iter (+/- 28,572)
benching Get on raft cluster (tcp),     nodes: 5        ...     17,735 ns/iter (+/- 1,447)
benching Delete on raft cluster (tcp),  nodes: 5        ...    329,308 ns/iter (+/- 23,500)
```

With **this PR**:

```
Begin to run: raftstore
benching Set on raft cluster (channel), nodes: 1, value len:    8       ...     30,221 ns/iter (+/- 7,197)
benching Set on raft cluster (channel), nodes: 1, value len:  128       ...     30,800 ns/iter (+/- 7,490)
benching Set on raft cluster (channel), nodes: 1, value len: 1024       ...     41,309 ns/iter (+/- 6,337)
benching Set on raft cluster (channel), nodes: 1, value len: 4096       ...     58,102 ns/iter (+/- 35,968)
benching Get on raft cluster (channel), nodes: 1        ...     15,947 ns/iter (+/- 969)
benching Delete on raft cluster (channel),      nodes: 1        ...     32,619 ns/iter (+/- 7,035)
benching Set on raft cluster (channel), nodes: 3, value len:    8       ...     80,111 ns/iter (+/- 13,715)
benching Set on raft cluster (channel), nodes: 3, value len:  128       ...     80,830 ns/iter (+/- 13,125)
benching Set on raft cluster (channel), nodes: 3, value len: 1024       ...     87,357 ns/iter (+/- 11,750)
benching Set on raft cluster (channel), nodes: 3, value len: 4096       ...    113,161 ns/iter (+/- 66,971)
benching Get on raft cluster (channel), nodes: 3        ...     15,388 ns/iter (+/- 1,103)
benching Delete on raft cluster (channel),      nodes: 3        ...     81,159 ns/iter (+/- 13,002)
benching Set on raft cluster (channel), nodes: 5, value len:    8       ...     91,051 ns/iter (+/- 13,179)
benching Set on raft cluster (channel), nodes: 5, value len:  128       ...     92,492 ns/iter (+/- 15,413)
benching Set on raft cluster (channel), nodes: 5, value len: 1024       ...    102,103 ns/iter (+/- 10,981)
benching Set on raft cluster (channel), nodes: 5, value len: 4096       ...    135,170 ns/iter (+/- 62,198)
benching Get on raft cluster (channel), nodes: 5        ...     16,462 ns/iter (+/- 621)
benching Delete on raft cluster (channel),      nodes: 5        ...     94,448 ns/iter (+/- 16,299)
benching Set on raft cluster (tcp),     nodes: 1, value len:    8       ...     32,616 ns/iter (+/- 9,700)
benching Set on raft cluster (tcp),     nodes: 1, value len:  128       ...     35,519 ns/iter (+/- 7,489)
benching Set on raft cluster (tcp),     nodes: 1, value len: 1024       ...     42,009 ns/iter (+/- 10,693)
benching Set on raft cluster (tcp),     nodes: 1, value len: 4096       ...     58,263 ns/iter (+/- 31,890)
benching Get on raft cluster (tcp),     nodes: 1        ...     16,245 ns/iter (+/- 1,830)
benching Delete on raft cluster (tcp),  nodes: 1        ...     32,963 ns/iter (+/- 18,811)
benching Set on raft cluster (tcp),     nodes: 3, value len:    8       ...    207,939 ns/iter (+/- 19,772)
benching Set on raft cluster (tcp),     nodes: 3, value len:  128       ...    214,757 ns/iter (+/- 29,875)
benching Set on raft cluster (tcp),     nodes: 3, value len: 1024       ...    218,234 ns/iter (+/- 32,567)
benching Set on raft cluster (tcp),     nodes: 3, value len: 4096       ...    247,335 ns/iter (+/- 54,398)
benching Get on raft cluster (tcp),     nodes: 3        ...     16,917 ns/iter (+/- 1,437)
benching Delete on raft cluster (tcp),  nodes: 3        ...    208,355 ns/iter (+/- 23,317)
benching Set on raft cluster (tcp),     nodes: 5, value len:    8       ...    315,500 ns/iter (+/- 25,545)
benching Set on raft cluster (tcp),     nodes: 5, value len:  128       ...    313,588 ns/iter (+/- 32,911)
benching Set on raft cluster (tcp),     nodes: 5, value len: 1024       ...    328,193 ns/iter (+/- 23,980)
benching Set on raft cluster (tcp),     nodes: 5, value len: 4096       ...    363,133 ns/iter (+/- 46,415)
benching Get on raft cluster (tcp),     nodes: 5        ...     17,430 ns/iter (+/- 956)
benching Delete on raft cluster (tcp),  nodes: 5        ...    318,073 ns/iter (+/- 22,214)

```

## Samples

Sample of terminal output:

![2018-05-03-163205_1868x2050_scrot](https://user-images.githubusercontent.com/130903/39607380-8b40778a-4eef-11e8-99b8-9b348536993b.png)

Sample of a log file:

```
May 03 16:30:01.968 INFO starting working thread: storage-scheduler
May 03 16:30:01.968 INFO starting working thread: end-point-worker
May 03 16:30:01.969 INFO starting working thread: snap-handler
May 03 16:30:01.975 INFO TiKV is ready to serve
May 03 16:30:04.326 INFO heartbeat receiver is refreshed.
May 03 16:30:04.326 INFO heartbeat sender is refreshed.
May 03 16:30:44.693 INFO receive signal 2, stopping server...
May 03 16:30:44.693 INFO stoping end-point-worker
May 03 16:30:44.693 INFO stoping snap-handler
May 03 16:30:44.693 INFO stoping storage-scheduler
May 03 16:30:44.694 INFO scheduler stopped
May 03 16:30:44.694 INFO scheduler stopped
May 03 16:30:44.721 INFO storage RaftKv closed.
May 03 16:30:44.734 INFO stop raft store 1 thread
May 03 16:30:44.734 INFO [store 1] receive quit message
May 03 16:30:44.734 INFO start to stop raftstore.
May 03 16:30:44.734 INFO stoping split check worker
May 03 16:30:44.734 INFO stoping snapshot worker
May 03 16:30:44.734 INFO stoping raft gc worker
May 03 16:30:44.734 INFO stoping compact worker
May 03 16:30:44.734 INFO stoping pd worker
May 03 16:30:44.734 INFO stoping consistency check worker
May 03 16:30:44.735 INFO stoping cleanup sst worker
May 03 16:30:44.735 INFO stoping apply worker
May 03 16:30:44.735 INFO stop raftstore finished.
May 03 16:30:44.735 INFO stoping store address resolve worker
```