### PR TITLE
Make CI builds faster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,117 +1,71 @@
 version: 2
 jobs:
-  # Since RocksDB and TiKV require more than 4GB RAM to compile so we can't use docker.
-  test:
+  docker:
+    # Seems Circle can't build us on a container due to RAM.
     machine: true
-    environment:
-      # CircleCI does not support env variable interpolation, set those later
-      # Variables used by cargo
-      RUST_TEST_THREADS: "1"
-      RUST_BACKTRACE: "1"
-      RUSTFLAGS: "-Dwarnings"
-      FAIL_POINT: "1"
     steps:
-      - run:
-          name: Defining runtime determined environment variables
-          # Define variables that need interpolation
-          # As CircleCI's each `run` declaration starts a new shell, we need to persist them to $BASH_ENV
-          command: |
-            echo 'export PATH=$HOME/.local/cmake/bin:$HOME/.cargo/bin:$HOME/.local/bin:$PATH' >> $BASH_ENV
-            echo 'export LD_RUN_PATH=$LD_RUN_PATH:$HOME/.local/lib' >> $BASH_ENV
-            echo 'export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$HOME/.local/lib' >> $BASH_ENV
-            echo 'export LDFLAGS=-L$HOME/.local/lib' >> $BASH_ENV
-            echo 'export CPPFLAGS=-I$HOME/.local/include' >> $BASH_ENV
-            echo 'export CXXFLAGS=-I$HOME/.local/include' >> $BASH_ENV
-            echo 'export LOCAL_PREFIX=$HOME/.local' >> $BASH_ENV
       - checkout
       - restore_cache:
-          name: Restoring ~/.cargo Cache
+          name: Restoring ~/docker Cache
           keys:
-            - cargo-{{checksum "RUST_VERSION" }}-{{ checksum "Cargo.lock" }}
+            - docker-{{ checksum "RUST_VERSION" }}-{{ checksum "Cargo.lock" }}
       - run:
-          name: Installing build dependencies
+          name: Rebuild docker image if necessary
+          no_output_timeout: 2400s
           command: |
-            sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y;
-            sudo apt-get update -y;
-            sudo apt-get install -y g++-4.8 libdw-dev libelf-dev elfutils binutils-dev curl git python golang
-      - run:
-          name: Installing Rust toolchain
-          command: |
-            RUST_VERSION=`tail -n 1 RUST_VERSION`
-            if [[ ! -e $HOME/.cargo ]]; then
-              curl https://sh.rustup.rs -sSf |
-                sh -s -- --no-modify-path --default-toolchain ${RUST_VERSION} -y;
-              rustup default ${RUST_VERSION};
-            else
-              rustup default ${RUST_VERSION};
-            fi
-      # Unfortunately the images CircleCI uses don't pull CMake 3.10 via apt which is what we need.
-      - run:
-          name: Installing CMake
-          command: |
-            if [[ ! -f $HOME/.local/cmake/bin/cmake ]]; then
-              curl https://cmake.org/files/v3.10/cmake-3.10.0-Linux-x86_64.tar.gz -sSf | tar xzf -;
-              rm -rf $HOME/.local/cmake
-              mv cmake-3.10.0-Linux-x86_64 $HOME/.local/cmake
-            fi
-      - run:
-          name: Fetching crates
-          command: cargo fetch
+            cd ~/project
+            # If one of these files changed we need to rebuild the image. Otherwise we can reuse.
+            git diff-index --name-only "HEAD^" | grep -e ci-build/Dockerfile -e Cargo.lock -e RUST_VERSION || [ ! -f  ~/docker/ci.tar.gz ] || exit 0
+
+            docker build -t pingcap/tikv-ci --force-rm --no-cache -f ci-build/Dockerfile .
+            mkdir -p ~/docker
+            docker save pingcap/tikv-ci > ~/docker/ci.tar.gz
       - save_cache:
-          name: Saving ~/.cargo Cache
-          # This should change each dependency update, or Rust version update.
-          key: cargo-{{ checksum "RUST_VERSION" }}-{{ checksum "Cargo.lock" }}
+          name: Saving ~/docker Cache
+          key: docker-{{ checksum "RUST_VERSION" }}-{{ checksum "Cargo.lock" }}
           paths:
-            - ~/.cargo
+            - ~/docker
+  test:
+    machine: true
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restoring ~/docker Cache
+          keys:
+            - docker-{{ checksum "RUST_VERSION" }}-{{ checksum "Cargo.lock" }}
+      - run:
+          name: Loading docker image
+          command: zcat /home/travis/docker/ci.tar.gz | docker load
       - run:
           name: Testing
