### PR TITLE
Fix C++ 8.1 build errors.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,7 +533,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#b011ecb17759d052ae39e2c86addc7b1c7e6c178"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#2a150c328125181f48e46b1f0a17c89f2f9b5e45"
 dependencies = [
  "bzip2-sys 0.1.6 (git+https://github.com/alexcrichton/bzip2-rs.git)",
  "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -958,7 +958,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#b011ecb17759d052ae39e2c86addc7b1c7e6c178"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#2a150c328125181f48e46b1f0a17c89f2f9b5e45"
 dependencies = [
  "crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
Bumps the rocksdb version we use to include a backported patch that
resolves the relevant warnings.

Related:
https://github.com/pingcap/rocksdb/pull/22
https://github.com/pingcap/rust-rocksdb/pull/207