### PR TITLE
Use AtomicU64 instead RwLock for tracking snapshot size.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 #![feature(alloc)]
 #![feature(slice_patterns)]
 #![feature(box_syntax)]
-#![feature(iterator_for_each)]
+#![feature(integer_atomics)]
 #![feature(entry_or_default)]
 #![cfg_attr(feature = "dev", feature(plugin))]
 #![cfg_attr(feature = "dev", plugin(clippy))]

--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -872,11 +872,10 @@ impl Snapshot for Snap {
         debug!("deleting {}", self.path());
         for cf_file in &self.cf_files {
             delete_file_if_exist(&cf_file.tmp_path);
-            if file_exists(&cf_file.path) {
+            delete_file_if_exist(&cf_file.clone_path);
+            if delete_file_if_exist(&cf_file.path) {
                 self.size_track.fetch_sub(cf_file.size, Ordering::SeqCst);
             }
-            delete_file_if_exist(&cf_file.path);
-            delete_file_if_exist(&cf_file.clone_path);
         }
         delete_file_if_exist(&self.meta_file.tmp_path);
         delete_file_if_exist(&self.meta_file.path);

--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -1293,7 +1293,6 @@ impl SnapManager {
     /// Get the approximate size of snap file exists in snap directory.
     ///
     /// Return value is not guaranteed to be accurate.
-    #[allow(let_and_return)]
     pub fn get_total_snap_size(&self) -> u64 {
         let core = self.core.rl();
         core.snap_size.load(Ordering::SeqCst)

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -237,7 +237,9 @@ impl Debugger {
         let handle = box_try!(get_cf_handle(db, cf));
         let start = if start.is_empty() { None } else { Some(start) };
         let end = if end.is_empty() { None } else { Some(end) };
+        info!("Debugger starts manual comapct on {:?}.{}", db, cf);
         compact_range(db, handle, start, end, false);
+        info!("Debugger finishs manual comapct on {:?}.{}", db, cf);
         Ok(())
     }
 

--- a/src/util/file.rs
+++ b/src/util/file.rs
@@ -27,14 +27,14 @@ pub fn file_exists(file: &PathBuf) -> bool {
     path.exists() && path.is_file()
 }
 
-pub fn delete_file_if_exist(file: &PathBuf) {
+/// Delete given path from file system. Return `true` for success.
+pub fn delete_file_if_exist(file: &PathBuf) -> bool {
     match fs::remove_file(file) {
-        Ok(_) => {}
+        Ok(_) => return true,
         Err(ref e) if e.kind() == ErrorKind::NotFound => {}
-        Err(e) => {
-            warn!("failed to delete file {}: {:?}", file.display(), e);
-        }
+        Err(e) => warn!("failed to delete file {}: {:?}", file.display(), e),
     }
+    false
 }
 
 pub fn copy_and_sync<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<u64> {


### PR DESCRIPTION
It's easy to write bug for tracking snapshot size with `RwLock`, especially for now rustc is not smart enough to deconstruct `LockGuard`s ASAP. For example, in function `Snap::save_cf_files` the lock won't be released until the file crc32 is calculated. If the file is large, it will take a long while so that maybe block `raftstore` thread.
This PR fix this issue by replace `RwLock` with `AtomicU64`.