-          command: make trace_test
-          no_output_timeout: 1800s
-  # We can use the docker executor for format runs since we don't need so much memory.
+          command: |
+            cd ~/project
+            docker run -ti --rm -v `pwd`:`/build pingcap/tikv-ci bash -c "make trace_test"
   format:
-    docker:
-      - image: ubuntu:latest
+    machine: true
     steps:
-      - run:
-          name: Defining runtime determined environment variables
-          # Define variables that need interpolation
-          # As CircleCI's each `run` declaration starts a new shell, we need to persist them to $BASH_ENV
-          command: |
-            echo 'export PATH=$HOME/.cargo/bin:$HOME/.local/bin:$PATH' >> $BASH_ENV
-            echo 'export LD_RUN_PATH=$LD_RUN_PATH:$HOME/.local/lib' >> $BASH_ENV
-            echo 'export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$HOME/.local/lib' >> $BASH_ENV
-            echo 'export LDFLAGS=-L$HOME/.local/lib' >> $BASH_ENV
-            echo 'export CPPFLAGS=-I$HOME/.local/include' >> $BASH_ENV
-            echo 'export CXXFLAGS=-I$HOME/.local/include' >> $BASH_ENV
-            echo 'export LOCAL_PREFIX=$HOME/.local' >> $BASH_ENV
       - checkout
+      - restore_cache:
+          name: Restoring ~/docker Cache
+          keys:
+            - docker-{{ checksum "RUST_VERSION" }}-{{ checksum "Cargo.lock" }}
       - run:
-          name: Installing build dependencies
+          name: Loading docker image
+          command: zcat /home/travis/docker/ci.tar.gz | docker load
+      - run:
+          name: Testing
           command: |
-            apt-get update -y;
-            apt-get install -y curl make git
-      - run:
-          name: Installing Rust toolchain
-          command: |
-            RUST_VERSION=`tail -n 1 RUST_VERSION`
-            if [[ ! -e $HOME/.cargo ]]; then
-              curl https://sh.rustup.rs -sSf |
-                sh -s -- --no-modify-path --default-toolchain ${RUST_VERSION} -y;
-              rustup default ${RUST_VERSION};
-            else
-              rustup default ${RUST_VERSION};
-            fi
-      - run:
-          name: Installing rustfmt
-          command: |
-            make -f ci-build/Makefile prepare-rustfmt
-      - run:
-          name: Checking Format
-          command: make format && git diff-index --quiet HEAD -- || (git diff; echo please make format and run tests before creating a PR!; exit 1)
+            cd ~/project
+            docker run -ti --rm -v `pwd`:`/build pingcap/tikv-ci bash -c "make format && git diff-index --quiet HEAD -- || (git diff; echo please make format and run tests before creating a PR!; exit 1)"
 
 workflows:
   version: 2
   ci-test:
       jobs:
-        - format
-        - test
+        - docker
+        - format:
+            requires:
+              - docker
+        - test:
+            requires:
+              - docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,6 @@ jobs:
           name: Restoring ~/.cargo Cache
           keys:
             - cargo-{{checksum "RUST_VERSION" }}-{{ checksum "Cargo.lock" }}
-      - restore_cache:
-          name: Restoring ./target Cache
-          keys:
-            - target-{{ checksum "RUST_VERSION" }}-{{ checksum "Cargo.lock" }}
       - run:
           name: Installing build dependencies
           command: |
@@ -61,23 +57,16 @@ jobs:
       - run:
           name: Fetching crates
           command: cargo fetch
-      - run:
-          name: Testing
-          command: make trace_test
-          no_output_timeout: 1800s
-      # Unfortunately we can't report success early here, but it would save time.
       - save_cache:
           name: Saving ~/.cargo Cache
           # This should change each dependency update, or Rust version update.
           key: cargo-{{ checksum "RUST_VERSION" }}-{{ checksum "Cargo.lock" }}
           paths:
             - ~/.cargo
-      - save_cache:
-          name: Saving ~/.target Cache
-          # This should change each Rust version.
-          key: target-{{ checksum "RUST_VERSION" }}-{{ checksum "Cargo.lock" }}
-          paths:
-            - .target
+      - run:
+          name: Testing
+          command: make trace_test
+          no_output_timeout: 1800s
   # We can use the docker executor for format runs since we don't need so much memory.
   format:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 jobs:
