### PR TITLE
service/kv: adjust WriteConflict error in KeyError

### DIFF
--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1265,8 +1265,22 @@ fn extract_key_error(err: &storage::Error) -> KeyError {
             lock_info.set_lock_ttl(ttl);
             key_error.set_locked(lock_info);
         }
-        storage::Error::Txn(TxnError::Mvcc(MvccError::WriteConflict { .. }))
-        | storage::Error::Txn(TxnError::Mvcc(MvccError::TxnLockNotFound { .. })) => {
+        // failed in prewrite
+        storage::Error::Txn(TxnError::Mvcc(MvccError::WriteConflict {
+            start_ts,
+            conflict_ts,
+            ref key,
+            ref primary,
+        })) => {
+            let mut write_conflict = WriteConflict::new();
+            write_conflict.set_start_ts(start_ts);
+            write_conflict.set_conflict_ts(conflict_ts);
+            write_conflict.set_key(key.to_owned());
+            write_conflict.set_primary(primary.to_owned());
+            key_error.set_conflict(write_conflict);
+        }
+        // failed in commit
+        storage::Error::Txn(TxnError::Mvcc(MvccError::TxnLockNotFound { .. })) => {
             warn!("txn conflicts: {:?}", err);
             key_error.set_retryable(format!("{:?}", err));
         }
@@ -1365,4 +1379,37 @@ fn extract_key_errors(res: storage::Result<Vec<storage::Result<()>>>) -> Vec<Key
             .collect(),
         Err(e) => vec![extract_key_error(&e)],
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use storage;
+    use storage::mvcc::Error as MvccError;
+    use storage::txn::Error as TxnError;
+
+    #[test]
+    fn test_extract_key_error_write_conflict() {
+        let start_ts = 110;
+        let conflict_ts = 108;
+        let key = b"key".to_vec();
+        let primary = b"primary".to_vec();
+        let case = storage::Error::from(TxnError::from(MvccError::WriteConflict {
+            start_ts,
+            conflict_ts,
+            key: key.clone(),
+            primary: primary.clone(),
+        }));
+        let mut expect = KeyError::new();
+        let mut write_conflict = WriteConflict::new();
+        write_conflict.set_start_ts(start_ts);
+        write_conflict.set_conflict_ts(conflict_ts);
+        write_conflict.set_key(key);
+        write_conflict.set_primary(primary);
+        expect.set_conflict(write_conflict);
+
+        let got = extract_key_error(&case);
+        assert_eq!(got, expect);
+    }
+
 }

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -129,7 +129,7 @@ impl MvccTxn {
                     return Err(Error::WriteConflict {
                         start_ts: self.start_ts,
                         conflict_ts: commit,
-                        key: key.encoded().to_owned(),
+                        key: key.raw()?,
                         primary: primary.to_vec(),
                     });
                 }

--- a/tests/storage_cases/test_storage.rs
+++ b/tests/storage_cases/test_storage.rs
@@ -824,6 +824,24 @@ fn test_txn_store_lock_primary() {
     );
 }
 
+#[test]
+fn test_txn_store_write_conflict() {
+    let store = AssertionStorage::default();
+    let key = b"key";
+    let primary = b"key";
+    let start_ts = 5;
+    let conflict_ts = 10;
+    store.put_ok(key, primary, start_ts, conflict_ts);
+    let start_ts2 = 6;
+    store.prewrite_conflict(
+        vec![Mutation::Put((make_key(key), primary.to_vec()))],
+        primary,
+        start_ts2,
+        key,
+        conflict_ts,
+    );
+}
+
 struct Oracle {
     ts: AtomicUsize,
 }


### PR DESCRIPTION
Hi，
     This PR adjust `WriteConflict` error in KeyError, it moves from retryable to conflict field. @disksing @tiancaiamao @breeswish PTAL