### PR TITLE
*: remove unnecessary configs

### DIFF
--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -27,12 +27,10 @@ pub use storage::Config as StorageConfig;
 pub const DEFAULT_CLUSTER_ID: u64 = 0;
 pub const DEFAULT_LISTENING_ADDR: &str = "127.0.0.1:20160";
 const DEFAULT_ADVERTISE_LISTENING_ADDR: &str = "";
-const DEFAULT_NOTIFY_CAPACITY: usize = 40960;
 const DEFAULT_GRPC_CONCURRENCY: usize = 4;
 const DEFAULT_GRPC_CONCURRENT_STREAM: i32 = 1024;
 const DEFAULT_GRPC_RAFT_CONN_NUM: usize = 10;
 const DEFAULT_GRPC_STREAM_INITIAL_WINDOW_SIZE: u64 = 2 * 1024 * 1024;
-const DEFAULT_MESSAGES_PER_TICK: usize = 4096;
 
 // Number of rows in each chunk.
 pub const DEFAULT_ENDPOINT_BATCH_ROW_LIMIT: usize = 64;
@@ -61,8 +59,7 @@ pub struct Config {
     // Server advertise listening address for outer communication.
     // If not set, we will use listening address instead.
     pub advertise_addr: String,
-    pub notify_capacity: usize,
-    pub messages_per_tick: usize,
+
     // TODO: use CompressionAlgorithms instead once it supports traits like Clone etc.
     pub grpc_compression_type: GrpcCompressionType,
     pub grpc_concurrency: usize,
@@ -109,8 +106,6 @@ impl Default for Config {
             addr: DEFAULT_LISTENING_ADDR.to_owned(),
             labels: HashMap::default(),
             advertise_addr: DEFAULT_ADVERTISE_LISTENING_ADDR.to_owned(),
-            notify_capacity: DEFAULT_NOTIFY_CAPACITY,
-            messages_per_tick: DEFAULT_MESSAGES_PER_TICK,
             grpc_compression_type: GrpcCompressionType::None,
             grpc_concurrency: DEFAULT_GRPC_CONCURRENCY,
             grpc_concurrent_stream: DEFAULT_GRPC_CONCURRENT_STREAM,

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -22,7 +22,6 @@ pub const DEFAULT_ROCKSDB_SUB_DIR: &str = "db";
 const DEFAULT_GC_RATIO_THRESHOLD: f64 = 1.1;
 const DEFAULT_MAX_KEY_SIZE: usize = 4 * 1024;
 const DEFAULT_SCHED_CAPACITY: usize = 10240;
-const DEFAULT_SCHED_MSG_PER_TICK: usize = 1024;
 const DEFAULT_SCHED_CONCURRENCY: usize = 102400;
 
 // According to "Little's law", assuming you can write 100MB per
@@ -39,7 +38,6 @@ pub struct Config {
     pub gc_ratio_threshold: f64,
     pub max_key_size: usize,
     pub scheduler_notify_capacity: usize,
-    pub scheduler_messages_per_tick: usize,
     pub scheduler_concurrency: usize,
     pub scheduler_worker_pool_size: usize,
     pub scheduler_pending_write_threshold: ReadableSize,
@@ -53,7 +51,6 @@ impl Default for Config {
             gc_ratio_threshold: DEFAULT_GC_RATIO_THRESHOLD,
             max_key_size: DEFAULT_MAX_KEY_SIZE,
             scheduler_notify_capacity: DEFAULT_SCHED_CAPACITY,
-            scheduler_messages_per_tick: DEFAULT_SCHED_MSG_PER_TICK,
             scheduler_concurrency: DEFAULT_SCHED_CONCURRENCY,
             scheduler_worker_pool_size: if total_cpu >= 16 { 8 } else { 4 },
             scheduler_pending_write_threshold: ReadableSize::mb(DEFAULT_SCHED_PENDING_WRITE_MB),

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -60,8 +60,6 @@ fn test_serde_custom_tikv_config() {
         addr: "example.com:443".to_owned(),
         labels: map!{ "a".to_owned() => "b".to_owned() },
         advertise_addr: "example.com:443".to_owned(),
-        notify_capacity: 12_345,
-        messages_per_tick: 123,
         concurrent_send_snap_limit: 4,
         concurrent_recv_snap_limit: 4,
         grpc_compression_type: GrpcCompressionType::Gzip,

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -397,8 +397,6 @@ fn test_serde_custom_tikv_config() {
         gc_ratio_threshold: 1.2,
         max_key_size: 8192,
         scheduler_notify_capacity: 123,
-
-        scheduler_messages_per_tick: 123,
         scheduler_concurrency: 123,
         scheduler_worker_pool_size: 1,
         scheduler_pending_write_threshold: ReadableSize::kb(123),

--- a/tests/config/test-custom.toml
+++ b/tests/config/test-custom.toml
@@ -46,7 +46,6 @@ data-dir = "/var"
 gc-ratio-threshold = 1.2
 max-key-size = 8192
 scheduler-notify-capacity = 123
-scheduler-messages-per-tick = 123
 scheduler-concurrency = 123
 scheduler-worker-pool-size = 1
 scheduler-pending-write-threshold = "123KB"

--- a/tests/config/test-custom.toml
+++ b/tests/config/test-custom.toml
@@ -21,8 +21,6 @@ stack-size = "12MB"
 [server]
 addr = "example.com:443"
 advertise-addr = "example.com:443"
-notify-capacity = 12345
-messages-per-tick = 123
 grpc-compression-type = "gzip"
 grpc-concurrency = 123
 grpc-concurrent-stream = 1234


### PR DESCRIPTION
Notify and message per tick are not used in Server, we can remove them.

PTAL @BusyJay @overvenus 