### PR TITLE
increase snapshot send/generate metrics.

### DIFF
--- a/src/raftstore/store/metrics.rs
+++ b/src/raftstore/store/metrics.rs
@@ -177,7 +177,7 @@ lazy_static! {
         register_histogram!(
             "tikv_snapshot_build_time_duration_secs",
             "Bucketed histogram of snapshot build time duration.",
-            exponential_buckets(0.0005, 2.0, 20).unwrap()
+            exponential_buckets(0.05, 2.0, 20).unwrap()
         ).unwrap();
 
     pub static ref SNAPSHOT_KV_COUNT_HISTOGRAM: Histogram =

--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -16,7 +16,8 @@ use prometheus::*;
 lazy_static! {
     pub static ref SEND_SNAP_HISTOGRAM: Histogram = register_histogram!(
         "tikv_server_send_snapshot_duration_seconds",
-        "Bucketed histogram of server send snapshots duration"
+        "Bucketed histogram of server send snapshots duration",
+        exponential_buckets(0.05, 2.0, 20).unwrap()
     ).unwrap();
     pub static ref SNAP_TASK_COUNTER: IntCounterVec = register_int_counter_vec!(
         "tikv_server_snapshot_task_total",


### PR DESCRIPTION
For large snapshot or slow network, metrics of sending/generating snapshots need to be increased.
Fix #3085 .