+  # Since RocksDB and TiKV require more than 4GB RAM to compile so we can't use docker.
   test:
-    working_directory: ~/tikv-ci
     machine: true
     environment:
       # CircleCI does not support env variable interpolation, set those later
@@ -12,7 +12,7 @@ jobs:
       FAIL_POINT: "1"
     steps:
       - run:
-          name: Updating PATH and Define Environment Variable at Runtime
+          name: Defining runtime determined environment variables
           # Define variables that need interpolation
           # As CircleCI's each `run` declaration starts a new shell, we need to persist them to $BASH_ENV
           command: |
@@ -24,26 +24,18 @@ jobs:
             echo 'export CXXFLAGS=-I$HOME/.local/include' >> $BASH_ENV
             echo 'export LOCAL_PREFIX=$HOME/.local' >> $BASH_ENV
       - checkout
-      - run: 
-          name: Installing Build Dependencies
-          command: |
-            sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y;
-            sudo apt-get update -y;
-            sudo apt-get install -y g++-4.8 curl libdw-dev libelf-dev elfutils binutils-dev
-      - restore_cache:
-          name: Restoring ~/.local Cache
-          keys: 
-            - v1-local-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
-            - v1-local-{{ .Branch }}
-            - v1-local
       - restore_cache:
           name: Restoring ~/.cargo Cache
           keys:
-            - v1-cargo-{{ .Branch }}-{{ checksum "Cargo.lock" }}
-            - v1-cargo-{{ .Branch }}
-            - v1-cargo
-      - run: 
-          name: Setting up Rust and the rest of the Build Environment
+            - cargo-{{ checksum "Cargo.lock" }}
+      - run:
+          name: Installing build dependencies
+          command: |
+            sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y;
+            sudo apt-get update -y;
+            sudo apt-get install -y g++-4.8 libdw-dev libelf-dev elfutils binutils-dev curl git python golang
+      - run:
+          name: Installing Rust toolchain
           command: |
             RUST_VERSION=`tail -n 1 RUST_VERSION`
             if [[ ! -e $HOME/.cargo ]]; then
@@ -53,51 +45,72 @@ jobs:
             else
               rustup default ${RUST_VERSION};
             fi
-
-            make -f ci-build/Makefile prepare-rustfmt
-
+      # Unfortunately the images CircleCI uses don't pull CMake 3.10 via apt which is what we need.
+      - run:
+          name: Installing CMake
+          command: |
             if [[ ! -f $HOME/.local/cmake/bin/cmake ]]; then
               curl https://cmake.org/files/v3.10/cmake-3.10.0-Linux-x86_64.tar.gz -sSf | tar xzf -;
               rm -rf $HOME/.local/cmake
               mv cmake-3.10.0-Linux-x86_64 $HOME/.local/cmake
             fi
-      # check format first
-      -  run:
-          name: Checking Format
-          command: make format && git diff-index --quiet HEAD -- || (git diff; echo please make format and run tests before creating a PR!; exit 1)
-      - restore_cache:
-          name: Restoring ./target Cache  
-          keys:
-            - v1-target-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
-            - v1-target-{{ .Branch }}
-            - v1-target
-      - run: 
-          name: Building
-          command: env SKIP_TESTS=true make trace_test
-          no_output_timeout: 1800s
-      - save_cache:
-          name: Saving ./target Cache
-          key: v1-target-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
-          paths:
-            - target
-      - save_cache:
-          name: Saving ~/.cargo Cache
-          key: v1-cargo-{{ .Branch }}-{{ checksum "Cargo.lock" }}
-          paths:
-            - ~/.cargo
-      - save_cache:
-          name: Saving ~/.local Cache
-          key: v1-local-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
-          paths:
-            - ~/.local
-            - ~/.rustup
+      - run:
+          name: Fetching crates
+          command: cargo fetch
       - run:
           name: Testing
           command: make trace_test
           no_output_timeout: 1800s
