### PR TITLE
tikv-ctl: add region-properties

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git#64a1dd0094b73e8c02daec4dc52b6609953bde1a"
+source = "git+https://github.com/huachaohuang/kvproto.git?branch=properties#593b93e62b6033697cc75e4bff37634bbcdd2c39"
 dependencies = [
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1258,7 +1258,7 @@ dependencies = [
  "grpcio 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)",
- "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto 0.0.1 (git+https://github.com/huachaohuang/kvproto.git?branch=properties)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1595,7 +1595,7 @@ dependencies = [
 "checksum jemalloc-sys 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)" = "<none>"
+"checksum kvproto 0.0.1 (git+https://github.com/huachaohuang/kvproto.git?branch=properties)" = "<none>"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/huachaohuang/kvproto.git?branch=properties#593b93e62b6033697cc75e4bff37634bbcdd2c39"
+source = "git+https://github.com/huachaohuang/kvproto.git?branch=properties#1617d16e379b16fe1689aa17fe928ed2ca113114"
 dependencies = [
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/huachaohuang/kvproto.git?branch=properties#1617d16e379b16fe1689aa17fe928ed2ca113114"
+source = "git+https://github.com/pingcap/kvproto.git#56889fce9964b5c3ed6353df8041bcfb5fa52378"
 dependencies = [
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1258,7 +1258,7 @@ dependencies = [
  "grpcio 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)",
- "kvproto 0.0.1 (git+https://github.com/huachaohuang/kvproto.git?branch=properties)",
+ "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1595,7 +1595,7 @@ dependencies = [
 "checksum jemalloc-sys 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum kvproto 0.0.1 (git+https://github.com/huachaohuang/kvproto.git?branch=properties)" = "<none>"
+"checksum kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)" = "<none>"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,8 +91,7 @@ git = "https://github.com/pingcap/murmur3.git"
 git = "https://github.com/pingcap/rust-rocksdb.git"
 
 [dependencies.kvproto]
-git = "https://github.com/huachaohuang/kvproto.git"
-branch = "properties"
+git = "https://github.com/pingcap/kvproto.git"
 
 [dependencies.tipb]
 git = "https://github.com/pingcap/tipb.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,8 @@ git = "https://github.com/pingcap/murmur3.git"
 git = "https://github.com/pingcap/rust-rocksdb.git"
 
 [dependencies.kvproto]
-git = "https://github.com/pingcap/kvproto.git"
+git = "https://github.com/huachaohuang/kvproto.git"
+branch = "properties"
 
 [dependencies.tipb]
 git = "https://github.com/pingcap/tipb.git"

--- a/src/bin/tikv-ctl.rs
+++ b/src/bin/tikv-ctl.rs
@@ -670,8 +670,8 @@ impl DebugExecutor for DebugClient {
         req.set_region_id(region_id);
         let resp = self.get_region_properties(&req)
             .unwrap_or_else(|e| perror_and_exit("DebugClient::get_region_properties", e));
-        for (name, value) in resp.get_names().iter().zip(resp.get_values().iter()) {
-            println!("{}: {}", name, value);
+        for prop in resp.get_props() {
+            println!("{}: {}", prop.get_name(), prop.get_value());
         }
     }
 }

--- a/src/bin/tikv-ctl.rs
+++ b/src/bin/tikv-ctl.rs
@@ -514,6 +514,8 @@ trait DebugExecutor {
     fn modify_tikv_config(&self, module: MODULE, config_name: &str, config_value: &str);
 
     fn dump_metrics(&self, tags: Vec<&str>);
+
+    fn dump_region_properties(&self, region_id: u64);
 }
 
 impl DebugExecutor for DebugClient {
@@ -662,6 +664,16 @@ impl DebugExecutor for DebugClient {
             .unwrap_or_else(|e| perror_and_exit("DebugClient::modify_tikv_config", e));
         println!("success");
     }
+
+    fn dump_region_properties(&self, region_id: u64) {
+        let mut req = GetRegionPropertiesRequest::new();
+        req.set_region_id(region_id);
+        let resp = self.get_region_properties(&req)
+            .unwrap_or_else(|e| perror_and_exit("DebugClient::get_region_properties", e));
+        for (name, value) in resp.get_names().iter().zip(resp.get_values().iter()) {
+            println!("{}: {}", name, value);
+        }
+    }
 }
 
 impl DebugExecutor for Debugger {
@@ -768,6 +780,14 @@ impl DebugExecutor for Debugger {
     fn modify_tikv_config(&self, _: MODULE, _: &str, _: &str) {
         eprintln!("only support remote mode");
         process::exit(-1);
+    }
+
+    fn dump_region_properties(&self, region_id: u64) {
+        let props = self.get_region_properties(region_id)
+            .unwrap_or_else(|e| perror_and_exit("Debugger::get_region_properties", e));
+        for (name, value) in props {
+            println!("{}: {}", name, value);
+        }
     }
 }
 
@@ -1290,7 +1310,18 @@ fn main() {
                         .default_value("8")
                         .help("number of threads in one compaction")
                 ),
-    );
+        )
+        .subcommand(
+            SubCommand::with_name("region-properties")
+                .about("show region properties")
+                .arg(
+                    Arg::with_name("region")
+                        .short("r")
+                        .required(true)
+                        .takes_value(true)
+                        .help("the target region id"),
+                ),
+        );
 
     let matches = app.clone().get_matches();
 
@@ -1459,6 +1490,9 @@ fn main() {
     } else if let Some(matches) = matches.subcommand_matches("metrics") {
         let tags = Vec::from_iter(matches.values_of("tag").unwrap());
         debug_executor.dump_metrics(tags)
+    } else if let Some(matches) = matches.subcommand_matches("region-properties") {
+        let region_id = value_t_or_exit!(matches.value_of("region"), u64);
+        debug_executor.dump_region_properties(region_id)
     } else {
         let _ = app.print_help();
     }

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -39,6 +39,7 @@ use storage::types::{truncate_ts, Key};
 use storage::{CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
 use util::config::ReadableSize;
 use util::escape;
+use util::properties::MvccProperties;
 use util::rocksdb::{compact_range, get_cf_handle};
 use util::worker::Worker;
 
@@ -516,6 +517,53 @@ impl Debugger {
             )));
         }
         Ok(())
+    }
+
+    fn get_region_state(&self, region_id: u64) -> Result<RegionLocalState> {
+        let region_state_key = keys::region_state_key(region_id);
+        let region_state = box_try!(
+            self.engines
+                .kv_engine
+                .get_msg_cf::<RegionLocalState>(CF_RAFT, &region_state_key)
+        );
+        match region_state {
+            Some(v) => Ok(v),
+            None => Err(Error::NotFound(format!("region {}", region_id))),
+        }
+    }
+
+    pub fn get_region_properties(&self, region_id: u64) -> Result<Vec<(String, String)>> {
+        let region_state = self.get_region_state(region_id)?;
+        let region = region_state.get_region();
+        let db = &self.engines.kv_engine;
+
+        let mut num_entries = 0;
+        let mut mvcc_properties = MvccProperties::new();
+        let collection = box_try!(raftstore_util::get_region_properties_cf(
+            db,
+            CF_WRITE,
+            region
+        ));
+        for (_, v) in &*collection {
+            num_entries += v.num_entries();
+            let mvcc = box_try!(MvccProperties::decode(v.user_collected_properties()));
+            mvcc_properties.add(&mvcc);
+        }
+
+        let res = [
+            ("num_files", collection.len() as u64),
+            ("num_entries", num_entries),
+            ("num_deletes", num_entries - mvcc_properties.num_versions),
+            ("mvcc.min_ts", mvcc_properties.min_ts),
+            ("mvcc.max_ts", mvcc_properties.max_ts),
+            ("mvcc.num_rows", mvcc_properties.num_rows),
+            ("mvcc.num_puts", mvcc_properties.num_puts),
+            ("mvcc.num_versions", mvcc_properties.num_versions),
+            ("mvcc.max_row_versions", mvcc_properties.max_row_versions),
+        ].iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        Ok(res)
     }
 }
 

--- a/src/server/service/debug.rs
+++ b/src/server/service/debug.rs
@@ -382,9 +382,11 @@ impl<T: RaftStoreRouter + 'static + Send> debugpb_grpc::Debug for Service<T> {
             )
             .map(|props| {
                 let mut resp = GetRegionPropertiesResponse::new();
-                for (k, v) in props {
-                    resp.mut_names().push(k);
-                    resp.mut_values().push(v);
+                for (name, value) in props {
+                    let mut prop = Property::new();
+                    prop.set_name(name);
+                    prop.set_value(value);
+                    resp.mut_props().push(prop);
                 }
                 resp
             });


### PR DESCRIPTION
The output looks like this:

```
$ bin/tikv-ctl --host 127.0.0.1:20160 region-properties -r 4                                                                                           huachao@Huachao-X1
num_files: 1
num_entries: 384374
num_deletes: 1245
mvcc.min_ts: 400469785325076491
mvcc.max_ts: 400470640006266884
mvcc.num_rows: 383097
mvcc.num_puts: 383115
mvcc.num_versions: 383129
mvcc.max_row_versions: 15
```