### PR TITLE
Logger supports both time and size-based rotation

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -12,6 +12,9 @@
 # file to store log, write to stderr if it's empty.
 # log-file = ""
 
+# size to allow log files to grow to before rotating.
+# log-rotation-size = "4GB"
+
 [readpool.storage]
 # size of thread pool for high-priority operations
 # high-concurrency = 4

--- a/src/bin/setup.rs
+++ b/src/bin/setup.rs
@@ -51,15 +51,16 @@ pub fn init_log(config: &TiKvConfig) {
             fatal!("failed to initialize log: {:?}", e);
         });
     } else {
-        let logger = BufWriter::new(RotatingFileLogger::new(&config.log_file).unwrap_or_else(
-            |e| {
-                fatal!(
-                    "failed to initialize log with file {:?}: {:?}",
-                    config.log_file,
-                    e
-                );
-            },
-        ));
+        let logger = BufWriter::new(
+            RotatingFileLogger::new(&config.log_file, config.log_rotation_size.0 as u64)
+                .unwrap_or_else(|e| {
+                    fatal!(
+                        "failed to initialize log with file {:?}: {:?}",
+                        config.log_file,
+                        e
+                    );
+                }),
+        );
         let decorator = PlainDecorator::new(logger);
         let drain = FullFormat::new(decorator).build().fuse();
         let drain = Async::new(drain).build().fuse();

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,6 +49,7 @@ const LOCKCF_MAX_MEM: usize = GB as usize;
 const RAFT_MIN_MEM: usize = 256 * MB as usize;
 const RAFT_MAX_MEM: usize = 2 * GB as usize;
 pub const LAST_CONFIG_FILE: &str = "last_tikv.toml";
+const DEFAULT_LOG_ROTATION_SIZE: u64 = 4096 * MB as u64;
 
 fn memory_mb_for_cf(is_raft_db: bool, cf: &str) -> usize {
     let total_mem = sys_info::mem_info().unwrap().total * KB;
@@ -749,6 +750,7 @@ pub struct TiKvConfig {
     #[serde(with = "log_level_serde")]
     pub log_level: slog::Level,
     pub log_file: String,
+    pub log_rotation_size: ReadableSize,
     pub readpool: ReadPoolConfig,
     pub server: ServerConfig,
     pub storage: StorageConfig,
@@ -768,6 +770,7 @@ impl Default for TiKvConfig {
         TiKvConfig {
             log_level: slog::Level::Info,
             log_file: "".to_owned(),
+            log_rotation_size: ReadableSize(DEFAULT_LOG_ROTATION_SIZE),
             readpool: ReadPoolConfig::default(),
             server: ServerConfig::default(),
             metric: MetricConfig::default(),

--- a/src/util/file_log.rs
+++ b/src/util/file_log.rs
@@ -11,42 +11,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, metadata, read_dir, File, OpenOptions};
 use std::io::{self, Write};
-use std::path::Path;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use time::{self, Timespec, Tm};
+use std::path::{Path, PathBuf};
 
-const ONE_DAY_SECONDS: u64 = 60 * 60 * 24;
+const FLUSHES_BEFORE_ESTIMATE_RENEWAL: u8 = 10;
 
-fn systemtime_to_tm(t: SystemTime) -> Tm {
-    let duration = t.duration_since(UNIX_EPOCH).unwrap();
-    let spec = Timespec::new(duration.as_secs() as i64, duration.subsec_nanos() as i32);
-    time::at(spec)
-}
-
-fn compute_rollover_time(tm: Tm) -> Tm {
-    let day_start_tm = Tm {
-        tm_hour: 0,
-        tm_min: 0,
-        tm_sec: 0,
-        tm_nsec: 0,
-        ..tm
-    };
-    let duration = time::Duration::from_std(Duration::new(ONE_DAY_SECONDS, 0)).unwrap();
-    (day_start_tm.to_utc() + duration).to_local()
-}
-
-/// Returns a Tm at the time one day before the given Tm.
-/// It expects the argument `tm` to be in local timezone. The resulting Tm is in local timezone.
-fn one_day_before(tm: Tm) -> Tm {
-    let duration = time::Duration::from_std(Duration::new(ONE_DAY_SECONDS, 0)).unwrap();
-    (tm.to_utc() - duration).to_local()
-}
-
-fn open_log_file(path: &str) -> io::Result<File> {
-    let p = Path::new(path);
-    let parent = p.parent().unwrap();
+fn open_log_file(path: impl AsRef<Path>) -> io::Result<File> {
+    let path = path.as_ref();
+    let parent = path.parent().unwrap();
     if !parent.is_dir() {
         fs::create_dir_all(parent)?
     }
@@ -54,130 +27,255 @@ fn open_log_file(path: &str) -> io::Result<File> {
 }
 
 pub struct RotatingFileLogger {
-    rollover_time: Tm,
-    file_path: String,
+    /// The path pointing to the most-current log file.
+    file_path: PathBuf,
+    /// The max size of the file, in bytes.
+    rollover_size: u64,
+    /// A rough estimate of the current size of the file.
+    ///
+    /// Checking the size of the file from the metadata takes approximately 800ns on a modern Linux
+    /// machine with an EXT4 filesystem. This is too slow to check every log record written.
+    ///
+    /// Since it is an estimate it may drift (significantly) if there is mutation of the actual
+    /// file on disk.
+    estimated_file_size: u64,
+    /// The number of `flush()` calls since last `estimated_current_size` is updated.
+    flushes_since_last_estimate: u8,
+    /// Handle for the current log file.
     file: File,
 }
 
 impl RotatingFileLogger {
-    pub fn new(path: &str) -> io::Result<Self> {
-        let file = open_log_file(path)?;
-        let file_attr = fs::metadata(path).unwrap();
-        let file_modified_time = file_attr.modified().unwrap();
-        let rollover_time = compute_rollover_time(systemtime_to_tm(file_modified_time));
-        let ret = Self {
-            rollover_time,
-            file_path: path.to_string(),
+    pub fn new(path: impl AsRef<Path>, rollover_size: u64) -> io::Result<RotatingFileLogger> {
+        let path = path.as_ref();
+        let file = open_log_file(&path)?;
+        let estimated_file_size = metadata(&path)?.len();
+        let ret = RotatingFileLogger {
+            rollover_size,
+            estimated_file_size,
+            flushes_since_last_estimate: 0,
+            file_path: path.canonicalize()?,
             file,
         };
         Ok(ret)
     }
 
+    /// Open the log file and read the size for the running estimate.
     fn open(&mut self) -> io::Result<()> {
         self.file = open_log_file(&self.file_path)?;
+        self.update_estimate()
+    }
+
+    /// Reinitializes the file size esimate.
+    fn update_estimate(&mut self) -> io::Result<()> {
+        self.estimated_file_size = metadata(&self.file_path).map(|metadata| metadata.len())?;
+        self.flushes_since_last_estimate = 0;
         Ok(())
     }
 
-    fn should_rollover(&mut self) -> bool {
-        time::now() > self.rollover_time
+    /// Determine if the log file should rollover.
+    ///
+    /// This is a fuzzy determination, we don't want to check the file size each time, but we also
+    /// don't want to trust that we're the only process writing to the file. So we check
+    /// occasionally to make sure our guess is accurate.
+    fn should_rollover(&mut self) -> io::Result<bool> {
+        if self.flushes_since_last_estimate >= FLUSHES_BEFORE_ESTIMATE_RENEWAL {
+            self.update_estimate()?;
+        }
+        Ok(self.estimated_file_size >= self.rollover_size)
     }
 
+    /// Perform a log rollover.
+    ///
+    /// Flushes then renames the current log file according to `next_log_file_name`, then creates a
+    /// new log file under the current log file name.
     fn do_rollover(&mut self) -> io::Result<()> {
         self.close()?;
-        let mut s = self.file_path.clone();
-        s.push_str(".");
-        s.push_str(&time::strftime("%Y%m%d", &one_day_before(self.rollover_time)).unwrap());
-        fs::rename(&self.file_path, &s)?;
-        self.update_rollover_time();
+        let mut next = self.file_path.clone();
+        next.set_file_name(self.next_log_file_name()?);
+        fs::rename(&self.file_path, &next)?;
         self.open()
-    }
-
-    fn update_rollover_time(&mut self) {
-        let now = time::now();
-        self.rollover_time = compute_rollover_time(now);
     }
 
     fn close(&mut self) -> io::Result<()> {
         self.file.flush()
     }
+
+    /// Determine the next name for a rolling over log file.
+    ///
+    /// Uses the current log file's name along with an up to 6 digit number (with leading zeros). The next number
+    /// will always be the maximum of those found in the directory. Rollover over to 0 when it reaches
+    /// 999999. At this point it wi
+    fn next_log_file_name(&self) -> io::Result<PathBuf> {
+        let parent = self.file_path
+            .parent()
+            .expect("Could not get parent of log file path.");
+        let log_file_name = self.file_path
+            .file_name()
+            .and_then(|f| f.to_str())
+            .expect("Log file name was invalid UTF-8 string");
+        let entries = read_dir(parent)?.filter_map(|maybe_entry| {
+            let entry = maybe_entry.ok()?;
+            let file_name = entry.file_name();
+            let file_name = file_name.to_str()?;
+            if file_name.starts_with(log_file_name) {
+                let number: usize = file_name.split('.').last()?.parse().ok()?;
+                Some(number)
+            } else {
+                None
+            }
+        });
+        let next = entries.max().unwrap_or(0) + 1;
+        Ok(format!(
+            "{log_file_name}.{next:03}",
+            log_file_name = log_file_name,
+            next = next
+        ).into())
+    }
 }
 
 impl Write for RotatingFileLogger {
     fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
-        self.file.write(bytes)
+        let written = self.file.write(bytes)?;
+        self.estimated_file_size += written as u64;
+        Ok(written)
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        if self.should_rollover() {
+        self.flushes_since_last_estimate += 1;
+        self.file.flush()?;
+        if self.should_rollover()? {
             self.do_rollover()?;
         };
-        self.file.flush()
-    }
-}
-
-impl Drop for RotatingFileLogger {
-    fn drop(&mut self) {
-        self.close().unwrap()
+        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::fs::OpenOptions;
+    use std::fs::{read_dir, OpenOptions};
     use std::io::prelude::*;
-    use std::path::Path;
-    use time::{self, Timespec};
 
+    use super::{RotatingFileLogger, FLUSHES_BEFORE_ESTIMATE_RENEWAL};
     use tempdir::TempDir;
-    use utime;
-
-    use super::{RotatingFileLogger, ONE_DAY_SECONDS};
 
     #[test]
-    fn test_one_day_before() {
-        let tm = time::strptime("2016-08-30", "%Y-%m-%d").unwrap().to_local();
-        let one_day_ago = time::strptime("2016-08-29", "%Y-%m-%d").unwrap().to_local();
-        assert_eq!(one_day_ago, super::one_day_before(tm));
-    }
-
-    fn file_exists(file: &str) -> bool {
-        let path = Path::new(file);
-        path.exists() && path.is_file()
-    }
-
-    #[test]
-    fn test_rotating_file_logger() {
+    fn test_ensure_paths_are_created() {
         let tmp_dir = TempDir::new("").unwrap();
         let log_file = tmp_dir
             .path()
-            .join("test_rotating_file_logger.log")
+            .join("non-existing")
+            .join("more-non-existent")
+            .join("some_filename.log")
             .to_str()
             .unwrap()
             .to_string();
-        // create a file with mtime == one day ago
-        {
-            let mut file = OpenOptions::new()
-                .append(true)
-                .create(true)
-                .open(&log_file)
-                .unwrap();
-            file.write_all(b"hello world!").unwrap();
+        // Make sure that the logger won't error if we ask it to create a new dir/file.
+        RotatingFileLogger::new(&log_file, 1).unwrap();
+    }
+
+    #[test]
+    fn test_next_log_file_name() {
+        let tmp_dir = TempDir::new("").unwrap();
+        let log_file = tmp_dir
+            .path()
+            .join("test_next_rollover_log_filename.log")
+            .to_str()
+            .unwrap()
+            .to_string();
+        let mut logger = RotatingFileLogger::new(&log_file, 1).unwrap();
+        for index in 1..1010 {
+            let next = logger.next_log_file_name();
+            let expected = format!("test_next_rollover_log_filename.log.{:03}", index);
+            assert_eq!(next.unwrap().to_str().unwrap(), expected);
+            // Force a rollover.
+            logger.write_all(&[0_u8; 16]).unwrap();
+            logger.flush().unwrap();
         }
-        let ts = time::now().to_timespec();
-        let one_day_ago = Timespec::new(ts.sec - ONE_DAY_SECONDS as i64, ts.nsec);
-        let time_in_sec = one_day_ago.sec as u64;
-        utime::set_file_times(&log_file, time_in_sec, time_in_sec).unwrap();
-        // initialize the logger
-        let mut core = RotatingFileLogger::new(&log_file).unwrap();
-        assert!(core.should_rollover());
-        core.do_rollover().unwrap();
-        // check the rotated file exist
-        let mut rotated_file = log_file.clone();
-        rotated_file.push_str(".");
-        let file_suffix_time =
-            super::one_day_before(super::compute_rollover_time(time::at(one_day_ago)));
-        rotated_file.push_str(&time::strftime("%Y%m%d", &file_suffix_time).unwrap());
-        assert!(file_exists(&rotated_file));
-        assert!(!core.should_rollover());
+    }
+
+    #[test]
+    fn test_rotating_file_logger_rollover() {
+        const ROTATION_SIZE: u64 = 16;
+        let tmp_dir = TempDir::new("").unwrap();
+        let log_file = tmp_dir
+            .path()
+            .join("test_rotating_file_logger_rollover.log")
+            .to_str()
+            .unwrap()
+            .to_string();
+        let mut logger = RotatingFileLogger::new(&log_file, ROTATION_SIZE).unwrap();
+        for index in 1..1010 {
+            // Not enough to roll over.
+            logger
+                .write_all(&[0_u8; (ROTATION_SIZE - 1) as usize])
+                .unwrap();
+            logger.flush().unwrap();
+            assert_eq!(read_dir(tmp_dir.path()).unwrap().count(), index);
+            // Enough to roll over.
+            logger.write_all(&[0_u8; 1]).unwrap();
+            logger.flush().unwrap();
+            assert_eq!(read_dir(tmp_dir.path()).unwrap().count(), index + 1);
+        }
+    }
+
+    #[test]
+    fn test_rotating_file_logger_estimate() {
+        const ROTATION_SIZE: u64 = 10;
+        let tmp_dir = TempDir::new("").unwrap();
+        let log_file = tmp_dir
+            .path()
+            .join("test_rotating_file_logger_estimate_renewal.log")
+            .to_str()
+            .unwrap()
+            .to_string();
+        let mut logger = RotatingFileLogger::new(&log_file, ROTATION_SIZE).unwrap();
+        // Ensure the estimate is being incremented.
+        logger.write_all(&[0_u8; 1]).unwrap();
+        assert_eq!(logger.estimated_file_size, 1);
+        logger.write_all(&[0_u8; 1]).unwrap();
+        assert_eq!(logger.estimated_file_size, 2);
+
+        // Ensure the flushes are being tracked.
+        assert_eq!(logger.flushes_since_last_estimate, 0);
+        logger.flush().unwrap();
+        assert_eq!(logger.flushes_since_last_estimate, 1);
+
+        // Open again and write to the file as well, this should make the esimate incorrect.
+        let mut other_handle = OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(log_file)
+            .unwrap();
+        other_handle.write_all(&[0_u8; 1]).unwrap();
+        other_handle.flush().unwrap();
+        // Since we're writing from the other handle the estimate isn't updated.
+        assert_eq!(logger.estimated_file_size, 2);
+        assert_eq!(read_dir(tmp_dir.path()).unwrap().count(), 1);
+
+        // We've already flushed the logger once, now flush it until it is almost ready to renew
+        // its estimate.
+        while logger.flushes_since_last_estimate < (FLUSHES_BEFORE_ESTIMATE_RENEWAL - 1) {
+            logger.flush().unwrap()
+        }
+
+        // Ensure it still hasn't refreshed its estimate.
+        assert_eq!(logger.estimated_file_size, 2);
+        assert_eq!(
+            logger.flushes_since_last_estimate,
+            FLUSHES_BEFORE_ESTIMATE_RENEWAL - 1
+        );
+
+        // At this point the flush will renew the estimate.
+        logger.flush().unwrap();
+        assert_eq!(logger.flushes_since_last_estimate, 0);
+        assert_eq!(logger.estimated_file_size, 3);
+
+        // Write enough to force a rollover, creating a new file.
+        logger.write_all(&[0_u8; 7]).unwrap();
+        logger.flush().unwrap();
+        assert_eq!(read_dir(tmp_dir.path()).unwrap().count(), 2);
+        assert_eq!(logger.flushes_since_last_estimate, 0);
+        assert_eq!(logger.estimated_file_size, 0);
     }
 }


### PR DESCRIPTION
Based off #3010 . 

Closes #3035.

Currently our file logger uses time based rotation, which is not always adequate in high load situations. This PR allows for new log rotation options:

* Size based, rotating logs whenever they grow larger than the given size.
* Time based, the current system, rotating logs after every given interval.
* Off, such as when logging to `STDERR`

## Implementation

### Choosing a logger

We could have chosen a design that used dynamic dispatch like so:

```rust
struct Logger {
  strategy: RotationStrategy,
}

enum RotationStrategy {
  Size(ReadableSize),
  Time(ReadableDuration),
  Off,
}

impl Logger {
  fn log(self, bytes: [u8]) -> io::Result<()> {
    match self.strategy {
      Size(amount) => /* .. */,
      Time(amount) => /* .. */,
      Off => /* .. */
    }
}
```

However this has some performance implications since we are doing a match each log call. It's better to try to push this down into static dispatch if possible.

### Estimating log file metadata

An initial implementation called `fs::metadata(path)` each flush, however it was noted that getting this information took approximately 800ns per call.

```rust
#![feature(test)]
extern crate test;use std::fs::metadata;
use test::Bencher;

const FILE: &'static str = "./src/main.rs";

#[bench]
fn bench_metadata(b: &mut Bencher) {
    b.iter(||
        metadata(FILE).unwrap()
    );
}
```

```
test bench_metadata ... bench:         798 ns/iter (+/- 185)
```

This cost was found to be relatively constant regardless of file size.

As a result this implementation uses an estimated file size and only updates the estimate with the real value every 10 flushes. This reduces the overhead of checking the file's size, while still checking the size often enough to avoid any hugely serious problems where multiple processes might be writing to the same file.

This PR **adds the configuration option** `log_rotation_size` which defaults to 4GB.

## Created files:

```
here
here.2018-06-18-19:34:53
here.2018-06-18-19:35:00
here.2018-06-18-19:35:07
here.2018-06-18-19:35:12
```

## TODO

* [ ] Add command line flag?
* [x] Update template configuration.
* [x] Ensure configuration can accept other units such as megabytes, gigabytes.