-              
+      - save_cache:
+          name: Saving ~/.cargo Cache
+          key: cargo-{{ checksum "Cargo.lock" }}
+          paths:
+            - ~/.cargo
+  # We can use the docker executor for format runs since we don't need so much memory.
+  format:
+    docker:
+      - image: ubuntu:latest
+    steps:
+      - run:
+          name: Defining runtime determined environment variables
+          # Define variables that need interpolation
+          # As CircleCI's each `run` declaration starts a new shell, we need to persist them to $BASH_ENV
+          command: |
+            echo 'export PATH=$HOME/.cargo/bin:$HOME/.local/bin:$PATH' >> $BASH_ENV
+            echo 'export LD_RUN_PATH=$LD_RUN_PATH:$HOME/.local/lib' >> $BASH_ENV
+            echo 'export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$HOME/.local/lib' >> $BASH_ENV
+            echo 'export LDFLAGS=-L$HOME/.local/lib' >> $BASH_ENV
+            echo 'export CPPFLAGS=-I$HOME/.local/include' >> $BASH_ENV
+            echo 'export CXXFLAGS=-I$HOME/.local/include' >> $BASH_ENV
+            echo 'export LOCAL_PREFIX=$HOME/.local' >> $BASH_ENV
+      - checkout
+      - run:
+          name: Installing build dependencies
+          command: |
+            apt-get update -y;
+            apt-get install -y curl make git
+      - run:
+          name: Installing Rust toolchain
+          command: |
+            RUST_VERSION=`tail -n 1 RUST_VERSION`
+            if [[ ! -e $HOME/.cargo ]]; then
+              curl https://sh.rustup.rs -sSf |
+                sh -s -- --no-modify-path --default-toolchain ${RUST_VERSION} -y;
+              rustup default ${RUST_VERSION};
+            else
+              rustup default ${RUST_VERSION};
+            fi
+      - run:
+          name: Installing rustfmt
+          command: |
+            make -f ci-build/Makefile prepare-rustfmt
+      - run:
+          name: Checking Format
+          command: make format && git diff-index --quiet HEAD -- || (git diff; echo please make format and run tests before creating a PR!; exit 1)
+
 workflows:
   version: 2
   ci-test:
       jobs:
+        - format
         - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,21 +8,21 @@ jobs:
       - restore_cache:
           name: Restoring ~/docker Cache
           keys:
-            - docker-{{ checksum "RUST_VERSION" }}-{{ checksum "Cargo.lock" }}
+            - docker-{{ checksum "RUST_VERSION" }}{{ checksum "Cargo.lock" }}{{ checksum ".circleci/config.yml" }}
       - run:
           name: Rebuild docker image if necessary
           no_output_timeout: 2400s
           command: |
             cd ~/project
             # If one of these files changed we need to rebuild the image. Otherwise we can reuse.
-            git diff-index --name-only "HEAD^" | grep -e ci-build/Dockerfile -e Cargo.lock -e RUST_VERSION || [ ! -f  ~/docker/ci.tar.gz ] || exit 0
+            git diff-index --name-only "HEAD^" | grep -e ci-build/Dockerfile -e Cargo.lock -e RUST_VERSION || [ ! -f  ~/docker/ci ] || exit 0
 
             docker build -t pingcap/tikv-ci --force-rm --no-cache -f ci-build/Dockerfile .
             mkdir -p ~/docker
-            docker save pingcap/tikv-ci > ~/docker/ci.tar.gz
+            docker save pingcap/tikv-ci > ~/docker/ci
       - save_cache:
           name: Saving ~/docker Cache
-          key: docker-{{ checksum "RUST_VERSION" }}-{{ checksum "Cargo.lock" }}
+          key: docker-{{ checksum "RUST_VERSION" }}{{ checksum "Cargo.lock" }}{{ checksum ".circleci/config.yml" }}
           paths:
             - ~/docker
   test:
@@ -32,15 +32,16 @@ jobs:
       - restore_cache:
           name: Restoring ~/docker Cache
           keys:
-            - docker-{{ checksum "RUST_VERSION" }}-{{ checksum "Cargo.lock" }}
+            - docker-{{ checksum "RUST_VERSION" }}{{ checksum "Cargo.lock" }}{{ checksum ".circleci/config.yml" }}
       - run:
           name: Loading docker image
-          command: zcat /home/travis/docker/ci.tar.gz | docker load
+          command: |
+            docker load -i ~/docker/ci
       - run:
           name: Testing
           command: |
             cd ~/project
