### PR TITLE
raftstore: getter/setter for region

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -462,7 +462,7 @@ impl Peer {
         fail_point!("raft_store_skip_destroy_peer", |_| Ok(()));
         let t = Instant::now();
 
-        let region = self.get_store().get_region().clone();
+        let region = self.region().clone();
         info!("{} begin to destroy", self.tag);
 
         // Set Tombstone state explicitly
@@ -518,7 +518,7 @@ impl Peer {
     }
 
     pub fn region(&self) -> &metapb::Region {
-        self.get_store().get_region()
+        self.get_store().region()
     }
 
     /// Set the region of a peer.
@@ -637,7 +637,7 @@ impl Peer {
         }
 
         // Insert heartbeats in case that some peers never response heartbeats.
-        let region = self.raft_group.get_store().get_region();
+        let region = self.raft_group.get_store().region();
         for peer in region.get_peers() {
             self.peer_heartbeats
                 .entry(peer.get_id())
@@ -1844,7 +1844,7 @@ impl Peer {
         }
 
         // Try to find in region, if found, set in cache.
-        for peer in self.get_store().get_region().get_peers() {
+        for peer in self.region().get_peers() {
             if peer.get_id() == peer_id {
                 self.peer_cache.borrow_mut().insert(peer_id, peer.clone());
                 return Some(peer.clone());

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -517,6 +517,7 @@ impl Peer {
         Arc::clone(&self.raft_engine)
     }
 
+    #[inline]
     pub fn region(&self) -> &metapb::Region {
         self.get_store().region()
     }
@@ -526,7 +527,7 @@ impl Peer {
     /// This will update the region of the peer, caller must ensure the region
     /// has been preserved in a durable device.
     pub fn set_region(&mut self, region: metapb::Region) {
-        self.mut_store().set_region(region);
+        self.mut_store().set_region(region)
     }
 
     pub fn peer_id(&self) -> u64 {

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -521,6 +521,14 @@ impl Peer {
         self.get_store().get_region()
     }
 
+    /// Set the region of a peer.
+    ///
+    /// This will update the region of the peer, caller must ensure the region
+    /// has been preserved in a durable device.
+    pub fn set_region(&mut self, region: metapb::Region) {
+        *self.mut_store().region_mut() = region;
+    }
+
     pub fn peer_id(&self) -> u64 {
         self.peer.get_id()
     }

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -526,7 +526,7 @@ impl Peer {
     /// This will update the region of the peer, caller must ensure the region
     /// has been preserved in a durable device.
     pub fn set_region(&mut self, region: metapb::Region) {
-        *self.mut_store().region_mut() = region;
+        self.mut_store().set_region(region);
     }
 
     pub fn peer_id(&self) -> u64 {

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -621,7 +621,7 @@ impl PeerStorage {
         self.apply_state.get_truncated_state().get_term()
     }
 
-    pub fn get_region(&self) -> &metapb::Region {
+    pub fn region(&self) -> &metapb::Region {
         &self.region
     }
 
@@ -661,7 +661,7 @@ impl PeerStorage {
             return false;
         }
         let snap_epoch = snap_data.get_region().get_region_epoch();
-        let latest_epoch = self.get_region().get_region_epoch();
+        let latest_epoch = self.region.get_region_epoch();
         if snap_epoch.get_conf_ver() < latest_epoch.get_conf_ver() {
             info!(
                 "{} snapshot epoch {:?} < {:?}, generate again.",
@@ -885,8 +885,8 @@ impl PeerStorage {
     /// If return Err, data may get partial deleted.
     pub fn clear_data(&self) -> Result<()> {
         let (start_key, end_key) = (
-            enc_start_key(self.get_region()),
-            enc_end_key(self.get_region()),
+            enc_start_key(&self.region),
+            enc_end_key(&self.region),
         );
         let region_id = self.get_region_id();
         box_try!(
@@ -899,8 +899,8 @@ impl PeerStorage {
     /// Delete all data that is not covered by `new_region`.
     fn clear_extra_data(&self, new_region: &metapb::Region) -> Result<()> {
         let (old_start_key, old_end_key) = (
-            enc_start_key(self.get_region()),
-            enc_end_key(self.get_region()),
+            enc_start_key(&self.region),
+            enc_end_key(&self.region),
         );
         let (new_start_key, new_end_key) = (enc_start_key(new_region), enc_end_key(new_region));
         let region_id = new_region.get_id();

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -496,7 +496,7 @@ impl PeerStorage {
     }
 
     pub fn is_initialized(&self) -> bool {
-        !self.region.get_peers().is_empty()
+        !self.region().get_peers().is_empty()
     }
 
     pub fn initial_state(&self) -> raft::Result<RaftState> {
@@ -517,7 +517,7 @@ impl PeerStorage {
         }
         Ok(RaftState {
             hard_state,
-            conf_state: conf_state_from_region(&self.region),
+            conf_state: conf_state_from_region(self.region()),
         })
     }
 
@@ -661,7 +661,7 @@ impl PeerStorage {
             return false;
         }
         let snap_epoch = snap_data.get_region().get_region_epoch();
-        let latest_epoch = self.region.get_region_epoch();
+        let latest_epoch = self.region().get_region_epoch();
         if snap_epoch.get_conf_ver() < latest_epoch.get_conf_ver() {
             info!(
                 "{} snapshot epoch {:?} < {:?}, generate again.",
@@ -885,8 +885,8 @@ impl PeerStorage {
     /// If return Err, data may get partial deleted.
     pub fn clear_data(&self) -> Result<()> {
         let (start_key, end_key) = (
-            enc_start_key(&self.region),
-            enc_end_key(&self.region),
+            enc_start_key(self.region()),
+            enc_end_key(self.region()),
         );
         let region_id = self.get_region_id();
         box_try!(
@@ -899,8 +899,8 @@ impl PeerStorage {
     /// Delete all data that is not covered by `new_region`.
     fn clear_extra_data(&self, new_region: &metapb::Region) -> Result<()> {
         let (old_start_key, old_end_key) = (
-            enc_start_key(&self.region),
-            enc_end_key(&self.region),
+            enc_start_key(self.region()),
+            enc_end_key(self.region()),
         );
         let (new_start_key, new_end_key) = (enc_start_key(new_region), enc_end_key(new_region));
         let region_id = new_region.get_id();
@@ -1009,7 +1009,7 @@ impl PeerStorage {
     }
 
     pub fn get_region_id(&self) -> u64 {
-        self.region.get_id()
+        self.region().get_id()
     }
 
     pub fn schedule_applying_snapshot(&mut self) {
@@ -1104,7 +1104,7 @@ impl PeerStorage {
         };
         // cleanup data before scheduling apply task
         if self.is_initialized() {
-            if let Err(e) = self.clear_extra_data(&self.region) {
+            if let Err(e) = self.clear_extra_data(self.region()) {
                 // No need panic here, when applying snapshot, the deletion will be tried
                 // again. But if the region range changes, like [a, c) -> [a, b) and [b, c),
                 // [b, c) will be kept in rocksdb until a covered snapshot is applied or
@@ -1117,12 +1117,12 @@ impl PeerStorage {
         }
 
         self.schedule_applying_snapshot();
-        let prev_region = self.region.clone();
+        let prev_region = self.region().clone();
         self.region = snap_region;
 
         Some(ApplySnapResult {
             prev_region,
-            region: self.region.clone(),
+            region: self.region().clone(),
         })
     }
 }

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -625,8 +625,8 @@ impl PeerStorage {
         &self.region
     }
 
-    pub fn region_mut(&mut self) -> &mut metapb::Region {
-        &mut self.region
+    pub fn set_region(&mut self, region: metapb::Region) {
+        self.region = region;
     }
 
     pub fn raw_snapshot(&self) -> DbSnapshot {

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -255,7 +255,7 @@ pub struct PeerStorage {
     pub kv_engine: Arc<DB>,
     pub raft_engine: Arc<DB>,
 
-    pub region: metapb::Region,
+    region: metapb::Region,
     pub raft_state: RaftLocalState,
     pub apply_state: RaftApplyState,
     pub applied_index_term: u64,
@@ -623,6 +623,10 @@ impl PeerStorage {
 
     pub fn get_region(&self) -> &metapb::Region {
         &self.region
+    }
+
+    pub fn region_mut(&mut self) -> &mut metapb::Region {
+        &mut self.region
     }
 
     pub fn raw_snapshot(&self) -> DbSnapshot {

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -884,10 +884,7 @@ impl PeerStorage {
     /// Delete all data belong to the region.
     /// If return Err, data may get partial deleted.
     pub fn clear_data(&self) -> Result<()> {
-        let (start_key, end_key) = (
-            enc_start_key(self.region()),
-            enc_end_key(self.region()),
-        );
+        let (start_key, end_key) = (enc_start_key(self.region()), enc_end_key(self.region()));
         let region_id = self.get_region_id();
         box_try!(
             self.region_sched
@@ -898,10 +895,8 @@ impl PeerStorage {
 
     /// Delete all data that is not covered by `new_region`.
     fn clear_extra_data(&self, new_region: &metapb::Region) -> Result<()> {
-        let (old_start_key, old_end_key) = (
-            enc_start_key(self.region()),
-            enc_end_key(self.region()),
-        );
+        let (old_start_key, old_end_key) =
+            (enc_start_key(self.region()), enc_end_key(self.region()));
         let (new_start_key, new_end_key) = (enc_start_key(new_region), enc_end_key(new_region));
         let region_id = new_region.get_id();
         if old_start_key < new_start_key {

--- a/src/raftstore/store/region_snapshot.rs
+++ b/src/raftstore/store/region_snapshot.rs
@@ -31,7 +31,7 @@ pub struct RegionSnapshot {
 
 impl RegionSnapshot {
     pub fn new(ps: &PeerStorage) -> RegionSnapshot {
-        RegionSnapshot::from_snapshot(ps.raw_snapshot().into_sync(), ps.get_region().clone())
+        RegionSnapshot::from_snapshot(ps.raw_snapshot().into_sync(), ps.region().clone())
     }
 
     pub fn from_raw(db: Arc<DB>, region: Region) -> RegionSnapshot {


### PR DESCRIPTION
Add getter and setter for region, so it is easy to add a hook when we updates Peer's region.

Cc #2639  