### PR TITLE
observer/split_check: clean up

### DIFF
--- a/src/raftstore/coprocessor/split_check/half.rs
+++ b/src/raftstore/coprocessor/split_check/half.rs
@@ -15,36 +15,39 @@ use rocksdb::DB;
 
 use util::config::ReadableSize;
 
-use super::super::{Coprocessor, ObserverContext, SplitCheckObserver};
-use super::Status;
+use super::super::{Coprocessor, ObserverContext, SplitCheckObserver, SplitChecker};
+use super::Host;
 
 const BUCKET_NUMBER_LIMIT: usize = 1024;
 const BUCKET_SIZE_LIMIT_MB: u64 = 512;
 
-#[derive(Default)]
-pub struct HalfStatus {
+pub struct Checker {
     buckets: Vec<Vec<u8>>,
     cur_bucket_size: u64,
     each_bucket_size: u64,
 }
 
-impl HalfStatus {
-    fn new(each_bucket_size: u64) -> HalfStatus {
-        HalfStatus {
+impl Checker {
+    fn new(each_bucket_size: u64) -> Checker {
+        Checker {
             each_bucket_size,
-            ..Default::default()
+            cur_bucket_size: 0,
+            buckets: vec![],
         }
     }
+}
 
-    pub fn push_data(&mut self, key: &[u8], value_size: u64) {
+impl SplitChecker for Checker {
+    fn on_kv(&mut self, _: &mut ObserverContext, key: &[u8], value_size: u64) -> bool {
         if self.buckets.is_empty() || self.cur_bucket_size >= self.each_bucket_size {
             self.buckets.push(key.to_vec());
             self.cur_bucket_size = 0;
         }
         self.cur_bucket_size += key.len() as u64 + value_size;
+        false
     }
 
-    pub fn split_key(mut self) -> Option<Vec<u8>> {
+    fn split_key(&mut self) -> Option<Vec<u8>> {
         let mid = self.buckets.len() / 2;
         if mid == 0 {
             None
@@ -76,29 +79,11 @@ impl HalfCheckObserver {
 impl Coprocessor for HalfCheckObserver {}
 
 impl SplitCheckObserver for HalfCheckObserver {
-    fn new_split_check_status(
-        &self,
-        _ctx: &mut ObserverContext,
-        status: &mut Status,
-        _engine: &DB,
-    ) {
-        if status.auto_split {
+    fn add_checker(&self, _: &mut ObserverContext, host: &mut Host, _: &DB) {
+        if host.auto_split() {
             return;
         }
-        status.half = Some(HalfStatus::new(self.half_split_bucket_size));
-    }
-
-    fn on_split_check(
-        &self,
-        _: &mut ObserverContext,
-        status: &mut Status,
-        key: &[u8],
-        value_size: u64,
-    ) -> Option<Vec<u8>> {
-        if let Some(status) = status.half.as_mut() {
-            status.push_data(key, value_size);
-        }
-        None
+        host.add_checker(Box::new(Checker::new(self.half_split_bucket_size)))
     }
 }
 
@@ -156,7 +141,7 @@ mod tests {
             engine.put(&s, &s).unwrap();
         }
 
-        runnable.run(SplitCheckTask::new(&region, false));
+        runnable.run(SplitCheckTask::new(region.clone(), false));
         loop {
             match rx.try_recv() {
                 Ok(Msg::SplitRegion {

--- a/src/raftstore/coprocessor/split_check/size.rs
+++ b/src/raftstore/coprocessor/split_check/size.rs
@@ -16,13 +16,43 @@ use rocksdb::DB;
 use util::transport::{RetryableSendCh, Sender};
 
 use super::super::metrics::*;
-use super::super::{Coprocessor, ObserverContext, SplitCheckObserver};
-use super::Status;
+use super::super::{Coprocessor, ObserverContext, SplitCheckObserver, SplitChecker};
+use super::Host;
 
-#[derive(Default)]
-pub struct SizeStatus {
+pub struct Checker {
+    max_size: u64,
+    split_size: u64,
     current_size: u64,
     split_key: Option<Vec<u8>>,
+}
+
+impl Checker {
+    pub fn new(max_size: u64, split_size: u64) -> Checker {
+        Checker {
+            max_size,
+            split_size,
+            current_size: 0,
+            split_key: None,
+        }
+    }
+}
+
+impl SplitChecker for Checker {
+    fn on_kv(&mut self, _: &mut ObserverContext, key: &[u8], value_size: u64) -> bool {
+        self.current_size += key.len() as u64 + value_size;
+        if self.current_size > self.split_size && self.split_key.is_none() {
+            self.split_key = Some(key.to_vec());
+        }
+        self.current_size >= self.max_size
+    }
+
+    fn split_key(&mut self) -> Option<Vec<u8>> {
+        if self.current_size >= self.max_size {
+            self.split_key.take()
+        } else {
+            None
+        }
+    }
 }
 
 pub struct SizeCheckObserver<C> {
@@ -48,19 +78,21 @@ impl<C: Sender<Msg>> SizeCheckObserver<C> {
 impl<C> Coprocessor for SizeCheckObserver<C> {}
 
 impl<C: Sender<Msg> + Send> SplitCheckObserver for SizeCheckObserver<C> {
-    fn new_split_check_status(&self, ctx: &mut ObserverContext, status: &mut Status, engine: &DB) {
-        let size_status = SizeStatus::default();
+    fn add_checker(&self, ctx: &mut ObserverContext, host: &mut Host, engine: &DB) {
         let region = ctx.region();
         let region_id = region.get_id();
         let region_size = match util::get_region_approximate_size(engine, region) {
             Ok(size) => size,
             Err(e) => {
-                error!(
+                warn!(
                     "[region {}] failed to get approximate size: {}",
                     region_id, e
                 );
                 // Need to check size.
-                status.size = Some(size_status);
+                host.add_checker(Box::new(Checker::new(
+                    self.region_max_size,
+                    self.split_size,
+                )));
                 return;
             }
         };
@@ -70,7 +102,7 @@ impl<C: Sender<Msg> + Send> SplitCheckObserver for SizeCheckObserver<C> {
             region_size,
         };
         if let Err(e) = self.ch.try_send(res) {
-            error!(
+            warn!(
                 "[region {}] failed to send approximate region size: {}",
                 region_id, e
             );
@@ -85,7 +117,10 @@ impl<C: Sender<Msg> + Send> SplitCheckObserver for SizeCheckObserver<C> {
                 self.region_max_size
             );
             // Need to check size.
-            status.size = Some(size_status);
+            host.add_checker(Box::new(Checker::new(
+                self.region_max_size,
+                self.split_size,
+            )));
         } else {
             // Does not need to check size.
             debug!(
@@ -94,28 +129,6 @@ impl<C: Sender<Msg> + Send> SplitCheckObserver for SizeCheckObserver<C> {
                 region_size,
                 self.region_max_size
             );
-        }
-    }
-
-    fn on_split_check(
-        &self,
-        _: &mut ObserverContext,
-        status: &mut Status,
-        key: &[u8],
-        value_size: u64,
-    ) -> Option<Vec<u8>> {
-        if let Some(size_status) = status.size.as_mut() {
-            size_status.current_size += key.len() as u64 + value_size;
-            if size_status.current_size > self.split_size && size_status.split_key.is_none() {
-                size_status.split_key = Some(key.to_vec());
-            }
-            if size_status.current_size >= self.region_max_size {
-                size_status.split_key.take()
-            } else {
-                None
-            }
-        } else {
-            None
         }
     }
 }
@@ -181,7 +194,7 @@ mod tests {
             engine.put(&s, &s).unwrap();
         }
 
-        runnable.run(SplitCheckTask::new(&region, true));
+        runnable.run(SplitCheckTask::new(region.clone(), true));
         // size has not reached the max_size 100 yet.
         match rx.try_recv() {
             Ok(Msg::ApproximateRegionSize { region_id, .. }) => {
@@ -199,7 +212,7 @@ mod tests {
         // we flush it to SST so we can use the size properties instead.
         engine.flush(true).unwrap();
 
-        runnable.run(SplitCheckTask::new(&region, true));
+        runnable.run(SplitCheckTask::new(region.clone(), true));
         match rx.try_recv() {
             Ok(Msg::ApproximateRegionSize { region_id, .. }) => {
                 assert_eq!(region_id, region.get_id());
@@ -233,7 +246,7 @@ mod tests {
             engine.flush_cf(handle, true).unwrap();
         }
 
-        runnable.run(SplitCheckTask::new(&region, true));
+        runnable.run(SplitCheckTask::new(region.clone(), true));
         match rx.try_recv() {
             Ok(Msg::ApproximateRegionSize { region_id, .. }) => {
                 assert_eq!(region_id, region.get_id());
@@ -256,6 +269,6 @@ mod tests {
 
         drop(rx);
         // It should be safe even the result can't be sent back.
-        runnable.run(SplitCheckTask::new(&region, true));
+        runnable.run(SplitCheckTask::new(region, true));
     }
 }

--- a/src/raftstore/coprocessor/split_check/table.rs
+++ b/src/raftstore/coprocessor/split_check/table.rs
@@ -23,13 +23,50 @@ use storage::CF_WRITE;
 use storage::types::Key;
 use util::escape;
 
-use super::super::{Coprocessor, ObserverContext, Result, SplitCheckObserver};
-use super::Status;
+use super::super::{Coprocessor, ObserverContext, Result, SplitCheckObserver, SplitChecker};
+use super::Host;
 
 #[derive(Default)]
-pub struct TableStatus {
+pub struct Checker {
     first_encoded_table_prefix: Option<Vec<u8>>,
-    last_encoded_table_prefix: Option<Vec<u8>>,
+    split_key: Option<Vec<u8>>,
+}
+
+impl SplitChecker for Checker {
+    /// Feed keys in order to find the split key.
+    /// If `current_data_key` does not belong to `status.first_encoded_table_prefix`.
+    /// it returns the encoded table prefix of `current_data_key`.
+    fn on_kv(&mut self, _: &mut ObserverContext, key: &[u8], _: u64) -> bool {
+        if self.split_key.is_some() {
+            return true;
+        }
+
+        let current_encoded_key = keys::origin_key(key);
+
+        let split_key = if self.first_encoded_table_prefix.is_some() {
+            if !is_same_table(
+                self.first_encoded_table_prefix.as_ref().unwrap(),
+                current_encoded_key,
+            ) {
+                // Different tables.
+                Some(current_encoded_key)
+            } else {
+                None
+            }
+        } else if is_table_key(current_encoded_key) {
+            // Now we meet the very first table key of this region.
+            Some(current_encoded_key)
+        } else {
+            None
+        };
+        self.split_key = split_key.and_then(to_encoded_table_prefix);
+        self.split_key.is_some()
+    }
+
+    fn split_key(&mut self) -> Option<Vec<u8>> {
+        let key = self.split_key.take()?;
+        Some(keys::data_key(&key))
+    }
 }
 
 #[derive(Default)]
@@ -38,138 +75,86 @@ pub struct TableCheckObserver;
 impl Coprocessor for TableCheckObserver {}
 
 impl SplitCheckObserver for TableCheckObserver {
-    fn new_split_check_status(&self, ctx: &mut ObserverContext, status: &mut Status, engine: &DB) {
-        let mut table_status = TableStatus::default();
-        let skip = before_check(&mut table_status, engine, ctx.region());
-        if !skip {
-            status.table = Some(table_status);
+    fn add_checker(&self, ctx: &mut ObserverContext, host: &mut Host, engine: &DB) {
+        let region = ctx.region();
+        if is_same_table(region.get_start_key(), region.get_end_key()) {
+            // Region is inside a table, skip for saving IO.
+            return;
         }
-    }
 
-    fn on_split_check(
-        &self,
-        _: &mut ObserverContext,
-        status: &mut Status,
-        key: &[u8],
-        _: u64,
-    ) -> Option<Vec<u8>> {
-        if let Some(ref mut table_status) = status.table {
-            check_key(table_status, key)
-        } else {
-            None
-        }
-    }
-}
-
-/// Do some quick checks, true for skipping `check_key`.
-fn before_check(status: &mut TableStatus, engine: &DB, region: &Region) -> bool {
-    if is_same_table(region.get_start_key(), region.get_end_key()) {
-        // Region is inside a table, skip for saving IO.
-        return true;
-    }
-
-    let end_key = match last_key_of_region(engine, region) {
-        Ok(Some(end_key)) => end_key,
-        Ok(None) => return true,
-        Err(err) => {
-            error!(
-                "[region {}] failed to get region last key: {}",
-                region.get_id(),
-                err
-            );
-            return true;
-        }
-    };
-
-    let encoded_start_key = region.get_start_key();
-    let encoded_end_key = keys::origin_key(&end_key);
-
-    if encoded_start_key.len() < table_codec::TABLE_PREFIX_KEY_LEN
-        || encoded_end_key.len() < table_codec::TABLE_PREFIX_KEY_LEN
-    {
-        // For now, let us scan region if encoded_start_key or encoded_end_key
-        // is less than TABLE_PREFIX_KEY_LEN.
-        return false;
-    }
-
-    // Table data starts with `TABLE_PREFIX`.
-    // Find out the actual range of this region by comparing with `TABLE_PREFIX`.
-    match (
-        encoded_start_key[..table_codec::TABLE_PREFIX_LEN].cmp(table_codec::TABLE_PREFIX),
-        encoded_end_key[..table_codec::TABLE_PREFIX_LEN].cmp(table_codec::TABLE_PREFIX),
-    ) {
-        // The range does not cover table data.
-        (Ordering::Less, Ordering::Less) | (Ordering::Greater, Ordering::Greater) => true,
-
-        // Following arms matches when the region contains table data.
-        // Covers all table data.
-        (Ordering::Less, Ordering::Greater) => false,
-        // The later part contains table data.
-        (Ordering::Less, Ordering::Equal) => {
-            // It starts from non-table area to table area,
-            // try to extract a split key from `encoded_end_key`, and save it in status.
-            status.last_encoded_table_prefix = to_encoded_table_prefix(encoded_end_key);
-            false
-        }
-        // Region is in table area.
-        (Ordering::Equal, Ordering::Equal) => {
-            if is_same_table(encoded_start_key, encoded_end_key) {
-                // Same table.
-                true
-            } else {
-                // Different tables.
-                // Note that table id does not grow by 1, so have to use
-                // `encoded_end_key` to extract a table prefix.
-                // See more: https://github.com/pingcap/tidb/issues/4727
-                status.last_encoded_table_prefix = to_encoded_table_prefix(encoded_end_key);
-                false
+        let end_key = match last_key_of_region(engine, region) {
+            Ok(Some(end_key)) => end_key,
+            Ok(None) => return,
+            Err(err) => {
+                warn!(
+                    "[region {}] failed to get region last key: {}",
+                    region.get_id(),
+                    err
+                );
+                return;
             }
+        };
+
+        let encoded_start_key = region.get_start_key();
+        let encoded_end_key = keys::origin_key(&end_key);
+
+        if encoded_start_key.len() < table_codec::TABLE_PREFIX_KEY_LEN
+            || encoded_end_key.len() < table_codec::TABLE_PREFIX_KEY_LEN
+        {
+            // For now, let us scan region if encoded_start_key or encoded_end_key
+            // is less than TABLE_PREFIX_KEY_LEN.
+            host.add_checker(Box::new(Checker::default()));
+            return;
         }
-        // The region starts from tabel area to non-table area.
-        (Ordering::Equal, Ordering::Greater) => {
-            // As the comment above, outside needs scan for finding a split key.
-            status.first_encoded_table_prefix = to_encoded_table_prefix(encoded_start_key);
-            false
-        }
-        _ => panic!(
-            "start_key {:?} and end_key {:?} out of order",
-            escape(encoded_start_key),
-            escape(encoded_end_key)
-        ),
-    }
-}
 
-/// Feed keys in order to find the split key.
-/// If `current_data_key` does not belong to `status.first_encoded_table_prefix`.
-/// it returns the encoded table prefix of `current_data_key`.
-fn check_key(status: &mut TableStatus, current_data_key: &[u8]) -> Option<Vec<u8>> {
-    if let Some(last_encoded_table_prefix) = status.last_encoded_table_prefix.take() {
-        // `before_check` found a split key.
-        return Some(keys::data_key(&last_encoded_table_prefix));
-    }
-
-    let current_encoded_key = keys::origin_key(current_data_key);
-
-    let split_key = if status.first_encoded_table_prefix.is_some() {
-        if !is_same_table(
-            status.first_encoded_table_prefix.as_ref().unwrap(),
-            current_encoded_key,
+        let mut first_encoded_table_prefix = None;
+        let mut split_key = None;
+        // Table data starts with `TABLE_PREFIX`.
+        // Find out the actual range of this region by comparing with `TABLE_PREFIX`.
+        match (
+            encoded_start_key[..table_codec::TABLE_PREFIX_LEN].cmp(table_codec::TABLE_PREFIX),
+            encoded_end_key[..table_codec::TABLE_PREFIX_LEN].cmp(table_codec::TABLE_PREFIX),
         ) {
-            // Different tables.
-            Some(current_encoded_key)
-        } else {
-            None
+            // The range does not cover table data.
+            (Ordering::Less, Ordering::Less) | (Ordering::Greater, Ordering::Greater) => return,
+
+            // Following arms matches when the region contains table data.
+            // Covers all table data.
+            (Ordering::Less, Ordering::Greater) => {}
+            // The later part contains table data.
+            (Ordering::Less, Ordering::Equal) => {
+                // It starts from non-table area to table area,
+                // try to extract a split key from `encoded_end_key`, and save it in status.
+                split_key = to_encoded_table_prefix(encoded_end_key);
+            }
+            // Region is in table area.
+            (Ordering::Equal, Ordering::Equal) => {
+                if is_same_table(encoded_start_key, encoded_end_key) {
+                    // Same table.
+                    return;
+                } else {
+                    // Different tables.
+                    // Note that table id does not grow by 1, so have to use
+                    // `encoded_end_key` to extract a table prefix.
+                    // See more: https://github.com/pingcap/tidb/issues/4727
+                    split_key = to_encoded_table_prefix(encoded_end_key);
+                }
+            }
+            // The region starts from tabel area to non-table area.
+            (Ordering::Equal, Ordering::Greater) => {
+                // As the comment above, outside needs scan for finding a split key.
+                first_encoded_table_prefix = to_encoded_table_prefix(encoded_start_key);
+            }
+            _ => panic!(
+                "start_key {:?} and end_key {:?} out of order",
+                escape(encoded_start_key),
+                escape(encoded_end_key)
+            ),
         }
-    } else if is_table_key(current_encoded_key) {
-        // Now we meet the very first table key of this region.
-        Some(current_encoded_key)
-    } else {
-        None
-    };
-    if let Some(key) = split_key {
-        to_encoded_table_prefix(key).map(|k| keys::data_key(&k))
-    } else {
-        None
+        host.add_checker(Box::new(Checker {
+            first_encoded_table_prefix,
+            split_key,
+        }));
     }
 }
 
@@ -335,7 +320,7 @@ mod test {
             for (encoded_start_key, encoded_end_key, table_id) in cases {
                 region.set_start_key(encoded_start_key.unwrap_or_else(Vec::new));
                 region.set_end_key(encoded_end_key.unwrap_or_else(Vec::new));
-                runnable.run(SplitCheckTask::new(&region, true));
+                runnable.run(SplitCheckTask::new(region.clone(), true));
 
                 if let Some(id) = table_id {
                     let key = Key::from_raw(&gen_table_prefix(id));

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -2323,7 +2323,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             {
                 continue;
             }
-            let task = SplitCheckTask::new(peer.region(), true);
+            let task = SplitCheckTask::new(peer.region().clone(), true);
             if let Err(e) = self.split_check_worker.schedule(task) {
                 error!("{} failed to schedule split check: {}", self.tag, e);
             }
@@ -2528,7 +2528,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             return;
         }
 
-        let task = SplitCheckTask::new(region, false);
+        let task = SplitCheckTask::new(region.clone(), false);
         if let Err(e) = self.split_check_worker.schedule(task) {
             error!("{} failed to schedule split check: {}", self.tag, e);
         }


### PR DESCRIPTION
This pr adds a `SplitChecker` trait and `SplitCheckerHost` to abstract the check logic from the split check worker and make things clear. Also the new mechanism is a little more efficient than the original one as table checker can be omitted if suitable.

After this is merged, I will add batch split support.