-            docker run -ti --rm -v `pwd`:`/build pingcap/tikv-ci bash -c "make trace_test"
+            docker run -ti --rm -v $HOME/project:/build pingcap/tikv-ci bash -c "make trace_test"
   format:
     machine: true
     steps:
@@ -48,15 +49,16 @@ jobs:
       - restore_cache:
           name: Restoring ~/docker Cache
           keys:
-            - docker-{{ checksum "RUST_VERSION" }}-{{ checksum "Cargo.lock" }}
+            - docker-{{ checksum "RUST_VERSION" }}{{ checksum "Cargo.lock" }}{{ checksum ".circleci/config.yml" }}
       - run:
           name: Loading docker image
-          command: zcat /home/travis/docker/ci.tar.gz | docker load
+          command: |
+            docker load -i ~/docker/ci
       - run:
           name: Testing
           command: |
             cd ~/project
-            docker run -ti --rm -v `pwd`:`/build pingcap/tikv-ci bash -c "make format && git diff-index --quiet HEAD -- || (git diff; echo please make format and run tests before creating a PR!; exit 1)"
+            docker run -ti --rm -v $HOME/project:/build pingcap/tikv-ci bash -c "make format && git diff-index --quiet HEAD -- || (git diff; echo please make format and run tests before creating a PR!; exit 1)"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,11 @@ jobs:
       - restore_cache:
           name: Restoring ~/.cargo Cache
           keys:
-            - cargo-{{ checksum "Cargo.lock" }}
+            - cargo-{{checksum "RUST_VERSION" }}-{{ checksum "Cargo.lock" }}
+      - restore_cache:
+          name: Restoring ./target Cache
+          keys:
+            - target-{{ checksum "RUST_VERSION" }}-{{ checksum "Cargo.lock" }}
       - run:
           name: Installing build dependencies
           command: |
@@ -61,11 +65,19 @@ jobs:
           name: Testing
           command: make trace_test
           no_output_timeout: 1800s
+      # Unfortunately we can't report success early here, but it would save time.
       - save_cache:
           name: Saving ~/.cargo Cache
-          key: cargo-{{ checksum "Cargo.lock" }}
+          # This should change each dependency update, or Rust version update.
+          key: cargo-{{ checksum "RUST_VERSION" }}-{{ checksum "Cargo.lock" }}
           paths:
             - ~/.cargo
+      - save_cache:
+          name: Saving ~/.target Cache
+          # This should change each Rust version.
+          key: target-{{ checksum "RUST_VERSION" }}-{{ checksum "Cargo.lock" }}
+          paths:
+            - .target
   # We can use the docker executor for format runs since we don't need so much memory.
   format:
     docker:

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,4 @@
 .git
+target
+fuzz/artifacts
+fuzz/target

--- a/ci-build/Dockerfile
+++ b/ci-build/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:latest
+ENV PATH $PATH:/root/.cargo/bin
+
+# Install all dependencies
+RUN apt-get -qq update -y
+RUN apt-get install -y -qq curl clang git make cmake golang python
+
+# Cache source, we limit this heavily to avoid loading a large context.
+RUN mkdir -p build
+COPY RUST_VERSION /build/RUST_VERSION
+COPY Cargo.lock /build/Cargo.lock
+COPY Cargo.toml /build/Cargo.toml
+COPY src /build/src
+COPY fuzz/Cargo.toml /build/fuzz/Cargo.toml
+
+
+WORKDIR /build
+
+# Pull in Rust toolchain
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain `tail -n 1 RUST_VERSION` -y
+
+# Ensure we have rustfmt
+RUN rustup component add rustfmt-preview
+
+# Prefetch packages
+RUN cargo fetch
+
+# Clean up
+RUN rm -rf /build
+
+# Mark a volume
+VOLUME /build


### PR DESCRIPTION
This PR explores how to make the Circle CI builds faster.

## Diagnosis

This is not necessarily a new problem, and does not seem to be caused by #2993:

* Circle 1.0 https://circleci.com/gh/pingcap/tikv/10072
* Circle 2.0 https://circleci.com/gh/pingcap/tikv/10119

Currently caching is a massive portion of the build, taking around 21 minutes (nearly half the build time):

