### PR TITLE
*: relax atomic counter operations

### DIFF
--- a/benches/bin/utils.rs
+++ b/benches/bin/utils.rs
@@ -20,7 +20,7 @@ use tikv::util::codec::number::NumberEncoder;
 #[inline]
 pub fn next_ts() -> u64 {
     static CURRENT: AtomicU64 = ATOMIC_U64_INIT;
-    CURRENT.fetch_add(1, Ordering::SeqCst)
+    CURRENT.fetch_add(1, Ordering::Relaxed)
 }
 
 /// Generate `count` row keys that all with the specified `table_id`.

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -96,7 +96,7 @@ impl Host {
 
     #[inline]
     fn running_task_count(&self) -> usize {
-        self.running_task_count.load(Ordering::Acquire)
+        self.running_task_count.load(Ordering::Relaxed)
     }
 
     fn notify_failed<E: Into<Error> + Debug>(&mut self, e: E, reqs: Vec<RequestTask>) {
@@ -285,7 +285,7 @@ struct RequestTracker {
 
 impl RequestTracker {
     fn task_count(&mut self, running_task_count: Arc<AtomicUsize>) {
-        running_task_count.fetch_add(1, Ordering::Release);
+        running_task_count.fetch_add(1, Ordering::Relaxed);
         self.running_task_count = Some(running_task_count);
     }
 
@@ -357,7 +357,7 @@ impl RequestTracker {
 impl Drop for RequestTracker {
     fn drop(&mut self) {
         if let Some(task_count) = self.running_task_count.take() {
-            task_count.fetch_sub(1, Ordering::Release);
+            task_count.fetch_sub(1, Ordering::Relaxed);
         }
 
         if self.total_handle_time > SLOW_QUERY_LOWER_BOUND {

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -65,7 +65,7 @@ impl Conn {
             // hack: so it's different args, grpc will always create a new connection.
             .raw_cfg_int(
                 CString::new("random id").unwrap(),
-                CONN_ID.fetch_add(1, Ordering::SeqCst),
+                CONN_ID.fetch_add(1, Ordering::Relaxed),
             );
         let channel = security_mgr.connect(cb, addr);
         let client = TikvClient::new(channel);

--- a/src/util/futurepool.rs
+++ b/src/util/futurepool.rs
@@ -215,7 +215,7 @@ impl<T: Context + 'static> FuturePool<T> {
     /// Get current running task count
     #[inline]
     pub fn get_running_task_count(&self) -> usize {
-        self.running_task_count.load(Ordering::Acquire)
+        self.running_task_count.load(Ordering::Relaxed)
     }
 
     /// TODO: Remove this interface to avoid accessing context delegators from outside.
@@ -239,14 +239,14 @@ impl<T: Context + 'static> FuturePool<T> {
             future_factory(delegators.clone()).then(move |r| {
                 let delegator = delegators.get_current_thread_delegator();
                 delegator.on_task_finish();
-                running_task_count.fetch_sub(1, Ordering::Release);
+                running_task_count.fetch_sub(1, Ordering::Relaxed);
                 metrics_pending_task_count.dec();
                 metrics_handled_task_count.inc();
                 r
             })
         };
 
-        self.running_task_count.fetch_add(1, Ordering::Release);
+        self.running_task_count.fetch_add(1, Ordering::Relaxed);
         self.metrics_pending_task_count.inc();
         self.pool.spawn_fn(func)
     }

--- a/src/util/threadpool.rs
+++ b/src/util/threadpool.rs
@@ -217,12 +217,12 @@ where
             state.queue.push(task);
             cvar.notify_one();
         }
-        self.task_count.fetch_add(1, AtomicOrdering::SeqCst);
+        self.task_count.fetch_add(1, AtomicOrdering::Relaxed);
     }
 
     #[inline]
     pub fn get_task_count(&self) -> usize {
-        self.task_count.load(AtomicOrdering::SeqCst)
+        self.task_count.load(AtomicOrdering::Relaxed)
     }
 
     pub fn stop(&mut self) -> Result<(), String> {
@@ -311,7 +311,7 @@ where
             self.ctx.on_task_started();
             (task.task).call_box((&mut self.ctx,));
             self.ctx.on_task_finished();
-            self.task_count.fetch_sub(1, AtomicOrdering::SeqCst);
+            self.task_count.fetch_sub(1, AtomicOrdering::Relaxed);
             if self.task_counter == self.tasks_per_tick {
                 self.task_counter = 0;
                 self.ctx.on_tick();

--- a/src/util/worker/mod.rs
+++ b/src/util/worker/mod.rs
@@ -166,14 +166,14 @@ impl<T: Display> Scheduler<T> {
                 _ => unreachable!(),
             }
         }
-        self.counter.fetch_add(1, Ordering::SeqCst);
+        self.counter.fetch_add(1, Ordering::Relaxed);
         self.metrics_pending_task_count.inc();
         Ok(())
     }
 
     /// Check if underlying worker can't handle task immediately.
     pub fn is_busy(&self) -> bool {
-        self.counter.load(Ordering::SeqCst) > 0
+        self.counter.load(Ordering::Relaxed) > 0
     }
 }
 
@@ -277,7 +277,7 @@ fn poll<R, T, U>(
             // before `run_batch`.
             let batch_len = batch.len();
             runner.run_batch(&mut batch);
-            counter.fetch_sub(batch_len, Ordering::SeqCst);
+            counter.fetch_sub(batch_len, Ordering::Relaxed);
             metrics_pending_task_count.sub(batch_len as i64);
             metrics_handled_task_count.inc_by(batch_len as i64);
             batch.clear();


### PR DESCRIPTION
Atomic operations can be relaxed if they don't piggyback memory synchronization.