### PR TITLE
codec/number: remove trait NumberDecoder

### DIFF
--- a/src/coprocessor/codec/chunk/column.rs
+++ b/src/coprocessor/codec/chunk/column.rs
@@ -17,7 +17,7 @@ use coprocessor::codec::mysql::decimal::DECIMAL_STRUCT_SIZE;
 use coprocessor::codec::mysql::{types, Decimal, DecimalEncoder, Duration, DurationEncoder, Json,
                                 JsonEncoder, Time, TimeEncoder};
 use tipb::expression::FieldType;
-use util::codec::number::{NumberDecoder, NumberEncoder};
+use util::codec::number::{self, NumberEncoder};
 
 #[derive(Default)]
 pub struct Column {
@@ -193,7 +193,7 @@ impl Column {
         let start = idx * self.fixed_len;
         let end = start + self.fixed_len;
         let mut data = &self.data[start..end];
-        data.decode_i64_le()
+        number::decode_i64_le(&mut data)
     }
 
     pub fn append_u64(&mut self, v: u64) -> Result<()> {
@@ -205,7 +205,7 @@ impl Column {
         let start = idx * self.fixed_len;
         let end = start + self.fixed_len;
         let mut data = &self.data[start..end];
-        data.decode_u64_le()
+        number::decode_u64_le(&mut data)
     }
 
     pub fn append_f64(&mut self, v: f64) -> Result<()> {
@@ -217,7 +217,7 @@ impl Column {
         let start = idx * self.fixed_len;
         let end = start + self.fixed_len;
         let mut data = &self.data[start..end];
-        data.decode_f64_le()
+        number::decode_f64_le(&mut data)
     }
 
     fn finished_append_var(&mut self) -> Result<()> {

--- a/src/coprocessor/codec/datum.rs
+++ b/src/coprocessor/codec/datum.rs
@@ -24,9 +24,9 @@ use super::mysql::{self, parse_json_path_expr, Decimal, DecimalEncoder, Duration
                    JsonEncoder, PathExpression, Time, DEFAULT_FSP, MAX_FSP};
 use super::{convert, Error, Result};
 use coprocessor::dag::expr::EvalContext;
-use util::codec::bytes::{BytesDecoder, BytesEncoder, CompactBytesDecoder};
+use util::codec::bytes::{self, BytesEncoder};
 use util::codec::number::NumberDecoder;
-use util::codec::{bytes, number, BytesSlice};
+use util::codec::{number, BytesSlice};
 use util::escape;
 
 pub const NIL_FLAG: u8 = 0;
@@ -767,8 +767,8 @@ pub fn decode_datum(data: &mut BytesSlice) -> Result<Datum> {
         match flag {
             INT_FLAG => number::decode_i64(data).map(Datum::I64),
             UINT_FLAG => number::decode_u64(data).map(Datum::U64),
-            BYTES_FLAG => data.decode_bytes(false).map(Datum::Bytes),
-            COMPACT_BYTES_FLAG => data.decode_compact_bytes().map(Datum::Bytes),
+            BYTES_FLAG => bytes::decode_bytes(data, false).map(Datum::Bytes),
+            COMPACT_BYTES_FLAG => bytes::decode_compact_bytes(data).map(Datum::Bytes),
             NIL_FLAG => Ok(Datum::Null),
             FLOAT_FLAG => number::decode_f64(data).map(Datum::F64),
             DURATION_FLAG => {

--- a/src/coprocessor/codec/datum.rs
+++ b/src/coprocessor/codec/datum.rs
@@ -25,7 +25,6 @@ use super::mysql::{self, parse_json_path_expr, Decimal, DecimalEncoder, Duration
 use super::{convert, Error, Result};
 use coprocessor::dag::expr::EvalContext;
 use util::codec::bytes::{self, BytesEncoder};
-use util::codec::number::NumberDecoder;
 use util::codec::{number, BytesSlice};
 use util::escape;
 
@@ -939,13 +938,13 @@ pub fn split_datum(buf: &[u8], desc: bool) -> Result<(&[u8], &[u8])> {
         VAR_INT_FLAG => {
             let mut v = &buf[1..];
             let l = v.len();
-            v.decode_var_i64()?;
+            number::decode_var_i64(&mut v)?;
             l - v.len()
         }
         VAR_UINT_FLAG => {
             let mut v = &buf[1..];
             let l = v.len();
-            v.decode_var_u64()?;
+            number::decode_var_u64(&mut v)?;
             l - v.len()
         }
         JSON_FLAG => {

--- a/src/coprocessor/codec/table.rs
+++ b/src/coprocessor/codec/table.rs
@@ -24,7 +24,7 @@ use util::escape;
 use super::mysql::{types, Duration, Time};
 use super::{datum, Datum, Result};
 use util::codec::BytesSlice;
-use util::codec::number::{NumberDecoder, NumberEncoder};
+use util::codec::number::{self, NumberEncoder};
 
 // handle or index id
 pub const ID_LEN: usize = 8;
@@ -90,7 +90,7 @@ pub fn decode_table_id(key: &[u8]) -> Result<i64> {
     }
 
     let mut remaining = &key[TABLE_PREFIX.len()..];
-    remaining.decode_i64()
+    number::decode_i64(&mut remaining)
 }
 
 pub fn flatten(data: Datum) -> Result<Datum> {
@@ -151,7 +151,7 @@ pub fn decode_handle(encoded: &[u8]) -> Result<i64> {
     }
 
     let mut remaining = &encoded[TABLE_PREFIX.len()..];
-    remaining.decode_i64()?;
+    number::decode_i64(&mut remaining)?;
 
     if !remaining.starts_with(RECORD_PREFIX_SEP) {
         return Err(invalid_type!(
@@ -161,7 +161,7 @@ pub fn decode_handle(encoded: &[u8]) -> Result<i64> {
     }
 
     remaining = &remaining[RECORD_PREFIX_SEP.len()..];
-    remaining.decode_i64()
+    number::decode_i64(&mut remaining)
 }
 
 /// `truncate_as_row_key` truncate extra part of a tidb key and just keep the row key part.

--- a/src/coprocessor/dag/executor/mod.rs
+++ b/src/coprocessor/dag/executor/mod.rs
@@ -19,7 +19,7 @@ use tipb::expression::{Expr, ExprType};
 use tipb::schema::ColumnInfo;
 
 use storage::SnapshotStore;
-use util::codec::number::NumberDecoder;
+use util::codec::number;
 use util::collections::HashSet;
 
 use coprocessor::codec::datum::{self, Datum};
@@ -65,7 +65,7 @@ impl ExprColumnRefVisitor {
 
     pub fn visit(&mut self, expr: &Expr) -> Result<()> {
         if expr.get_tp() == ExprType::ColumnRef {
-            let offset = box_try!(expr.get_val().decode_i64()) as usize;
+            let offset = box_try!(number::decode_i64(&mut expr.get_val())) as usize;
             if offset >= self.cols_len {
                 return Err(Error::Other(box_err!(
                     "offset {} overflow, should be less than {}",

--- a/src/raftstore/coprocessor/split_observer.rs
+++ b/src/raftstore/coprocessor/split_observer.rs
@@ -13,7 +13,7 @@
 
 use super::{AdminObserver, Coprocessor, ObserverContext, Result as CopResult};
 use coprocessor::codec::table;
-use util::codec::bytes::{encode_bytes, BytesDecoder};
+use util::codec::bytes::{self, encode_bytes};
 
 use kvproto::raft_cmdpb::{AdminCmdType, AdminRequest, SplitRequest};
 use std::result::Result as StdResult;
@@ -31,7 +31,7 @@ impl SplitObserver {
             return Err("split key is expected!".to_owned());
         }
 
-        let mut key = match split.get_split_key().decode_bytes(false) {
+        let mut key = match bytes::decode_bytes(&mut split.get_split_key(), false) {
             Ok(x) => x,
             Err(_) => return Ok(()),
         };

--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -32,7 +32,7 @@ use raftstore::store::Msg;
 use raftstore::store::util::check_key_in_region;
 use storage::{CfName, CF_DEFAULT, CF_LOCK, CF_WRITE};
 use util::HandyRwLock;
-use util::codec::bytes::{BytesEncoder, CompactBytesDecoder};
+use util::codec::bytes::{BytesEncoder, CompactBytesFromFileDecoder};
 use util::collections::{HashMap, HashMapEntry as Entry};
 use util::io_limiter::{IOLimiter, LimitWriter};
 use util::rocksdb::{prepare_sst_for_ingestion, validate_sst_for_ingestion};
@@ -792,7 +792,7 @@ pub fn build_plain_cf_file<E: BytesEncoder>(
     Ok((cf_key_count, cf_size))
 }
 
-fn apply_plain_cf_file<D: CompactBytesDecoder>(
+fn apply_plain_cf_file<D: CompactBytesFromFileDecoder>(
     decoder: &mut D,
     options: &ApplyOptions,
     handle: &CFHandle,

--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -14,7 +14,7 @@
 use std::cmp::Reverse;
 use std::fmt::{self, Display, Formatter};
 use std::fs::{self, Metadata};
-use std::io::{self, ErrorKind, Read, Write};
+use std::io::{self, BufReader, ErrorKind, Read, Write};
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
@@ -970,7 +970,7 @@ impl Snapshot for Snap {
             let cf_handle = box_try!(rocksdb::get_cf_handle(&options.db, cf_file.cf));
             if plain_file_used(cf_file.cf) {
                 let mut file = box_try!(File::open(&cf_file.path));
-                apply_plain_cf_file(&mut file, &options, cf_handle)?;
+                apply_plain_cf_file(&mut BufReader::new(file), &options, cf_handle)?;
             } else {
                 let mut ingest_opt = IngestExternalFileOptions::new();
                 ingest_opt.move_files(true);

--- a/src/storage/mvcc/lock.rs
+++ b/src/storage/mvcc/lock.rs
@@ -15,7 +15,7 @@ use super::super::types::Value;
 use super::{Error, Result};
 use byteorder::ReadBytesExt;
 use storage::{Mutation, SHORT_VALUE_MAX_LEN, SHORT_VALUE_PREFIX};
-use util::codec::bytes::{BytesEncoder, CompactBytesDecoder};
+use util::codec::bytes::{self, BytesEncoder};
 use util::codec::number::{MAX_VAR_U64_LEN, NumberDecoder, NumberEncoder};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -103,7 +103,7 @@ impl Lock {
             return Err(Error::BadFormatLock);
         }
         let lock_type = LockType::from_u8(b.read_u8()?).ok_or(Error::BadFormatLock)?;
-        let primary = b.decode_compact_bytes()?;
+        let primary = bytes::decode_compact_bytes(&mut b)?;
         let ts = b.decode_var_u64()?;
         let ttl =
             if b.is_empty() { 0 } else { b.decode_var_u64()? };

--- a/src/storage/mvcc/lock.rs
+++ b/src/storage/mvcc/lock.rs
@@ -16,7 +16,7 @@ use super::{Error, Result};
 use byteorder::ReadBytesExt;
 use storage::{Mutation, SHORT_VALUE_MAX_LEN, SHORT_VALUE_PREFIX};
 use util::codec::bytes::{self, BytesEncoder};
-use util::codec::number::{MAX_VAR_U64_LEN, NumberDecoder, NumberEncoder};
+use util::codec::number::{self, MAX_VAR_U64_LEN, NumberEncoder};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum LockType {
@@ -104,9 +104,12 @@ impl Lock {
         }
         let lock_type = LockType::from_u8(b.read_u8()?).ok_or(Error::BadFormatLock)?;
         let primary = bytes::decode_compact_bytes(&mut b)?;
-        let ts = b.decode_var_u64()?;
-        let ttl =
-            if b.is_empty() { 0 } else { b.decode_var_u64()? };
+        let ts = number::decode_var_u64(&mut b)?;
+        let ttl = if b.is_empty() {
+            0
+        } else {
+            number::decode_var_u64(&mut b)?
+        };
 
         if b.is_empty() {
             return Ok(Lock::new(lock_type, primary, ts, ttl, None));

--- a/src/storage/mvcc/write.rs
+++ b/src/storage/mvcc/write.rs
@@ -16,7 +16,7 @@ use super::lock::LockType;
 use super::{Error, Result};
 use byteorder::ReadBytesExt;
 use storage::{SHORT_VALUE_MAX_LEN, SHORT_VALUE_PREFIX};
-use util::codec::number::{MAX_VAR_U64_LEN, NumberDecoder, NumberEncoder};
+use util::codec::number::{self, MAX_VAR_U64_LEN, NumberEncoder};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum WriteType {
@@ -93,7 +93,7 @@ impl Write {
             return Err(Error::BadFormatWrite);
         }
         let write_type = WriteType::from_u8(b.read_u8()?).ok_or(Error::BadFormatWrite)?;
-        let start_ts = b.decode_var_u64()?;
+        let start_ts = number::decode_var_u64(&mut b)?;
         if b.is_empty() {
             return Ok(Write::new(write_type, start_ts, None));
         }

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -18,7 +18,7 @@ use std::hash::{Hash, Hasher};
 use std::u64;
 
 use util::codec::bytes;
-use util::codec::number::{self, NumberDecoder, NumberEncoder};
+use util::codec::number::{self, NumberEncoder};
 use util::{codec, escape};
 
 use storage::mvcc::{Lock, Write};
@@ -109,7 +109,7 @@ impl Key {
             Err(codec::Error::KeyLength)
         } else {
             let mut ts = &self.0[len - number::U64_SIZE..];
-            Ok(ts.decode_u64_desc()?)
+            Ok(number::decode_u64_desc(&mut ts)?)
         }
     }
 
@@ -161,7 +161,7 @@ pub fn split_encoded_key_on_ts(key: &[u8]) -> Result<(&[u8], u64), codec::Error>
         let pos = key.len() - number::U64_SIZE;
         let k = &key[..pos];
         let mut ts = &key[pos..];
-        Ok((k, ts.decode_u64_desc()?))
+        Ok((k, number::decode_u64_desc(&mut ts)?))
     }
 }
 

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -17,7 +17,7 @@ use std::fmt::{self, Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::u64;
 
-use util::codec::bytes::BytesDecoder;
+use util::codec::bytes;
 use util::codec::number::{self, NumberDecoder, NumberEncoder};
 use util::{codec, escape};
 
@@ -70,7 +70,7 @@ impl Key {
 
     /// Gets the raw representation of this key.
     pub fn raw(&self) -> Result<Vec<u8>, codec::Error> {
-        self.0.as_slice().decode_bytes(false)
+        bytes::decode_bytes(&mut self.0.as_slice(), false)
     }
 
     /// Creates a key from encoded bytes.

--- a/src/util/codec/bytes.rs
+++ b/src/util/codec/bytes.rs
@@ -13,8 +13,8 @@
 
 use std::io::{Read, Write};
 
-use super::{Error, Result};
-use util::codec::number::{NumberDecoder, NumberEncoder};
+use super::{BytesSlice, Error, Result};
+use util::codec::number::{self, NumberDecoder, NumberEncoder};
 
 const ENC_GROUP_SIZE: usize = 8;
 const ENC_MARKER: u8 = b'\xff';
@@ -102,7 +102,7 @@ fn encode_order_bytes(bs: &[u8], desc: bool) -> Vec<u8> {
 pub fn encoded_compact_len(mut encoded: &[u8]) -> usize {
     let last_encoded = encoded.as_ptr() as usize;
     let total_len = encoded.len();
-    let vn = match encoded.decode_var_i64() {
+    let vn = match number::decode_var_i64(&mut encoded) {
         Ok(vn) => vn as usize,
         Err(e) => {
             debug!("failed to decode bytes' length: {:?}", e);
@@ -112,7 +112,7 @@ pub fn encoded_compact_len(mut encoded: &[u8]) -> usize {
     vn + (encoded.as_ptr() as usize - last_encoded)
 }
 
-pub trait CompactBytesDecoder: NumberDecoder {
+pub trait CompactBytesFromFileDecoder: NumberDecoder {
     /// `decode_compact_bytes` decodes bytes which is encoded by `encode_compact_bytes` before.
     fn decode_compact_bytes(&mut self) -> Result<Vec<u8>> {
         let vn = self.decode_var_i64()? as usize;
@@ -122,7 +122,7 @@ pub trait CompactBytesDecoder: NumberDecoder {
     }
 }
 
-impl<T: Read> CompactBytesDecoder for T {}
+impl<T: Read> CompactBytesFromFileDecoder for T {}
 
 /// Get the first encoded bytes's length in encoded.
 ///
@@ -142,58 +142,56 @@ pub fn encoded_bytes_len(encoded: &[u8], desc: bool) -> usize {
     }
 }
 
-pub trait BytesDecoder: NumberDecoder + CompactBytesDecoder {
-    /// Get the remaining length in bytes of current reader.
-    fn remaining(&self) -> usize;
-
-    fn peak_u8(&self) -> Option<u8>;
-
-    fn decode_bytes(&mut self, desc: bool) -> Result<Vec<u8>> {
-        let mut key = Vec::with_capacity(self.remaining());
-        let mut chunk = [0; ENC_GROUP_SIZE + 1];
-        loop {
-            self.read_exact(&mut chunk)?;
-            let (&marker, bytes) = chunk.split_last().unwrap();
-            let pad_size = if desc {
-                marker as usize
-            } else {
-                (ENC_MARKER - marker) as usize
-            };
-            if pad_size == 0 {
-                key.write_all(bytes).unwrap();
-                continue;
-            }
-            if pad_size > ENC_GROUP_SIZE {
-                return Err(Error::KeyPadding);
-            }
-            let (bytes, padding) = bytes.split_at(ENC_GROUP_SIZE - pad_size);
-            key.write_all(bytes).unwrap();
-            let pad_byte = if desc { !0 } else { 0 };
-            if padding.iter().any(|x| *x != pad_byte) {
-                return Err(Error::KeyPadding);
-            }
-            key.shrink_to_fit();
-            if desc {
-                for k in &mut key {
-                    *k = !*k;
-                }
-            }
-            return Ok(key);
-        }
+/// `decode_compact_bytes` decodes bytes which is encoded by `encode_compact_bytes` before.
+pub fn decode_compact_bytes(data: &mut BytesSlice) -> Result<Vec<u8>> {
+    let vn = number::decode_var_i64(data)? as usize;
+    if data.len() >= vn {
+        let bs = data[0..vn].to_vec();
+        *data = &data[vn..];
+        return Ok(bs);
     }
+    Err(Error::unexpected_eof())
 }
 
-impl<'a> BytesDecoder for &'a [u8] {
-    fn remaining(&self) -> usize {
-        self.len()
-    }
-
-    fn peak_u8(&self) -> Option<u8> {
-        if self.is_empty() {
-            None
+pub fn decode_bytes(data: &mut BytesSlice, desc: bool) -> Result<Vec<u8>> {
+    let mut key = Vec::with_capacity(data.len() / (ENC_GROUP_SIZE + 1) * ENC_GROUP_SIZE);
+    let mut offset = 0;
+    let chunk_len = ENC_GROUP_SIZE + 1;
+    loop {
+        let next_offset = offset + chunk_len;
+        let chunk = if next_offset <= data.len() {
+            &data[offset..next_offset]
         } else {
-            Some(self[0])
+            return Err(Error::unexpected_eof());
+        };
+        offset = next_offset;
+        let (&marker, bytes) = chunk.split_last().unwrap();
+        let pad_size = if desc {
+            marker as usize
+        } else {
+            (ENC_MARKER - marker) as usize
+        };
+        if pad_size == 0 {
+            key.write_all(bytes).unwrap();
+            continue;
         }
+        if pad_size > ENC_GROUP_SIZE {
+            return Err(Error::KeyPadding);
+        }
+        let (bytes, padding) = bytes.split_at(ENC_GROUP_SIZE - pad_size);
+        key.write_all(bytes).unwrap();
+        let pad_byte = if desc { !0 } else { 0 };
+        if padding.iter().any(|x| *x != pad_byte) {
+            return Err(Error::KeyPadding);
+        }
+        key.shrink_to_fit();
+        if desc {
+            for k in &mut key {
+                *k = !*k;
+            }
+        }
+        *data = &data[offset..];
+        return Ok(key);
     }
 }
 
@@ -263,12 +261,12 @@ mod tests {
 
             let asc_offset = asc.as_ptr() as usize;
             let mut asc_input = asc.as_slice();
-            assert_eq!(source, asc_input.decode_bytes(false).unwrap());
+            assert_eq!(source, decode_bytes(&mut asc_input, false).unwrap());
             assert_eq!(asc_input.as_ptr() as usize - asc_offset, asc.len());
 
             let desc_offset = desc.as_ptr() as usize;
             let mut desc_input = desc.as_slice();
-            assert_eq!(source, desc_input.decode_bytes(true).unwrap());
+            assert_eq!(source, decode_bytes(&mut desc_input, true).unwrap());
             assert_eq!(desc_input.as_ptr() as usize - desc_offset, desc.len());
         }
     }
@@ -288,7 +286,7 @@ mod tests {
         ];
 
         for x in invalid_bytes {
-            assert!(x.as_slice().decode_bytes(false).is_err());
+            assert!(decode_bytes(&mut x.as_slice(), false).is_err());
         }
     }
 
@@ -356,6 +354,21 @@ mod tests {
             buf.encode_compact_bytes(s.as_bytes()).unwrap();
             assert!(buf.len() <= max_size);
             let mut input = buf.as_slice();
+            let decoded = decode_compact_bytes(&mut input).unwrap();
+            assert!(input.is_empty());
+            assert_eq!(decoded, s.as_bytes());
+        }
+    }
+
+    #[test]
+    fn test_compact_codec_for_file() {
+        let tests = vec!["", "hello", "世界"];
+        for &s in &tests {
+            let max_size = s.len() + number::MAX_VAR_I64_LEN;
+            let mut buf = Vec::with_capacity(max_size);
+            buf.encode_compact_bytes(s.as_bytes()).unwrap();
+            assert!(buf.len() <= max_size);
+            let mut input = buf.as_slice();
             let decoded = input.decode_compact_bytes().unwrap();
             assert!(input.is_empty());
             assert_eq!(decoded, s.as_bytes());
@@ -374,6 +387,6 @@ mod tests {
     fn bench_decode(b: &mut Bencher) {
         let key = [b'x'; 2000000];
         let encoded = encode_bytes(&key);
-        b.iter(|| encoded.as_slice().decode_bytes(false));
+        b.iter(|| decode_bytes(&mut encoded.as_slice(), false));
     }
 }

--- a/src/util/codec/bytes.rs
+++ b/src/util/codec/bytes.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 use byteorder::ReadBytesExt;
-use std::io::{Read, Write};
+use std::io::{BufRead, Write};
 
 use super::{BytesSlice, Error, Result};
 use util::codec::number::{self, NumberEncoder};
@@ -113,7 +113,7 @@ pub fn encoded_compact_len(mut encoded: &[u8]) -> usize {
     vn + (encoded.as_ptr() as usize - last_encoded)
 }
 
-pub trait CompactBytesFromFileDecoder: Read {
+pub trait CompactBytesFromFileDecoder: BufRead {
     /// `decode_compact_bytes` decodes bytes which is encoded by `encode_compact_bytes` before.
     fn decode_compact_bytes(&mut self) -> Result<Vec<u8>> {
         let mut var_data = Vec::with_capacity(number::MAX_VAR_I64_LEN);
@@ -132,7 +132,7 @@ pub trait CompactBytesFromFileDecoder: Read {
     }
 }
 
-impl<T: Read> CompactBytesFromFileDecoder for T {}
+impl<T: BufRead> CompactBytesFromFileDecoder for T {}
 
 /// Get the first encoded bytes's length in encoded.
 ///

--- a/src/util/codec/bytes.rs
+++ b/src/util/codec/bytes.rs
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use byteorder::ReadBytesExt;
 use std::io::{BufRead, Write};
 
 use super::{BytesSlice, Error, Result};
@@ -116,17 +115,14 @@ pub fn encoded_compact_len(mut encoded: &[u8]) -> usize {
 pub trait CompactBytesFromFileDecoder: BufRead {
     /// `decode_compact_bytes` decodes bytes which is encoded by `encode_compact_bytes` before.
     fn decode_compact_bytes(&mut self) -> Result<Vec<u8>> {
-        let mut var_data = Vec::with_capacity(number::MAX_VAR_I64_LEN);
-        while var_data.len() < number::MAX_VAR_U64_LEN {
-            let b = self.read_u8()?;
-            var_data.push(b);
-            if b < 0x80 {
-                break;
-            }
-        }
-        let vn = number::decode_var_i64(&mut var_data.as_slice())? as usize;
-
-        let mut data = vec![0; vn];
+        let (consume_len, size) = {
+            let mut var_data = self.fill_buf()?;
+            let length = var_data.len();
+            let size = number::decode_var_i64(&mut var_data)? as usize;
+            (length - var_data.len(), size)
+        };
+        self.consume(consume_len);
+        let mut data = vec![0; size];
         self.read_exact(&mut data)?;
         Ok(data)
     }

--- a/src/util/codec/number.rs
+++ b/src/util/codec/number.rs
@@ -11,11 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// FIXME(shirly): remove following later
-#![allow(dead_code)]
-
-use byteorder::{BigEndian, ByteOrder, LittleEndian, ReadBytesExt, WriteBytesExt};
-use std::io::{self, ErrorKind, Read, Write};
+use byteorder::{BigEndian, ByteOrder, LittleEndian, WriteBytesExt};
+use std::io::{self, ErrorKind, Write};
 use std::mem;
 
 use super::{BytesSlice, Error, Result};
@@ -148,91 +145,6 @@ pub trait NumberEncoder: Write {
 }
 
 impl<T: Write> NumberEncoder for T {}
-
-pub trait NumberDecoder: Read {
-    /// `decode_i64` decodes value encoded by `encode_i64` before.
-    fn decode_i64(&mut self) -> Result<i64> {
-        self.decode_u64().map(order_decode_i64)
-    }
-
-    /// `decode_i64_desc` decodes value encoded by `encode_i64_desc` before.
-    fn decode_i64_desc(&mut self) -> Result<i64> {
-        self.decode_u64_desc().map(order_decode_i64)
-    }
-
-    /// `decode_u64` decodes value encoded by `encode_u64` before.
-    fn decode_u64(&mut self) -> Result<u64> {
-        self.read_u64::<BigEndian>().map_err(From::from)
-    }
-
-    /// `decode_u64_desc` decodes value encoded by `encode_u64_desc` before.
-    fn decode_u64_desc(&mut self) -> Result<u64> {
-        let v = self.read_u64::<BigEndian>()?;
-        Ok(!v)
-    }
-
-    /// `decode_var_i64` decodes value encoded by `encode_var_i64` before.
-    fn decode_var_i64(&mut self) -> Result<i64> {
-        let v = self.decode_var_u64()?;
-        let mut vx = v >> 1;
-        if v & 1 != 0 {
-            vx = !vx;
-        }
-        Ok(vx as i64)
-    }
-
-    /// `decode_var_u64` decodes value encoded by `encode_var_u64` before.
-    fn decode_var_u64(&mut self) -> Result<u64> {
-        let (mut x, mut s, mut i) = (0, 0, 0);
-        loop {
-            let b = self.read_u8()?;
-            if b < 0x80 {
-                if i > 9 || i == 9 && b > 1 {
-                    return Err(Error::Io(io::Error::new(
-                        ErrorKind::InvalidData,
-                        "overflow",
-                    )));
-                }
-                return Ok(x | (u64::from(b) << s));
-            }
-            x |= u64::from(b & 0x7f) << s;
-            s += 7;
-            i += 1;
-        }
-    }
-
-    /// `decode_f64` decodes value encoded by `encode_f64` before.
-    fn decode_f64(&mut self) -> Result<f64> {
-        self.decode_u64().map(order_decode_f64)
-    }
-
-    /// `decode_f64_desc` decodes value encoded by `encode_f64_desc` before.
-    fn decode_f64_desc(&mut self) -> Result<f64> {
-        self.decode_u64_desc().map(order_decode_f64)
-    }
-
-    fn decode_u16_le(&mut self) -> Result<u16> {
-        self.read_u16::<LittleEndian>().map_err(From::from)
-    }
-
-    fn decode_u32_le(&mut self) -> Result<u32> {
-        self.read_u32::<LittleEndian>().map_err(From::from)
-    }
-
-    fn decode_f64_le(&mut self) -> Result<f64> {
-        self.read_f64::<LittleEndian>().map_err(From::from)
-    }
-
-    fn decode_i64_le(&mut self) -> Result<i64> {
-        self.read_i64::<LittleEndian>().map_err(From::from)
-    }
-
-    fn decode_u64_le(&mut self) -> Result<u64> {
-        self.read_u64::<LittleEndian>().map_err(From::from)
-    }
-}
-
-impl<T: Read> NumberDecoder for T {}
 
 #[inline]
 fn read_num_bytes<T, F>(size: usize, data: &mut &[u8], f: F) -> Result<T>
@@ -643,7 +555,7 @@ mod test {
         for &v in F64_TESTS {
             let mut buf = vec![];
             buf.encode_f64_le(v).unwrap();
-            let value = buf.as_slice().decode_f64_le().unwrap();
+            let value = decode_f64_le(&mut buf.as_slice()).unwrap();
             assert_eq!(v, value);
         }
     }
@@ -661,7 +573,7 @@ mod test {
             buf.encode_var_u64(v).unwrap();
             assert!(buf.len() <= MAX_VAR_I64_LEN);
             assert_eq!(buf, p_buf);
-            let decoded = buf.as_slice().decode_var_u64().unwrap();
+            let decoded = decode_var_u64(&mut buf.as_slice()).unwrap();
             assert_eq!(v, decoded);
         }
     }
@@ -699,13 +611,16 @@ mod test {
     fn test_var_eof() {
         let mut buf = vec![0x80; 9];
         buf.push(0x2);
-        check_error!(buf.as_slice().decode_var_u64(), ErrorKind::InvalidData);
-        check_error!(buf.as_slice().decode_var_i64(), ErrorKind::InvalidData);
+        check_error!(decode_var_u64(&mut buf.as_slice()), ErrorKind::InvalidData);
+        check_error!(decode_var_i64(&mut buf.as_slice()), ErrorKind::InvalidData);
 
         buf = vec![0x80; 3];
-        check_error!(buf.as_slice().decode_var_u64(), ErrorKind::UnexpectedEof);
+        check_error!(
+            decode_var_u64(&mut buf.as_slice()),
+            ErrorKind::UnexpectedEof
+        );
 
         buf.push(0);
-        assert_eq!(0, buf.as_slice().decode_var_u64().unwrap());
+        assert_eq!(0, decode_var_u64(&mut buf.as_slice()).unwrap());
     }
 }


### PR DESCRIPTION
Hi, 
     This PR removes  the trait `NumberDecoder`.
@hicqu @BusyJay @breeswish PTAL