### PR TITLE
rust has the same drop order with struct's members.

### DIFF
--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -109,8 +109,8 @@ impl Conn {
 
 /// `RaftClient` is used for sending raft messages to other stores.
 pub struct RaftClient {
-    env: Arc<Environment>,
     conns: HashMap<(String, usize), Conn>,
+    env: Arc<Environment>,
     pub addrs: HashMap<u64, String>,
     cfg: Arc<Config>,
     security_mgr: Arc<SecurityManager>,
@@ -193,12 +193,5 @@ impl RaftClient {
         if counter > 0 {
             RAFT_MESSAGE_FLUSH_COUNTER.inc_by(counter as i64);
         }
-    }
-}
-
-impl Drop for RaftClient {
-    fn drop(&mut self) {
-        // Drop conns here to make sure all streams are dropped before Environment.
-        self.conns.clear();
     }
 }


### PR DESCRIPTION
Example:
[playground](https://play.rust-lang.org/?gist=a845314b48f36d460f9d5d05ae40b525&version=stable&mode=debug)