![look](https://user-images.githubusercontent.com/130903/40072687-7e9f2cd6-5829-11e8-9cf1-2b4e831827f1.jpg)

## Implementation

* Follow caching configuration from https://docs.travis-ci.com/user/caching/#Rust-Cargo-cache
* Split format and test into different builds.
  * Format only requires the Rust toolchain and can be done in a matter of a couple minutes.
  * Testing does not require rusftmt.
  * Splitting off `clippy` and `bench` might help as well but since they need to do the build compile of dependencies I suspect it might be even longer since it would add queuing issues.

## Failed Experiments

* Tried `sccache` however it didn't yield tangible build tiime improvements.

```
    Finished dev [unoptimized + debuginfo] target(s) in 409.90 secs
RUSTC_WRAPPER="sccache" cargo build  1642.19s user 151.41s system 437% cpu 6:50.27 total
# ...
    Finished dev [unoptimized + debuginfo] target(s) in 434.92 secs
RUSTC_WRAPPER="sccache" cargo build  1699.46s user 158.76s system 426% cpu 7:15.30 tota
# 
    Finished dev [unoptimized + debuginfo] target(s) in 395.50 secs
RUSTC_WRAPPER="sccache" cargo build  1685.84s user 159.83s system 466% cpu 6:35.94 tota
```

* Docker builds aren't working since we're using the default machine size (https://circleci.com/docs/2.0/configuration-reference/#resource_class) which only has 4GB of RAM. RocksDB gets killed.

```
[23102.855272] [ pid ]   uid  tgid total_vm      rss nr_ptes nr_pmds swapents oom_score_adj name
[23102.855360] [23609]     0 23609     7678     5173      20       5        0         -1000 circleci
[23102.855364] [24107] 165536 24107     1157       17       8       3        0             0 sh
[23102.855367] [24205] 165536 24205    15439    11691      34       5        0             0 picard
[23102.855411] [74133] 165536 74133   150931     9060     265       4        0             0 cargo
[23102.855413] [80263] 165536 80263     4627      114      16       3        0             0 bash
[23102.855419] [93708] 165536 93708     4549       86      13       3        0             0 build-script-bu
[23102.855459] [97626] 165536 97626    43647      376      69       3        0             0 cmake
[23102.855461] [97627] 165536 97627     1965      322      11       3        0             0 make
[23102.855464] [97629] 165536 97629     1839      169       9       3        0             0 make
[23102.855466] [97632] 165536 97632     1839      169       9       3        0             0 make
[23102.855469] [97690] 165536 97690     2515      865      10       3        0             0 make
[23102.855471] [97783] 165536 97783     1411       18       8       3        0             0 c++
[23102.855473] [97784] 165536 97784     1411       17       8       3        0             0 c++
[23102.855476] [97786] 165536 97786     1411       17       8       3        0             0 c++
[23102.855478] [97787] 165536 97787     1411       18       8       3        0             0 c++
[23102.855480] [97840] 165536 97840    83909    71535     166       3        0             0 cc1plus
[23102.855482] [97841] 165536 97841     1411       18       7       3        0             0 c++
[23102.855484] [97846] 165536 97846    86771    74115     172       3        0             0 cc1plus
[23102.855487] [97847] 165536 97847     1411       18       8       3        0             0 c++
[23102.855489] [97848] 165536 97848     1411       18       8       3        0             0 c++
[23102.855491] [97854] 165536 97854     1411       18       9       3        0             0 c++
[23102.855493] [97857] 165536 97857    86774    74107     172       4        0             0 cc1plus
[23102.855495] [97858] 165536 97858     1411       17       8       3        0             0 c++
[23102.855497] [97876] 165536 97876    86768    74097     172       4        0             0 cc1plus
[23102.855499] [97887] 165536 97887     1411       18       8       3        0             0 c++
[23102.855502] [97888] 165536 97888    86229    73519     170       4        0             0 cc1plus
[23102.855504] [97892] 165536 97892     1411       18       9       3        0             0 c++
[23102.855506] [97893] 165536 97893    84909    72621     168       3        0             0 cc1plus
[23102.855508] [97896] 165536 97896    86778    74176     171       3        0             0 cc1plus
[23102.855511] [97923] 165536 97923     1411       18       8       3        0             0 c++
[23102.855514] [97926] 165536 97926    86752    74130     172       3        0             0 cc1plus
[23102.855516] [97927] 165536 97927    83958    71273     167       3        0             0 cc1plus
[23102.855518] [97928] 165536 97928    82282    69495     163       3        0             0 cc1plus
[23102.855520] [97929] 165536 97929    86808    74114     171       3        0             0 cc1plus
[23102.855522] [97931] 165536 97931    86776    74135     171       3        0             0 cc1plus
[23102.855524] [98759] 165536 98759     1411       17       8       3        0             0 c++
[23102.855526] [98760] 165536 98760    84941    72276     168       3        0             0 cc1plus
[23102.855529] [98764] 165536 98764     1411       18       8       3        0             0 c++
[23102.855531] [98765] 165536 98765    86210    73304     169       3        0             0 cc1plus
[23102.855556] [102764] 165536 102764     9158      116      22       3        0             0 top
[23102.855567] Memory cgroup out of memory: Kill process 97896 (cc1plus) score 70 or sacrifice child
[23102.863076] Killed process 97896 (cc1plus) total-vm:347112kB, anon-rss:296704kB, file-rss:0kB
```

