### PR TITLE
logger: Bigger channel and blocks on overflow.

### DIFF
--- a/src/bin/util/setup.rs
+++ b/src/bin/util/setup.rs
@@ -31,7 +31,7 @@ use tikv::util::logger;
 pub static LOG_INITIALIZED: AtomicBool = ATOMIC_BOOL_INIT;
 // Default is 128.
 // Extended since blocking is set, and we don't want to block very often.
-const SLOG_CHANNEL_SIZE: usize = 2048;
+const SLOG_CHANNEL_SIZE: usize = 10240;
 // Default is DropAndReport.
 // It is not desirable to have dropped logs in our use case.
 const SLOG_CHANNEL_OVERFLOW_STRATEGY: OverflowStrategy = OverflowStrategy::Block;

--- a/src/bin/util/setup.rs
+++ b/src/bin/util/setup.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 use slog::{Drain, Logger};
-use slog_async::Async;
+use slog_async::{Async, OverflowStrategy};
 use slog_term::{FullFormat, PlainDecorator, TermDecorator};
 use std::env;
 use std::io::BufWriter;
@@ -29,6 +29,12 @@ use tikv::util::logger;
 
 // A workaround for checking if log is initialized.
 pub static LOG_INITIALIZED: AtomicBool = ATOMIC_BOOL_INIT;
+// Default is 128.
+// Extended since blocking is set, and we don't want to block very often.
+const SLOG_CHANNEL_SIZE: usize = 2048;
+// Default is DropAndReport.
+// It is not desirable to have dropped logs in our use case.
+const SLOG_CHANNEL_OVERFLOW_STRATEGY: OverflowStrategy = OverflowStrategy::Block;
 
 macro_rules! fatal {
     ($lvl:expr, $($arg:tt)+) => ({
@@ -45,7 +51,11 @@ pub fn init_log(config: &TiKvConfig) {
     if config.log_file.is_empty() {
         let decorator = TermDecorator::new().build();
         let drain = FullFormat::new(decorator).build().fuse();
-        let drain = Async::new(drain).build().fuse();
+        let drain = Async::new(drain)
+            .chan_size(SLOG_CHANNEL_SIZE)
+            .overflow_strategy(SLOG_CHANNEL_OVERFLOW_STRATEGY)
+            .build()
+            .fuse();
         let logger = Logger::root_typed(drain, slog_o!());
         logger::init_log(logger, config.log_level).unwrap_or_else(|e| {
             fatal!("failed to initialize log: {:?}", e);


### PR DESCRIPTION
We found that the default size of 128 with DropAndReport creates some
problems for us when there is, for example, high region turnover.

This commit makes the channel (much) bigger and configures the channel
to block when overflowing instead of dropping things.

We discussed that there might be some slowdown with the logging itself but it was not the case.

What are the type of the changes? (mandatory)

- [ ] Feature
- [x] Improvement
- [ ] Bug fix
- [ ] Breaking Change

How has this PR been tested? (mandatory)

- [x] Ran `cargo build --features dev`
- [x] Ran `cargo fmt`
- [x] Ran `tikv-server` manually.

Does this PR affect documentation (docs/docs-cn) update? (mandatory)

- [ ] Yup
- [x] Nope

Does this PR affect tidb-ansible update? (mandatory)

- [ ] Yup
- [x] Nope

References:
- N/A

Benchmark Result:
- N/A

Examples/Additional Info:

> N/A

