### PR TITLE
Snapshot can only remove tmp files created by itself.

### DIFF
--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -670,6 +670,7 @@ impl Snap {
             f.flush()?;
         }
         fs::rename(&self.meta_file.tmp_path, &self.meta_file.path)?;
+        self.hold_tmp_files = false;
         Ok(())
     }
 
@@ -952,6 +953,7 @@ impl Snapshot for Snap {
             meta_file.sync_all()?;
         }
         fs::rename(&self.meta_file.tmp_path, &self.meta_file.path)?;
+        self.hold_tmp_files = false;
         Ok(())
     }
 

--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -320,6 +320,7 @@ pub struct Snap {
     meta_file: MetaFile,
     size_track: Arc<AtomicU64>,
     limiter: Option<Arc<IOLimiter>>,
+    hold_tmp_files: bool,
 }
 
 impl Snap {
@@ -377,6 +378,7 @@ impl Snap {
             meta_file,
             size_track,
             limiter,
+            hold_tmp_files: false,
         };
 
         // load snapshot meta if meta_file exists
@@ -447,10 +449,17 @@ impl Snap {
     ) -> RaftStoreResult<Snap> {
         let mut s = Snap::new(dir, key, size_track, false, false, deleter, limiter)?;
         s.set_snapshot_meta(snapshot_meta)?;
-
         if s.exists() {
             return Ok(s);
         }
+
+        let f = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&s.meta_file.tmp_path)?;
+        s.meta_file.file = Some(f);
+        s.hold_tmp_files = true;
+
         for cf_file in &mut s.cf_files {
             if cf_file.size == 0 {
                 continue;
@@ -462,11 +471,6 @@ impl Snap {
             cf_file.file = Some(f);
             cf_file.write_digest = Some(Digest::new(crc32::IEEE));
         }
-        let f = OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&s.meta_file.tmp_path)?;
-        s.meta_file.file = Some(f);
         Ok(s)
     }
 
@@ -484,12 +488,18 @@ impl Snap {
         if self.exists() {
             return Ok(());
         }
+        let file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&self.meta_file.tmp_path)?;
+        self.meta_file.file = Some(file);
+        self.hold_tmp_files = true;
+
         for cf_file in &mut self.cf_files {
             if plain_file_used(cf_file.cf) {
                 let f = OpenOptions::new()
                     .write(true)
-                    .create(true)
-                    .truncate(true)
+                    .create_new(true)
                     .open(&cf_file.tmp_path)?;
                 cf_file.file = Some(f);
             } else {
@@ -506,11 +516,6 @@ impl Snap {
                 cf_file.sst_writer = Some(writer);
             }
         }
-        let file = OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&self.meta_file.tmp_path)?;
-        self.meta_file.file = Some(file);
         Ok(())
     }
 
@@ -871,14 +876,18 @@ impl Snapshot for Snap {
     fn delete(&self) {
         debug!("deleting {}", self.path());
         for cf_file in &self.cf_files {
-            delete_file_if_exist(&cf_file.tmp_path);
             delete_file_if_exist(&cf_file.clone_path);
+            if self.hold_tmp_files {
+                delete_file_if_exist(&cf_file.tmp_path);
+            }
             if delete_file_if_exist(&cf_file.path) {
                 self.size_track.fetch_sub(cf_file.size, Ordering::SeqCst);
             }
         }
-        delete_file_if_exist(&self.meta_file.tmp_path);
         delete_file_if_exist(&self.meta_file.path);
+        if self.hold_tmp_files {
+            delete_file_if_exist(&self.meta_file.tmp_path);
+        }
     }
 
     fn meta(&self) -> io::Result<Metadata> {


### PR DESCRIPTION
When drop snapshot it shouldn't delete tmp files created by others.