### PR TITLE
store: apply all changes before advancing apply

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -975,10 +975,8 @@ impl Peer {
         self.mut_store().applied_index_term = applied_index_term;
         self.peer_stat.written_keys += apply_metrics.written_keys;
         self.peer_stat.written_bytes += apply_metrics.written_bytes;
-        let diff = {
-            self.delete_keys_hint += apply_metrics.delete_keys_hint;
-            self.size_diff_hint as i64 + apply_metrics.size_diff_hint
-        };
+        self.delete_keys_hint += apply_metrics.delete_keys_hint;
+        let diff = self.size_diff_hint as i64 + apply_metrics.size_diff_hint;
         self.size_diff_hint = cmp::max(diff, 0) as u64;
 
         if self.has_pending_snapshot() && self.ready_to_handle_pending_snap() {
@@ -997,12 +995,10 @@ impl Peer {
         self.pending_reads.gc();
     }
 
-    pub fn post_split(&mut self, apply_metrics: &ApplyMetrics) {
-        let diff = {
-            self.delete_keys_hint = apply_metrics.delete_keys_hint;
-            apply_metrics.size_diff_hint
-        };
-        self.size_diff_hint = cmp::max(diff, 0) as u64;
+    pub fn post_split(&mut self) {
+        // Reset delete_keys_hint and size_diff_hint.
+        self.delete_keys_hint = 0;
+        self.size_diff_hint = 0;
     }
 
     /// Try to renew leader lease.

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -1540,7 +1540,6 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         left: metapb::Region,
         right: metapb::Region,
         right_derive: bool,
-        metrics: &ApplyMetrics,
     ) {
         let (origin_region, new_region) = if right_derive {
             (right.clone(), left.clone())
@@ -1551,7 +1550,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         {
             let peer = self.region_peers.get_mut(&region_id).unwrap();
             peer.mut_store().region = origin_region;
-            peer.post_split(metrics);
+            peer.post_split();
         }
         let new_region_id = new_region.get_id();
         if let Some(peer) = self.region_peers.get(&new_region_id) {
@@ -1941,7 +1940,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                     left,
                     right,
                     right_derive,
-                } => self.on_ready_split_region(region_id, left, right, right_derive, metrics),
+                } => self.on_ready_split_region(region_id, left, right, right_derive),
                 ExecResult::PrepareMerge { region, state } => {
                     self.on_ready_prepare_merge(region, state, merged);
                 }

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -61,7 +61,7 @@ use super::msg::{Callback, ReadResponse};
 use super::peer::{self, ConsistencyState, Peer, ReadyContext, StaleState};
 use super::peer_storage::{self, ApplySnapResult, CacheQueryStats};
 use super::transport::Transport;
-use super::worker::apply::{ChangePeer, ExecResult};
+use super::worker::apply::{ApplyMetrics, ApplyRes, ChangePeer, ExecResult};
 use super::worker::{ApplyRunner, ApplyTask, ApplyTaskRes, CleanupSSTRunner, CleanupSSTTask,
                     CompactRunner, CompactTask, ConsistencyCheckRunner, ConsistencyCheckTask,
                     RaftlogGcRunner, RaftlogGcTask, RegionRunner, RegionTask, SplitCheckRunner,
@@ -677,12 +677,32 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         loop {
             match self.apply_res_receiver.as_ref().unwrap().try_recv() {
                 Ok(ApplyTaskRes::Applys(multi_res)) => for res in multi_res {
-                    if let Some(p) = self.region_peers.get_mut(&res.region_id) {
-                        debug!("{} async apply finish: {:?}", p.tag, res);
-                        p.post_apply(&res, &mut self.pending_raft_groups, &mut self.store_stat);
+                    debug!(
+                        "{} async apply finish: {:?}",
+                        self.region_peers
+                            .get(&res.region_id)
+                            .map(|p| &p.tag)
+                            .unwrap_or(&self.tag),
+                        res
+                    );
+                    let ApplyRes {
+                        region_id,
+                        apply_state,
+                        applied_index_term,
+                        exec_res,
+                        metrics,
+                        merged,
+                    } = res;
+                    self.on_ready_result(region_id, merged, exec_res, &metrics);
+                    if let Some(p) = self.region_peers.get_mut(&region_id) {
+                        p.post_apply(
+                            &mut self.pending_raft_groups,
+                            apply_state,
+                            applied_index_term,
+                            merged,
+                            &metrics,
+                        );
                     }
-                    self.store_stat.lock_cf_bytes_written += res.metrics.lock_cf_written_bytes;
-                    self.on_ready_result(res.region_id, res.merged, res.exec_res);
                 },
                 Ok(ApplyTaskRes::Destroy(p)) => {
                     let store_id = self.store_id();
@@ -1520,6 +1540,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         left: metapb::Region,
         right: metapb::Region,
         right_derive: bool,
+        metrics: &ApplyMetrics,
     ) {
         let (origin_region, new_region) = if right_derive {
             (right.clone(), left.clone())
@@ -1527,11 +1548,11 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             (left.clone(), right.clone())
         };
 
-        self.region_peers
-            .get_mut(&region_id)
-            .unwrap()
-            .mut_store()
-            .region = origin_region.clone();
+        {
+            let peer = self.region_peers.get_mut(&region_id).unwrap();
+            peer.mut_store().region = origin_region;
+            peer.post_split(metrics);
+        }
         let new_region_id = new_region.get_id();
         if let Some(peer) = self.region_peers.get(&new_region_id) {
             // If the store received a raft msg with the new region raft group
@@ -1898,7 +1919,17 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             .insert(enc_end_key(&region), region.get_id());
     }
 
-    fn on_ready_result(&mut self, region_id: u64, merged: bool, exec_results: Vec<ExecResult>) {
+    fn on_ready_result(
+        &mut self,
+        region_id: u64,
+        merged: bool,
+        exec_results: Vec<ExecResult>,
+        metrics: &ApplyMetrics,
+    ) {
+        self.store_stat.lock_cf_bytes_written += metrics.lock_cf_written_bytes;
+        self.store_stat.engine_total_bytes_written += metrics.written_bytes;
+        self.store_stat.engine_total_keys_written += metrics.written_keys;
+
         // handle executing committed log results
         for result in exec_results {
             match result {
@@ -1910,7 +1941,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                     left,
                     right,
                     right_derive,
-                } => self.on_ready_split_region(region_id, left, right, right_derive),
+                } => self.on_ready_split_region(region_id, left, right, right_derive, metrics),
                 ExecResult::PrepareMerge { region, state } => {
                     self.on_ready_prepare_merge(region, state, merged);
                 }


### PR DESCRIPTION
It's part of #3045 . We should apply all changes before advancing apply.