### PR TITLE
*: use fxhash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,11 +273,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "flat_map"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "fnv"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1250,11 +1245,11 @@ dependencies = [
  "crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fail 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "flat_map 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)",
@@ -1569,7 +1564,6 @@ dependencies = [
 "checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
 "checksum either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18785c1ba806c258137c937e44ada9ee7e69a37e3c72077542cd2f069d78562a"
 "checksum fail 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd2e1a22c616c8c8c96b6e07c243014551f3ba77291d24c22e0bfea6830c0b4e"
-"checksum flat_map 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "fc16c081affe2ded9d62cd239a9ef1b4801fa98037b59523014f661c7bee182c"
 "checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
 "checksum fs2 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "237b7991317b8d94391c0a4813b1f74fd81c11352440cd598d2b763ed288bfc1"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,6 @@ url = "1.5"
 regex = "0.1"
 fnv = "1.0"
 sys-info = "0.5.1"
-flat_map = "0.0.4"
 indexmap = { version = "1.0", features = ["serde-1"] }
 mio = "0.5"
 futures = "0.1"
@@ -80,6 +79,7 @@ uuid = { version = "0.6", features = [ "serde", "v4" ] }
 grpcio = { version = "0.2", features = [ "secure" ] }
 raft = "0.2"
 crossbeam-channel = { version = "0.1", features = [ "nightly" ] }
+fxhash = "0.2"
 
 [target.'cfg(unix)'.dependencies]
 signal = "0.4"

--- a/benches/serialization/bench_serialization.rs
+++ b/benches/serialization/bench_serialization.rs
@@ -17,8 +17,8 @@ use kvproto::raft_cmdpb::{CmdType, RaftCmdRequest, Request};
 use protobuf::Message;
 use raft::eraftpb::Entry;
 use rand::{thread_rng, Rng};
-use std::collections::HashMap;
 use test::Bencher;
+use tikv::util::collections::HashMap;
 
 #[inline]
 fn gen_rand_str(len: usize) -> Vec<u8> {
@@ -62,7 +62,7 @@ fn decode(data: &[u8]) {
 fn bench_encode_one(b: &mut Bencher) {
     let key = gen_rand_str(30);
     let value = gen_rand_str(256);
-    let mut map: HashMap<&[u8], &[u8]> = HashMap::new();
+    let mut map: HashMap<&[u8], &[u8]> = HashMap::default();
     map.insert(&key, &value);
     b.iter(|| {
         encode(&map);
@@ -73,7 +73,7 @@ fn bench_encode_one(b: &mut Bencher) {
 fn bench_decode_one(b: &mut Bencher) {
     let key = gen_rand_str(30);
     let value = gen_rand_str(256);
-    let mut map: HashMap<&[u8], &[u8]> = HashMap::new();
+    let mut map: HashMap<&[u8], &[u8]> = HashMap::default();
     map.insert(&key, &value);
     let data = encode(&map);
     b.iter(|| {
@@ -87,7 +87,7 @@ fn bench_encode_two(b: &mut Bencher) {
     let value_for_lock = gen_rand_str(10);
     let key_for_data = gen_rand_str(30);
     let value_for_data = gen_rand_str(256);
-    let mut map: HashMap<&[u8], &[u8]> = HashMap::new();
+    let mut map: HashMap<&[u8], &[u8]> = HashMap::default();
     map.insert(&key_for_lock, &value_for_lock);
     map.insert(&key_for_data, &value_for_data);
     b.iter(|| {
@@ -101,7 +101,7 @@ fn bench_decode_two(b: &mut Bencher) {
     let value_for_lock = gen_rand_str(10);
     let key_for_data = gen_rand_str(30);
     let value_for_data = gen_rand_str(256);
-    let mut map: HashMap<&[u8], &[u8]> = HashMap::new();
+    let mut map: HashMap<&[u8], &[u8]> = HashMap::default();
     map.insert(&key_for_lock, &value_for_lock);
     map.insert(&key_for_data, &value_for_data);
     let data = encode(&map);

--- a/src/coprocessor/statistics/cmsketch.rs
+++ b/src/coprocessor/statistics/cmsketch.rs
@@ -80,8 +80,8 @@ mod test {
     use coprocessor::codec::datum::Datum;
     use rand::{Rng, SeedableRng, StdRng};
     use std::cmp::min;
-    use std::collections::HashMap;
     use util::as_slice;
+    use util::collections::HashMap;
     use zipf::ZipfDistribution;
 
     impl CMSketch {
@@ -110,7 +110,7 @@ mod test {
 
     fn average_error(depth: usize, width: usize, total: u32, max_value: usize, s: f64) -> u64 {
         let mut c = CMSketch::new(depth, width).unwrap();
-        let mut map: HashMap<u64, u32> = HashMap::new();
+        let mut map: HashMap<u64, u32> = HashMap::default();
         let seed: &[_] = &[1, 2, 3, 4];
         let mut gen: ZipfDistribution<StdRng> =
             ZipfDistribution::new(SeedableRng::from_seed(seed), max_value, s).unwrap();

--- a/src/coprocessor/statistics/fmsketch.rs
+++ b/src/coprocessor/statistics/fmsketch.rs
@@ -13,8 +13,8 @@
 
 use byteorder::{ByteOrder, LittleEndian};
 use murmur3::murmur3_x64_128;
-use std::collections::HashSet;
 use tipb::analyze;
+use util::collections::HashSet;
 
 /// `FMSketch` is used to count the approximate number of distinct
 /// elements in multiset.
@@ -31,7 +31,7 @@ impl FMSketch {
         FMSketch {
             mask: 0,
             max_size,
-            hash_set: HashSet::with_capacity(max_size + 1),
+            hash_set: HashSet::with_capacity_and_hasher(max_size + 1, Default::default()),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,11 +46,11 @@ extern crate crc;
 extern crate crossbeam_channel;
 #[macro_use]
 extern crate fail;
-extern crate flat_map;
 extern crate fnv;
 extern crate fs2;
 extern crate futures;
 extern crate futures_cpupool;
+extern crate fxhash;
 extern crate grpcio as grpc;
 extern crate indexmap;
 extern crate kvproto;

--- a/src/pd/util.rs
+++ b/src/pd/util.rs
@@ -11,12 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashSet;
 use std::result;
 use std::sync::Arc;
 use std::sync::RwLock;
 use std::time::Duration;
 use std::time::Instant;
+use util::collections::HashSet;
 
 use futures::future::{loop_fn, ok, Loop};
 use futures::sync::mpsc::UnboundedSender;
@@ -329,7 +329,7 @@ pub fn validate_endpoints(
     security_mgr: &SecurityManager,
 ) -> Result<(PdClient, GetMembersResponse)> {
     let len = cfg.endpoints.len();
-    let mut endpoints_set = HashSet::with_capacity(len);
+    let mut endpoints_set = HashSet::with_capacity_and_hasher(len, Default::default());
 
     let mut members = None;
     let mut cluster_id = None;

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -39,7 +39,7 @@ use raftstore::store::{Callback, Config, ReadResponse, RegionSnapshot};
 use raftstore::{Error, Result};
 
 use util::MustConsumeVec;
-use util::collections::{FlatMap, HashSet};
+use util::collections::{HashMap, HashSet};
 use util::time::{duration_to_sec, monotonic_raw_now};
 use util::worker::{FutureWorker, Scheduler};
 
@@ -227,7 +227,7 @@ pub struct Peer {
     kv_engine: Arc<DB>,
     raft_engine: Arc<DB>,
     cfg: Rc<Config>,
-    peer_cache: RefCell<FlatMap<u64, metapb::Peer>>,
+    peer_cache: RefCell<HashMap<u64, metapb::Peer>>,
     pub peer: metapb::Peer,
     region_id: u64,
     pub raft_group: RawNode<PeerStorage>,
@@ -235,7 +235,7 @@ pub struct Peer {
     apply_proposals: Vec<Proposal>,
     pending_reads: ReadIndexQueue,
     // Record the last instant of each peer's heartbeat response.
-    pub peer_heartbeats: FlatMap<u64, Instant>,
+    pub peer_heartbeats: HashMap<u64, Instant>,
 
     /// Record the instants of peers being added into the configuration.
     /// Remove them after they are not pending any more.
@@ -378,8 +378,8 @@ impl Peer {
             proposals: Default::default(),
             apply_proposals: vec![],
             pending_reads: Default::default(),
-            peer_cache: RefCell::new(FlatMap::default()),
-            peer_heartbeats: FlatMap::default(),
+            peer_cache: RefCell::new(HashMap::default()),
+            peer_heartbeats: HashMap::default(),
             peers_start_pending_time: vec![],
             coprocessor_host: Arc::clone(&store.coprocessor_host),
             size_diff_hint: 0,

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -13,12 +13,12 @@
 
 use std::cell::RefCell;
 use std::cmp::Ordering;
-use std::collections::HashSet;
 use std::iter::FromIterator;
 use std::rc::Rc;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::{error, result};
+use util::collections::HashSet;
 
 use protobuf::{self, Message, RepeatedField};
 

--- a/src/util/collections.rs
+++ b/src/util/collections.rs
@@ -11,12 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use fnv::FnvBuildHasher as BuildHasherDefault;
-pub use fnv::FnvHashMap as HashMap;
-pub use fnv::FnvHashSet as HashSet;
+pub use fxhash::FxHashMap as HashMap;
+pub use fxhash::FxHashSet as HashSet;
 pub use std::collections::hash_map::Entry as HashMapEntry;
 
-pub use flat_map::FlatMap;
-pub use flat_map::flat_map::{Entry as FlatMapEntry, Values as FlatMapValues};
 pub use indexmap::IndexMap as OrderMap;
 pub use indexmap::map::Entry as OrderMapEntry;

--- a/tests/pd/mock/mocker/service.rs
+++ b/tests/pd/mock/mocker/service.rs
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use tikv::util::collections::HashMap;
 
 use kvproto::metapb::{Peer, Region, Store};
 use kvproto::pdpb::*;
@@ -38,9 +38,9 @@ impl Service {
             members_resp: Mutex::new(None),
             id_allocator: AtomicUsize::new(1), // start from 1.
             is_bootstrapped: AtomicBool::new(false),
-            stores: Mutex::new(HashMap::new()),
-            regions: Mutex::new(HashMap::new()),
-            leaders: Mutex::new(HashMap::new()),
+            stores: Mutex::new(HashMap::default()),
+            regions: Mutex::new(HashMap::default()),
+            leaders: Mutex::new(HashMap::default()),
         }
     }
 

--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -11,11 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::{self, Arc, RwLock};
 use std::time::*;
 use std::{result, thread};
+use tikv::util::collections::{HashMap, HashSet};
 
 use futures::Future;
 use rocksdb::DB;
@@ -112,11 +112,11 @@ impl<T: Simulator> Cluster<T> {
         // TODO: In the future, maybe it's better to test both case where `use_delete_range` is true and false
         Cluster {
             cfg: new_tikv_config(id),
-            leaders: HashMap::new(),
+            leaders: HashMap::default(),
             paths: vec![],
             dbs: vec![],
             count,
-            engines: HashMap::new(),
+            engines: HashMap::default(),
             sim,
             pd_client,
         }

--- a/tests/raftstore/node.rs
+++ b/tests/raftstore/node.rs
@@ -11,10 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
 use std::path::Path;
 use std::sync::{mpsc, Arc, RwLock};
+use tikv::util::collections::{HashMap, HashSet};
 
 use tempdir::TempDir;
 
@@ -52,8 +52,8 @@ impl ChannelTransport {
     pub fn new() -> ChannelTransport {
         ChannelTransport {
             core: Arc::new(RwLock::new(ChannelTransportCore {
-                snap_paths: HashMap::new(),
-                routers: HashMap::new(),
+                snap_paths: HashMap::default(),
+                routers: HashMap::default(),
             })),
         }
     }
@@ -138,8 +138,8 @@ impl NodeCluster {
         NodeCluster {
             trans: ChannelTransport::new(),
             pd_client,
-            nodes: HashMap::new(),
-            simulate_trans: HashMap::new(),
+            nodes: HashMap::default(),
+            simulate_trans: HashMap::default(),
         }
     }
 }

--- a/tests/raftstore/pd.rs
+++ b/tests/raftstore/pd.rs
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
 use std::collections::Bound::{Excluded, Unbounded};
 use std::collections::hash_map::Entry;
-use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
@@ -30,6 +30,7 @@ use raft::eraftpb;
 use tikv::pd::{Error, Key, PdClient, PdFuture, RegionStat, Result};
 use tikv::raftstore::store::keys::{self, data_key, enc_end_key, enc_start_key};
 use tikv::raftstore::store::util::check_key_in_region;
+use tikv::util::collections::{HashMap, HashSet};
 use tikv::util::{escape, Either, HandyRwLock};
 
 struct Store {
@@ -235,18 +236,18 @@ impl Cluster {
 
         Cluster {
             meta,
-            stores: HashMap::new(),
+            stores: HashMap::default(),
             regions: BTreeMap::new(),
-            region_id_keys: HashMap::new(),
-            region_sizes: HashMap::new(),
+            region_id_keys: HashMap::default(),
+            region_sizes: HashMap::default(),
             base_id: AtomicUsize::new(1000),
-            store_stats: HashMap::new(),
+            store_stats: HashMap::default(),
             split_count: 0,
-            operators: HashMap::new(),
+            operators: HashMap::default(),
             enable_peer_count_check: true,
-            leaders: HashMap::new(),
-            down_peers: HashMap::new(),
-            pending_peers: HashMap::new(),
+            leaders: HashMap::default(),
+            down_peers: HashMap::default(),
+            pending_peers: HashMap::default(),
             is_bootstraped: false,
         }
     }

--- a/tests/raftstore/server.rs
+++ b/tests/raftstore/server.rs
@@ -11,11 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::{mpsc, Arc, RwLock};
 use std::thread;
 use std::time::Duration;
+use tikv::util::collections::{HashMap, HashSet};
 
 use grpc::{EnvBuilder, Error as GrpcError};
 use tempdir::TempDir;
@@ -77,11 +77,11 @@ impl ServerCluster {
         );
         let security_mgr = Arc::new(SecurityManager::new(&Default::default()).unwrap());
         ServerCluster {
-            metas: HashMap::new(),
-            addrs: HashMap::new(),
+            metas: HashMap::default(),
+            addrs: HashMap::default(),
             pd_client,
-            storages: HashMap::new(),
-            snap_paths: HashMap::new(),
+            storages: HashMap::default(),
+            snap_paths: HashMap::default(),
             raft_client: RaftClient::new(env, Arc::new(Config::default()), security_mgr),
         }
     }

--- a/tests/raftstore/transport_simulate.rs
+++ b/tests/raftstore/transport_simulate.rs
@@ -20,12 +20,12 @@ use tikv::server::transport::*;
 use tikv::util::{transport, Either, HandyRwLock};
 
 use rand;
-use std::collections::{HashMap, HashSet};
 use std::marker::PhantomData;
 use std::sync::atomic::*;
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex, RwLock};
 use std::{thread, time, usize};
+use tikv::util::collections::{HashMap, HashSet};
 
 pub trait Channel<M>: Send + Clone {
     fn send(&self, m: M) -> Result<()>;
@@ -422,7 +422,7 @@ impl CollectSnapshotFilter {
         CollectSnapshotFilter {
             dropped: AtomicBool::new(false),
             stale: AtomicBool::new(false),
-            pending_msg: Mutex::new(HashMap::new()),
+            pending_msg: Mutex::new(HashMap::default()),
             pending_count_sender: Mutex::new(sender),
         }
     }

--- a/tests/raftstore_cases/test_compact_log.rs
+++ b/tests/raftstore_cases/test_compact_log.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use tikv::util::collections::HashMap;
 
 use kvproto::raft_serverpb::{RaftApplyState, RaftTruncatedState};
 use protobuf;
@@ -34,7 +34,7 @@ where
 fn test_compact_log<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.run();
 
-    let mut before_states = HashMap::new();
+    let mut before_states = HashMap::default();
 
     for (&id, engines) in &cluster.engines {
         let mut state: RaftApplyState =
@@ -62,7 +62,7 @@ fn check_compacted(
     compact_count: u64,
 ) -> bool {
     // Every peer must have compacted logs, so the truncate log state index/term must > than before.
-    let mut compacted_idx = HashMap::new();
+    let mut compacted_idx = HashMap::default();
 
     for (&id, engines) in all_engines {
         let mut state: RaftApplyState =
@@ -105,7 +105,7 @@ fn test_compact_count_limit<T: Simulator>(cluster: &mut Cluster<T>) {
 
     cluster.must_put(b"k1", b"v1");
 
-    let mut before_states = HashMap::new();
+    let mut before_states = HashMap::default();
 
     for (&id, engines) in &cluster.engines {
         must_get_equal(&engines.kv_engine, b"k1", b"v1");
@@ -161,7 +161,7 @@ fn test_compact_many_times<T: Simulator>(cluster: &mut Cluster<T>) {
 
     cluster.must_put(b"k1", b"v1");
 
-    let mut before_states = HashMap::new();
+    let mut before_states = HashMap::default();
 
     for (&id, engines) in &cluster.engines {
         must_get_equal(&engines.kv_engine, b"k1", b"v1");
@@ -218,7 +218,7 @@ fn test_compact_size_limit<T: Simulator>(cluster: &mut Cluster<T>) {
 
     cluster.must_put(b"k1", b"v1");
 
-    let mut before_states = HashMap::new();
+    let mut before_states = HashMap::default();
 
     for (&id, engines) in &cluster.engines {
         if id == 1 {


### PR DESCRIPTION
Most of use cases of hashing in our codebase is to hash a u64/i64. fxhash is much faster than fnvhash in this case.

A simple benchmark shows that:
```
test bench_fnv_3  ... bench:           7 ns/iter (+/- 0)
test bench_fnv_5  ... bench:           7 ns/iter (+/- 0)
test bench_fx_3   ... bench:           3 ns/iter (+/- 0)
test bench_fx_5   ... bench:           3 ns/iter (+/- 0)
test bench_iter_3 ... bench:           5 ns/iter (+/- 0)
test bench_iter_5 ... bench:           6 ns/iter (+/- 0)
```

`bench_fnv_3` means querying elements of FnvHashMap which contains 3 elements. `bench_iter_3` means using pure iteration.

close #3032, #2851 and #1843.