### PR TITLE
Utilize `perf_context`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#2a150c328125181f48e46b1f0a17c89f2f9b5e45"
+source = "git+https://github.com/pingcap/rust-rocksdb.git?rev=9a1c83c5382fbaee8a5102213c711bbe52d71470#9a1c83c5382fbaee8a5102213c711bbe52d71470"
 dependencies = [
  "bzip2-sys 0.1.6 (git+https://github.com/alexcrichton/bzip2-rs.git)",
  "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -946,11 +946,11 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#2a150c328125181f48e46b1f0a17c89f2f9b5e45"
+source = "git+https://github.com/pingcap/rust-rocksdb.git?rev=9a1c83c5382fbaee8a5102213c711bbe52d71470#9a1c83c5382fbaee8a5102213c711bbe52d71470"
 dependencies = [
  "crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "librocksdb_sys 0.1.0 (git+https://github.com/pingcap/rust-rocksdb.git)",
+ "librocksdb_sys 0.1.0 (git+https://github.com/pingcap/rust-rocksdb.git?rev=9a1c83c5382fbaee8a5102213c711bbe52d71470)",
 ]
 
 [[package]]
@@ -1259,7 +1259,7 @@ dependencies = [
  "raft 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.70 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocksdb 0.3.0 (git+https://github.com/pingcap/rust-rocksdb.git)",
+ "rocksdb 0.3.0 (git+https://github.com/pingcap/rust-rocksdb.git?rev=9a1c83c5382fbaee8a5102213c711bbe52d71470)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1590,7 +1590,7 @@ dependencies = [
 "checksum lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce12306c4739d86ee97c23139f3a34ddf0387bbf181bc7929d287025a8c3ef6b"
 "checksum libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "b685088df2b950fccadf07a7187c8ef846a959c142338a48f9dc0b94517eb5f1"
 "checksum libfuzzer-sys 0.1.0 (git+https://github.com/rust-fuzz/libfuzzer-sys.git)" = "<none>"
-"checksum librocksdb_sys 0.1.0 (git+https://github.com/pingcap/rust-rocksdb.git)" = "<none>"
+"checksum librocksdb_sys 0.1.0 (git+https://github.com/pingcap/rust-rocksdb.git?rev=9a1c83c5382fbaee8a5102213c711bbe52d71470)" = "<none>"
 "checksum libz-sys 1.0.18 (git+https://github.com/busyjay/libz-sys.git?branch=static-link)" = "<none>"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
@@ -1639,7 +1639,7 @@ dependencies = [
 "checksum regex-syntax 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "841591b1e05609a643e3b4d0045fce04f701daba7151ddcd3ad47b080693d5a9"
 "checksum regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9191b1f57603095f105d317e375d19b1c9c5c3185ea9633a99a6dcbed04457"
 "checksum regex-syntax 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b2550876c31dc914696a6c2e01cbce8afba79a93c8ae979d2fe051c0230b3756"
-"checksum rocksdb 0.3.0 (git+https://github.com/pingcap/rust-rocksdb.git)" = "<none>"
+"checksum rocksdb 0.3.0 (git+https://github.com/pingcap/rust-rocksdb.git?rev=9a1c83c5382fbaee8a5102213c711bbe52d71470)" = "<none>"
 "checksum rustc-demangle 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "662b2795f21ff17df7c4c50c1d955c8b5fa9eaddd1cf1bb32f8de2372ffd989b"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ git = "https://github.com/pingcap/murmur3.git"
 
 [dependencies.rocksdb]
 git = "https://github.com/pingcap/rust-rocksdb.git"
+rev = "9a1c83c5382fbaee8a5102213c711bbe52d71470"
 
 [dependencies.kvproto]
 git = "https://github.com/pingcap/kvproto.git"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@
 #![feature(box_syntax)]
 #![feature(integer_atomics)]
 #![feature(entry_or_default)]
+#![feature(optin_builtin_traits)]
 #![cfg_attr(feature = "dev", feature(plugin))]
 #![cfg_attr(feature = "dev", plugin(clippy))]
 #![cfg_attr(not(feature = "dev"), allow(unknown_lints))]

--- a/src/raftstore/store/region_snapshot.rs
+++ b/src/raftstore/store/region_snapshot.rs
@@ -532,39 +532,39 @@ mod tests {
         let mut statistics = CFStatistics::default();
         let mut iter = Cursor::new(Box::new(snap.iter(IterOption::default())), ScanMode::Mixed);
         assert!(
-            !iter.reverse_seek(&Key::from_encoded(b"a2".to_vec()), &mut statistics)
+            !iter.reverse_seek(&Key::from_encoded(b"a2".to_vec()), &mut statistics, None)
                 .unwrap()
         );
         assert!(
-            iter.reverse_seek(&Key::from_encoded(b"a7".to_vec()), &mut statistics)
+            iter.reverse_seek(&Key::from_encoded(b"a7".to_vec()), &mut statistics, None)
                 .unwrap()
         );
         let mut pair = (iter.key().to_vec(), iter.value().to_vec());
         assert_eq!(pair, (b"a5".to_vec(), b"v5".to_vec()));
         assert!(
-            iter.reverse_seek(&Key::from_encoded(b"a5".to_vec()), &mut statistics)
+            iter.reverse_seek(&Key::from_encoded(b"a5".to_vec()), &mut statistics, None)
                 .unwrap()
         );
         pair = (iter.key().to_vec(), iter.value().to_vec());
         assert_eq!(pair, (b"a3".to_vec(), b"v3".to_vec()));
         assert!(
-            !iter.reverse_seek(&Key::from_encoded(b"a3".to_vec()), &mut statistics)
+            !iter.reverse_seek(&Key::from_encoded(b"a3".to_vec()), &mut statistics, None)
                 .unwrap()
         );
         assert!(
-            iter.reverse_seek(&Key::from_encoded(b"a1".to_vec()), &mut statistics)
+            iter.reverse_seek(&Key::from_encoded(b"a1".to_vec()), &mut statistics, None)
                 .is_err()
         );
         assert!(
-            iter.reverse_seek(&Key::from_encoded(b"a8".to_vec()), &mut statistics)
+            iter.reverse_seek(&Key::from_encoded(b"a8".to_vec()), &mut statistics, None)
                 .is_err()
         );
 
-        assert!(iter.seek_to_last(&mut statistics));
+        assert!(iter.seek_to_last(&mut statistics, None));
         let mut res = vec![];
         loop {
             res.push((iter.key().to_vec(), iter.value().to_vec()));
-            if !iter.prev(&mut statistics) {
+            if !iter.prev(&mut statistics, None) {
                 break;
             }
         }
@@ -579,11 +579,11 @@ mod tests {
         let snap = RegionSnapshot::new(&store);
         let mut iter = Cursor::new(Box::new(snap.iter(IterOption::default())), ScanMode::Mixed);
         assert!(
-            !iter.reverse_seek(&Key::from_encoded(b"a1".to_vec()), &mut statistics)
+            !iter.reverse_seek(&Key::from_encoded(b"a1".to_vec()), &mut statistics, None)
                 .unwrap()
         );
         assert!(
-            iter.reverse_seek(&Key::from_encoded(b"a2".to_vec()), &mut statistics)
+            iter.reverse_seek(&Key::from_encoded(b"a2".to_vec()), &mut statistics, None)
                 .unwrap()
         );
         let pair = (iter.key().to_vec(), iter.value().to_vec());
@@ -591,7 +591,7 @@ mod tests {
         for kv_pairs in test_data.windows(2) {
             let seek_key = Key::from_encoded(kv_pairs[1].0.clone());
             assert!(
-                iter.reverse_seek(&seek_key, &mut statistics).unwrap(),
+                iter.reverse_seek(&seek_key, &mut statistics, None).unwrap(),
                 "{}",
                 seek_key
             );
@@ -599,11 +599,11 @@ mod tests {
             assert_eq!(pair, kv_pairs[0]);
         }
 
-        assert!(iter.seek_to_last(&mut statistics));
+        assert!(iter.seek_to_last(&mut statistics, None));
         let mut res = vec![];
         loop {
             res.push((iter.key().to_vec(), iter.value().to_vec()));
-            if !iter.prev(&mut statistics) {
+            if !iter.prev(&mut statistics, None) {
                 break;
             }
         }

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -34,7 +34,7 @@ mod rocksdb;
 
 use super::super::raftstore::store::engine::IterOption;
 
-use self::perf_context::PerfContextCollector;
+use self::perf_context::OptionTargetPerfContextCollector;
 pub use self::perf_context::PerfStatistics;
 
 // only used for rocksdb without persistent.
@@ -198,7 +198,6 @@ pub struct CFStatistics {
     pub seek_for_prev: usize,
     pub over_seek_bound: usize,
     pub flow_stats: FlowStatistics,
-    pub perf_stats: PerfStatistics,
 }
 
 #[derive(Default, Debug, Clone)]
@@ -242,7 +241,6 @@ impl CFStatistics {
         self.seek_for_prev = self.seek_for_prev.saturating_add(other.seek_for_prev);
         self.over_seek_bound = self.over_seek_bound.saturating_add(other.over_seek_bound);
         self.flow_stats.add(&other.flow_stats);
-        self.perf_stats.add(&other.perf_stats);
     }
 
     pub fn scan_info(&self) -> ScanInfo {
@@ -323,8 +321,16 @@ impl Cursor {
         }
     }
 
-    pub fn seek(&mut self, key: &Key, statistics: &mut CFStatistics) -> Result<bool> {
-        let _ = PerfContextCollector::new(&mut statistics.perf_stats);
+    pub fn seek(
+        &mut self,
+        key: &Key,
+        statistics: &mut CFStatistics,
+        perf_statistics: Option<&mut PerfStatistics>,
+    ) -> Result<bool> {
+        // According to tests, `Drop` will not always happen right before `return`. Instead,
+        // it may be earlier. So we manually drops the collector later in order to control its
+        // scope.
+        let collector = OptionTargetPerfContextCollector::new(perf_statistics);
 
         assert_ne!(self.scan_mode, ScanMode::Backward);
         if self.max_key.as_ref().map_or(false, |k| k <= key.encoded()) {
@@ -344,6 +350,8 @@ impl Cursor {
             self.max_key = Some(key.encoded().to_owned());
             return Ok(false);
         }
+
+        drop(collector);
         Ok(true)
     }
 
@@ -351,12 +359,17 @@ impl Cursor {
     ///
     /// This method assume the current position of cursor is
     /// around `key`, otherwise you should use `seek` instead.
-    pub fn near_seek(&mut self, key: &Key, statistics: &mut CFStatistics) -> Result<bool> {
-        let _ = PerfContextCollector::new(&mut statistics.perf_stats);
+    pub fn near_seek(
+        &mut self,
+        key: &Key,
+        statistics: &mut CFStatistics,
+        perf_statistics: Option<&mut PerfStatistics>,
+    ) -> Result<bool> {
+        let collector = OptionTargetPerfContextCollector::new(perf_statistics);
 
         assert_ne!(self.scan_mode, ScanMode::Backward);
         if !self.iter.valid() {
-            return self.seek(key, statistics);
+            return self.seek(key, statistics, None);
         }
         let ord = self.iter.key().cmp(key.encoded());
         if ord == Ordering::Equal
@@ -370,23 +383,23 @@ impl Cursor {
         }
         if ord == Ordering::Greater {
             near_loop!(
-                self.prev(statistics) && self.iter.key() > key.encoded().as_slice(),
-                self.seek(key, statistics),
+                self.prev(statistics, None) && self.iter.key() > key.encoded().as_slice(),
+                self.seek(key, statistics, None),
                 statistics
             );
             if self.iter.valid() {
                 if self.iter.key() < key.encoded().as_slice() {
-                    self.next(statistics);
+                    self.next(statistics, None);
                 }
             } else {
-                assert!(self.seek_to_first(statistics));
+                assert!(self.seek_to_first(statistics, None));
                 return Ok(true);
             }
         } else {
             // ord == Less
             near_loop!(
-                self.next(statistics) && self.iter.key() < key.encoded().as_slice(),
-                self.seek(key, statistics),
+                self.next(statistics, None) && self.iter.key() < key.encoded().as_slice(),
+                self.seek(key, statistics, None),
                 statistics
             );
         }
@@ -394,6 +407,8 @@ impl Cursor {
             self.max_key = Some(key.encoded().to_owned());
             return Ok(false);
         }
+
+        drop(collector);
         Ok(true)
     }
 
@@ -401,23 +416,35 @@ impl Cursor {
     ///
     /// This method assume the current position of cursor is
     /// around `key`, otherwise you should `seek` first.
-    pub fn get(&mut self, key: &Key, statistics: &mut CFStatistics) -> Result<Option<&[u8]>> {
-        let _ = PerfContextCollector::new(&mut statistics.perf_stats);
+    pub fn get(
+        &mut self,
+        key: &Key,
+        statistics: &mut CFStatistics,
+        perf_statistics: Option<&mut PerfStatistics>,
+    ) -> Result<Option<&[u8]>> {
+        let collector = OptionTargetPerfContextCollector::new(perf_statistics);
 
         if self.scan_mode != ScanMode::Backward {
-            if self.near_seek(key, statistics)? && self.iter.key() == &**key.encoded() {
+            if self.near_seek(key, statistics, None)? && self.iter.key() == &**key.encoded() {
                 return Ok(Some(self.iter.value()));
             }
             return Ok(None);
         }
-        if self.near_seek_for_prev(key, statistics)? && self.iter.key() == &**key.encoded() {
+        if self.near_seek_for_prev(key, statistics, None)? && self.iter.key() == &**key.encoded() {
             return Ok(Some(self.iter.value()));
         }
+
+        drop(collector);
         Ok(None)
     }
 
-    fn seek_for_prev(&mut self, key: &Key, statistics: &mut CFStatistics) -> Result<bool> {
-        let _ = PerfContextCollector::new(&mut statistics.perf_stats);
+    fn seek_for_prev(
+        &mut self,
+        key: &Key,
+        statistics: &mut CFStatistics,
+        perf_statistics: Option<&mut PerfStatistics>,
+    ) -> Result<bool> {
+        let collector = OptionTargetPerfContextCollector::new(perf_statistics);
 
         assert_ne!(self.scan_mode, ScanMode::Forward);
         if self.min_key.as_ref().map_or(false, |k| k >= key.encoded()) {
@@ -436,16 +463,23 @@ impl Cursor {
             self.min_key = Some(key.encoded().to_owned());
             return Ok(false);
         }
+
+        drop(collector);
         Ok(true)
     }
 
     /// Find the largest key that is not greater than the specific key.
-    pub fn near_seek_for_prev(&mut self, key: &Key, statistics: &mut CFStatistics) -> Result<bool> {
-        let _ = PerfContextCollector::new(&mut statistics.perf_stats);
+    pub fn near_seek_for_prev(
+        &mut self,
+        key: &Key,
+        statistics: &mut CFStatistics,
+        perf_statistics: Option<&mut PerfStatistics>,
+    ) -> Result<bool> {
+        let collector = OptionTargetPerfContextCollector::new(perf_statistics);
 
         assert_ne!(self.scan_mode, ScanMode::Forward);
         if !self.iter.valid() {
-            return self.seek_for_prev(key, statistics);
+            return self.seek_for_prev(key, statistics, None);
         }
         let ord = self.iter.key().cmp(key.encoded());
         if ord == Ordering::Equal || (self.scan_mode == ScanMode::Backward && ord == Ordering::Less)
@@ -460,22 +494,22 @@ impl Cursor {
 
         if ord == Ordering::Less {
             near_loop!(
-                self.next(statistics) && self.iter.key() < key.encoded().as_slice(),
-                self.seek_for_prev(key, statistics),
+                self.next(statistics, None) && self.iter.key() < key.encoded().as_slice(),
+                self.seek_for_prev(key, statistics, None),
                 statistics
             );
             if self.iter.valid() {
                 if self.iter.key() > key.encoded().as_slice() {
-                    self.prev(statistics);
+                    self.prev(statistics, None);
                 }
             } else {
-                assert!(self.seek_to_last(statistics));
+                assert!(self.seek_to_last(statistics, None));
                 return Ok(true);
             }
         } else {
             near_loop!(
-                self.prev(statistics) && self.iter.key() > key.encoded().as_slice(),
-                self.seek_for_prev(key, statistics),
+                self.prev(statistics, None) && self.iter.key() > key.encoded().as_slice(),
+                self.seek_for_prev(key, statistics, None),
                 statistics
             );
         }
@@ -484,22 +518,30 @@ impl Cursor {
             self.min_key = Some(key.encoded().to_owned());
             return Ok(false);
         }
+
+        drop(collector);
         Ok(true)
     }
 
-    pub fn reverse_seek(&mut self, key: &Key, statistics: &mut CFStatistics) -> Result<bool> {
-        let _ = PerfContextCollector::new(&mut statistics.perf_stats);
+    pub fn reverse_seek(
+        &mut self,
+        key: &Key,
+        statistics: &mut CFStatistics,
+        perf_statistics: Option<&mut PerfStatistics>,
+    ) -> Result<bool> {
+        let collector = OptionTargetPerfContextCollector::new(perf_statistics);
 
-        if !self.seek_for_prev(key, statistics)? {
+        if !self.seek_for_prev(key, statistics, None)? {
             return Ok(false);
         }
 
         if self.iter.key() == &**key.encoded() {
             // should not update min_key here. otherwise reverse_seek_le may not
             // work as expected.
-            return Ok(self.prev(statistics));
+            return Ok(self.prev(statistics, None));
         }
 
+        drop(collector);
         Ok(true)
     }
 
@@ -507,17 +549,23 @@ impl Cursor {
     ///
     /// This method assume the current position of cursor is
     /// around `key`, otherwise you should use `reverse_seek` instead.
-    pub fn near_reverse_seek(&mut self, key: &Key, statistics: &mut CFStatistics) -> Result<bool> {
-        let _ = PerfContextCollector::new(&mut statistics.perf_stats);
+    pub fn near_reverse_seek(
+        &mut self,
+        key: &Key,
+        statistics: &mut CFStatistics,
+        perf_statistics: Option<&mut PerfStatistics>,
+    ) -> Result<bool> {
+        let collector = OptionTargetPerfContextCollector::new(perf_statistics);
 
-        if !self.near_seek_for_prev(key, statistics)? {
+        if !self.near_seek_for_prev(key, statistics, None)? {
             return Ok(false);
         }
 
         if self.iter.key() == &**key.encoded() {
-            return Ok(self.prev(statistics));
+            return Ok(self.prev(statistics, None));
         }
 
+        drop(collector);
         Ok(true)
     }
 
@@ -532,43 +580,79 @@ impl Cursor {
     }
 
     #[inline]
-    pub fn seek_to_first(&mut self, statistics: &mut CFStatistics) -> bool {
-        let _ = PerfContextCollector::new(&mut statistics.perf_stats);
+    pub fn seek_to_first(
+        &mut self,
+        statistics: &mut CFStatistics,
+        perf_statistics: Option<&mut PerfStatistics>,
+    ) -> bool {
+        let collector = OptionTargetPerfContextCollector::new(perf_statistics);
 
         statistics.seek += 1;
-        self.iter.seek_to_first()
+        let result = self.iter.seek_to_first();
+
+        drop(collector);
+        result
     }
 
     #[inline]
-    pub fn seek_to_last(&mut self, statistics: &mut CFStatistics) -> bool {
-        let _ = PerfContextCollector::new(&mut statistics.perf_stats);
+    pub fn seek_to_last(
+        &mut self,
+        statistics: &mut CFStatistics,
+        perf_statistics: Option<&mut PerfStatistics>,
+    ) -> bool {
+        let collector = OptionTargetPerfContextCollector::new(perf_statistics);
 
         statistics.seek += 1;
-        self.iter.seek_to_last()
+        let result = self.iter.seek_to_last();
+
+        drop(collector);
+        result
     }
 
     #[inline]
-    pub fn internal_seek(&mut self, key: &Key, statistics: &mut CFStatistics) -> Result<bool> {
-        let _ = PerfContextCollector::new(&mut statistics.perf_stats);
+    pub fn internal_seek(
+        &mut self,
+        key: &Key,
+        statistics: &mut CFStatistics,
+        perf_statistics: Option<&mut PerfStatistics>,
+    ) -> Result<bool> {
+        let collector = OptionTargetPerfContextCollector::new(perf_statistics);
 
         statistics.seek += 1;
-        self.iter.seek(key)
+        let result = self.iter.seek(key);
+
+        drop(collector);
+        result
     }
 
     #[inline]
-    pub fn next(&mut self, statistics: &mut CFStatistics) -> bool {
-        let _ = PerfContextCollector::new(&mut statistics.perf_stats);
+    pub fn next(
+        &mut self,
+        statistics: &mut CFStatistics,
+        perf_statistics: Option<&mut PerfStatistics>,
+    ) -> bool {
+        let collector = OptionTargetPerfContextCollector::new(perf_statistics);
 
         statistics.next += 1;
-        self.iter.next()
+        let result = self.iter.next();
+
+        drop(collector);
+        result
     }
 
     #[inline]
-    pub fn prev(&mut self, statistics: &mut CFStatistics) -> bool {
-        let _ = PerfContextCollector::new(&mut statistics.perf_stats);
+    pub fn prev(
+        &mut self,
+        statistics: &mut CFStatistics,
+        perf_statistics: Option<&mut PerfStatistics>,
+    ) -> bool {
+        let collector = OptionTargetPerfContextCollector::new(perf_statistics);
 
         statistics.prev += 1;
-        self.iter.prev()
+        let result = self.iter.prev();
+
+        drop(collector);
+        result
     }
 
     #[inline]
@@ -679,6 +763,77 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_statistics() {
+        let dir = TempDir::new("rocksdb_statistics_test").unwrap();
+        let engine = new_local_engine(dir.path().to_str().unwrap(), TEST_ENGINE_CFS).unwrap();
+        let e = engine.as_ref();
+
+        must_put(e, b"foo", b"bar1");
+        must_put(e, b"foo2", b"bar2");
+        must_put(e, b"foo3", b"bar3"); // deleted
+        must_put(e, b"foo4", b"bar4");
+        must_put(e, b"foo42", b"bar42"); // deleted
+        must_put(e, b"foo5", b"bar5"); // deleted
+        must_put(e, b"foo6", b"bar6");
+        must_delete(e, b"foo3");
+        must_delete(e, b"foo42");
+        must_delete(e, b"foo5");
+
+        let snapshot = e.snapshot(&Context::new()).unwrap();
+        let mut iter = snapshot
+            .iter(IterOption::default(), ScanMode::Forward)
+            .unwrap();
+
+        let mut statistics = CFStatistics::default();
+        let mut perf_statistics = PerfStatistics::default();
+        iter.seek(
+            &make_key(b"foo30"),
+            &mut statistics,
+            Some(&mut perf_statistics),
+        ).unwrap();
+
+        assert_eq!(iter.key(), &*bytes::encode_bytes(b"foo4"));
+        assert_eq!(iter.value(), b"bar4");
+        assert_eq!(statistics.seek, 1);
+        assert_eq!(perf_statistics.internal_delete_skipped_count, 0);
+
+        let mut statistics = CFStatistics::default();
+        let mut perf_statistics = PerfStatistics::default();
+        iter.near_seek(
+            &make_key(b"foo55"),
+            &mut statistics,
+            Some(&mut perf_statistics),
+        ).unwrap();
+
+        assert_eq!(iter.key(), &*bytes::encode_bytes(b"foo6"));
+        assert_eq!(iter.value(), b"bar6");
+        assert_eq!(statistics.seek, 0);
+        assert_eq!(statistics.next, 1);
+        assert_eq!(perf_statistics.internal_delete_skipped_count, 2);
+
+        let mut statistics = CFStatistics::default();
+        let mut perf_statistics = PerfStatistics::default();
+        iter.prev(&mut statistics, Some(&mut perf_statistics));
+
+        assert_eq!(iter.key(), &*bytes::encode_bytes(b"foo4"));
+        assert_eq!(iter.value(), b"bar4");
+        assert_eq!(statistics.prev, 1);
+        assert_eq!(perf_statistics.internal_delete_skipped_count, 2);
+
+        iter.prev(&mut statistics, Some(&mut perf_statistics));
+        assert_eq!(iter.key(), &*bytes::encode_bytes(b"foo2"));
+        assert_eq!(iter.value(), b"bar2");
+        assert_eq!(statistics.prev, 2);
+        assert_eq!(perf_statistics.internal_delete_skipped_count, 3);
+
+        iter.prev(&mut statistics, Some(&mut perf_statistics));
+        assert_eq!(iter.key(), &*bytes::encode_bytes(b"foo"));
+        assert_eq!(iter.value(), b"bar1");
+        assert_eq!(statistics.prev, 3);
+        assert_eq!(perf_statistics.internal_delete_skipped_count, 3);
+    }
+
     fn must_put(engine: &Engine, key: &[u8], value: &[u8]) {
         engine
             .put(&Context::new(), make_key(key), value.to_vec())
@@ -695,7 +850,7 @@ mod tests {
         engine.delete(&Context::new(), make_key(key)).unwrap();
     }
 
-    fn muest_delete_cf(engine: &Engine, cf: CfName, key: &[u8]) {
+    fn must_delete_cf(engine: &Engine, cf: CfName, key: &[u8]) {
         engine
             .delete_cf(&Context::new(), cf, make_key(key))
             .unwrap();
@@ -727,7 +882,7 @@ mod tests {
             .iter(IterOption::default(), ScanMode::Mixed)
             .unwrap();
         let mut statistics = CFStatistics::default();
-        iter.seek(&make_key(key), &mut statistics).unwrap();
+        iter.seek(&make_key(key), &mut statistics, None).unwrap();
         assert_eq!(
             (iter.key(), iter.value()),
             (&*bytes::encode_bytes(pair.0), pair.1)
@@ -740,7 +895,8 @@ mod tests {
             .iter(IterOption::default(), ScanMode::Mixed)
             .unwrap();
         let mut statistics = CFStatistics::default();
-        iter.reverse_seek(&make_key(key), &mut statistics).unwrap();
+        iter.reverse_seek(&make_key(key), &mut statistics, None)
+            .unwrap();
         assert_eq!(
             (iter.key(), iter.value()),
             (&*bytes::encode_bytes(pair.0), pair.1)
@@ -750,7 +906,9 @@ mod tests {
     fn assert_near_seek(cursor: &mut Cursor, key: &[u8], pair: (&[u8], &[u8])) {
         let mut statistics = CFStatistics::default();
         assert!(
-            cursor.near_seek(&make_key(key), &mut statistics).unwrap(),
+            cursor
+                .near_seek(&make_key(key), &mut statistics, None)
+                .unwrap(),
             escape(key)
         );
         assert_eq!(
@@ -763,7 +921,7 @@ mod tests {
         let mut statistics = CFStatistics::default();
         assert!(
             cursor
-                .near_reverse_seek(&make_key(key), &mut statistics)
+                .near_reverse_seek(&make_key(key), &mut statistics, None)
                 .unwrap(),
             escape(key)
         );
@@ -822,8 +980,10 @@ mod tests {
             .iter(IterOption::default(), ScanMode::Mixed)
             .unwrap();
         let mut statistics = CFStatistics::default();
-        assert!(!iter.seek(&make_key(b"z\x00"), &mut statistics).unwrap());
-        assert!(!iter.reverse_seek(&make_key(b"x"), &mut statistics).unwrap());
+        assert!(!iter.seek(&make_key(b"z\x00"), &mut statistics, None)
+            .unwrap());
+        assert!(!iter.reverse_seek(&make_key(b"x"), &mut statistics, None)
+            .unwrap());
         must_delete(engine, b"x");
         must_delete(engine, b"z");
     }
@@ -843,7 +1003,7 @@ mod tests {
         assert_near_seek(&mut cursor, b"x\x00", (b"z", b"2"));
         let mut statistics = CFStatistics::default();
         assert!(!cursor
-            .near_seek(&make_key(b"z\x00"), &mut statistics)
+            .near_seek(&make_key(b"z\x00"), &mut statistics, None)
             .unwrap());
         // Insert many key-values between 'x' and 'z' then near_seek will fallback to seek.
         for i in 0..super::SEEK_BOUND {
@@ -872,24 +1032,30 @@ mod tests {
             .unwrap();
         let mut statistics = CFStatistics::default();
         assert!(!cursor
-            .near_reverse_seek(&make_key(b"x"), &mut statistics)
+            .near_reverse_seek(&make_key(b"x"), &mut statistics, None)
             .unwrap());
         assert!(!cursor
-            .near_reverse_seek(&make_key(b"z"), &mut statistics)
+            .near_reverse_seek(&make_key(b"z"), &mut statistics, None)
             .unwrap());
         assert!(!cursor
-            .near_reverse_seek(&make_key(b"w"), &mut statistics)
+            .near_reverse_seek(&make_key(b"w"), &mut statistics, None)
             .unwrap());
-        assert!(!cursor.near_seek(&make_key(b"x"), &mut statistics).unwrap());
-        assert!(!cursor.near_seek(&make_key(b"z"), &mut statistics).unwrap());
-        assert!(!cursor.near_seek(&make_key(b"w"), &mut statistics).unwrap());
+        assert!(!cursor
+            .near_seek(&make_key(b"x"), &mut statistics, None)
+            .unwrap());
+        assert!(!cursor
+            .near_seek(&make_key(b"z"), &mut statistics, None)
+            .unwrap());
+        assert!(!cursor
+            .near_seek(&make_key(b"w"), &mut statistics, None)
+            .unwrap());
     }
 
     macro_rules! assert_seek {
         ($cursor:ident, $func:ident, $k:expr, $res:ident) => {{
             let mut statistics = CFStatistics::default();
             assert_eq!(
-                $cursor.$func(&$k, &mut statistics).unwrap(),
+                $cursor.$func(&$k, &mut statistics, None).unwrap(),
                 $res.is_some(),
                 "assert_seek {} failed exp {:?}",
                 $k,
@@ -1035,7 +1201,7 @@ mod tests {
         assert_none_cf(engine, "cf", b"key");
         must_put_cf(engine, "cf", b"key", b"value");
         assert_has_cf(engine, "cf", b"key", b"value");
-        muest_delete_cf(engine, "cf", b"key");
+        must_delete_cf(engine, "cf", b"key");
         assert_none_cf(engine, "cf", b"key");
     }
 

--- a/src/storage/engine/perf_context.rs
+++ b/src/storage/engine/perf_context.rs
@@ -1,0 +1,124 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocksdb::PerfContext;
+
+/// Store statistics we need. Data comes from RocksDB's `PerfContext` via `PerfContextCollector`.
+/// Depends on different contexts, it may either store absolute values (i.e. statistics since
+/// thread creation), or relative values (i.e. statistics delta).
+#[derive(Default, Clone, Debug, Copy)]
+pub struct PerfStatistics {
+    /// Whether values stored in this instance is absolute or not (i.e. relative).
+    /// By default, `PerfStatistics` stores (relative) 0 values.
+    /// TODO: Use const generics (RFC #2000) once it is available to make it safe in compile time
+    /// instead of runtime.
+    absolute: bool,
+
+    pub internal_key_skipped_count: usize,
+    pub internal_delete_skipped_count: usize,
+    pub block_cache_hit_count: usize,
+    pub block_read_count: usize,
+    pub block_read_byte: usize,
+}
+
+impl PerfStatistics {
+    /// Add statistics of another instance into the current one. This operation is valid
+    /// only if both instances store relative values.
+    pub fn add(&mut self, other: &Self) {
+        assert!(!self.absolute);
+        assert!(!other.absolute);
+        self.internal_key_skipped_count = self.internal_key_skipped_count
+            .saturating_add(other.internal_key_skipped_count);
+        self.internal_delete_skipped_count = self.internal_delete_skipped_count
+            .saturating_add(other.internal_delete_skipped_count);
+        self.block_cache_hit_count = self.block_cache_hit_count
+            .saturating_add(other.block_cache_hit_count);
+        self.block_read_count = self.block_read_count.saturating_add(other.block_read_count);
+        self.block_read_byte = self.block_read_byte.saturating_add(other.block_read_byte);
+    }
+
+    /// Calculates delta statistics from two instances storing absolute values. `other`
+    /// must contain statistics later then `self`, otherwise the behavior is undefined.
+    fn get_delta(&self, other: &Self) -> PerfStatistics {
+        assert!(self.absolute);
+        assert!(other.absolute);
+        PerfStatistics {
+            absolute: false,
+            internal_key_skipped_count: other.internal_key_skipped_count
+                - self.internal_key_skipped_count,
+            internal_delete_skipped_count: other.internal_delete_skipped_count
+                - self.internal_delete_skipped_count,
+            block_cache_hit_count: other.block_cache_hit_count - self.block_cache_hit_count,
+            block_read_count: other.block_read_count - self.block_read_count,
+            block_read_byte: other.block_read_byte - self.block_read_byte,
+        }
+    }
+
+    /// Create an instance which stores absolute statistics values, retrieved at creation.
+    fn new(perf_context: &PerfContext) -> PerfStatistics {
+        PerfStatistics {
+            absolute: true,
+            internal_key_skipped_count: perf_context.internal_key_skipped_count() as usize,
+            internal_delete_skipped_count: perf_context.internal_delete_skipped_count() as usize,
+            block_cache_hit_count: perf_context.block_cache_hit_count() as usize,
+            block_read_count: perf_context.block_read_count() as usize,
+            block_read_byte: perf_context.block_read_byte() as usize,
+        }
+    }
+
+    pub fn is_absolute(&self) -> bool {
+        self.absolute
+    }
+}
+
+/// Helper to collect RocksDB's `PerfContext`. This struct records the statistics at creation,
+/// and updates delta to the `collect_target` when it is dropped.
+#[must_use = "You must keep the collector live in the scope, otherwise it won't collect anything!"]
+pub struct PerfContextCollector<'a> {
+    collect_target: &'a mut PerfStatistics,
+    perf_context: PerfContext,
+
+    /// Absolute statistics values retrieved at creation.
+    perf: PerfStatistics,
+}
+
+impl<'a> PerfContextCollector<'a> {
+    pub fn new(collect_target: &'a mut PerfStatistics) -> PerfContextCollector<'a> {
+        let perf_context = PerfContext::get();
+        let perf = PerfStatistics::new(&perf_context);
+        PerfContextCollector {
+            collect_target,
+            perf_context,
+            perf,
+        }
+    }
+
+    /// Get delta statistics since instance creation.
+    pub fn collect(&self) -> PerfStatistics {
+        let current_perf = PerfStatistics::new(&self.perf_context);
+        self.perf.get_delta(&current_perf)
+    }
+}
+
+impl<'a> Drop for PerfContextCollector<'a> {
+    fn drop(&mut self) {
+        let statistics = self.collect();
+        self.collect_target.add(&statistics);
+    }
+}
+
+/// RocksDB's `PerfContext` is thread local. If we send `PerfContextCollector` to another thread,
+/// we will get incorrect delta values, so it is `!Send` and `!Sync`.
+impl<'a> !Send for PerfContextCollector<'a> {}
+
+impl<'a> !Sync for PerfContextCollector<'a> {}

--- a/src/storage/engine/perf_context.rs
+++ b/src/storage/engine/perf_context.rs
@@ -87,7 +87,6 @@ impl PerfStatistics {
 pub struct PerfContextCollector<'a> {
     collect_target: &'a mut PerfStatistics,
     perf_context: PerfContext,
-
     /// Absolute statistics values retrieved at creation.
     perf: PerfStatistics,
 }
@@ -122,3 +121,23 @@ impl<'a> Drop for PerfContextCollector<'a> {
 impl<'a> !Send for PerfContextCollector<'a> {}
 
 impl<'a> !Sync for PerfContextCollector<'a> {}
+
+/// A wrapper of `PerfContextCollector` to deal with optional targets. If the collecting target
+/// is `None`, there will be no overheads.
+pub enum OptionTargetPerfContextCollector<'a> {
+    SomeTarget(PerfContextCollector<'a>),
+    EmptyTarget,
+}
+
+impl<'a> OptionTargetPerfContextCollector<'a> {
+    pub fn new(
+        collect_target: Option<&'a mut PerfStatistics>,
+    ) -> OptionTargetPerfContextCollector<'a> {
+        match collect_target {
+            Some(collect_target) => OptionTargetPerfContextCollector::SomeTarget(
+                PerfContextCollector::new(collect_target),
+            ),
+            None => OptionTargetPerfContextCollector::EmptyTarget,
+        }
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1130,7 +1130,7 @@ impl Storage {
             option.set_upper_bound(end.encoded().clone());
         }
         let mut cursor = snapshot.iter_cf(Storage::rawkv_cf(cf)?, option, ScanMode::Forward)?;
-        if !cursor.seek(start_key, &mut stats.data)? {
+        if !cursor.seek(start_key, &mut stats.data, None)? {
             return Ok(vec![]);
         }
         let mut pairs = vec![];
@@ -1143,7 +1143,7 @@ impl Storage {
                     cursor.value().to_owned()
                 },
             )));
-            cursor.next(&mut stats.data);
+            cursor.next(&mut stats.data, None);
         }
         Ok(pairs)
     }

--- a/tests/storage_cases/test_raftkv.rs
+++ b/tests/storage_cases/test_raftkv.rs
@@ -176,7 +176,7 @@ fn assert_seek(ctx: &Context, engine: &Engine, key: &[u8], pair: (&[u8], &[u8]))
         .iter(IterOption::default(), ScanMode::Mixed)
         .unwrap();
     let mut statistics = CFStatistics::default();
-    iter.seek(&make_key(key), &mut statistics).unwrap();
+    iter.seek(&make_key(key), &mut statistics, None).unwrap();
     assert_eq!(
         (iter.key(), iter.value()),
         (&*bytes::encode_bytes(pair.0), pair.1)
@@ -189,7 +189,7 @@ fn assert_seek_cf(ctx: &Context, engine: &Engine, cf: CfName, key: &[u8], pair: 
         .iter_cf(cf, IterOption::default(), ScanMode::Mixed)
         .unwrap();
     let mut statistics = CFStatistics::default();
-    iter.seek(&make_key(key), &mut statistics).unwrap();
+    iter.seek(&make_key(key), &mut statistics, None).unwrap();
     assert_eq!(
         (iter.key(), iter.value()),
         (&*bytes::encode_bytes(pair.0), pair.1)
@@ -199,7 +199,9 @@ fn assert_seek_cf(ctx: &Context, engine: &Engine, cf: CfName, key: &[u8], pair: 
 fn assert_near_seek(cursor: &mut Cursor, key: &[u8], pair: (&[u8], &[u8])) {
     let mut statistics = CFStatistics::default();
     assert!(
-        cursor.near_seek(&make_key(key), &mut statistics).unwrap(),
+        cursor
+            .near_seek(&make_key(key), &mut statistics, None)
+            .unwrap(),
         escape(key)
     );
     assert_eq!(
@@ -212,7 +214,7 @@ fn assert_near_reverse_seek(cursor: &mut Cursor, key: &[u8], pair: (&[u8], &[u8]
     let mut statistics = CFStatistics::default();
     assert!(
         cursor
-            .near_reverse_seek(&make_key(key), &mut statistics)
+            .near_reverse_seek(&make_key(key), &mut statistics, None)
             .unwrap(),
         escape(key)
     );
@@ -268,7 +270,8 @@ fn seek(ctx: &Context, engine: &Engine) {
         .iter(IterOption::default(), ScanMode::Mixed)
         .unwrap();
     let mut statistics = CFStatistics::default();
-    assert!(!iter.seek(&make_key(b"z\x00"), &mut statistics).unwrap());
+    assert!(!iter.seek(&make_key(b"z\x00"), &mut statistics, None)
+        .unwrap());
     must_delete(ctx, engine, b"x");
     must_delete(ctx, engine, b"z");
 }
@@ -288,7 +291,7 @@ fn near_seek(ctx: &Context, engine: &Engine) {
     assert_near_seek(&mut cursor, b"x\x00", (b"z", b"2"));
     let mut statistics = CFStatistics::default();
     assert!(!cursor
-        .near_seek(&make_key(b"z\x00"), &mut statistics)
+        .near_seek(&make_key(b"z\x00"), &mut statistics, None)
         .unwrap());
     must_delete(ctx, engine, b"x");
     must_delete(ctx, engine, b"z");


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/pingcap/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

rust-rocksdb exposed `perf_context` [recently](https://github.com/pingcap/rust-rocksdb/pull/210). We can utilize `perf_context` to make it easy to diagnosis slow read issues related to tombstones.

This PR adds the ability to provide `perf_context` statistics for the Cursor. Later PRs will report statistics to the metrics in Coprocessor and Storage module.

- [x] Basic Impl
- [x] Test
- [ ] Benchmark (coming soon!)

## FAQ:

1. Why not integrate `PerfStatistics` into `CFStatistics`, for example, become one of its field?

   Note that the collector needs a `&mut PerfStatistics` in order to write statistics.

   So, if `PerfStatistics` is part of `CFStatistics`, there will be `&mut` violations: one is `&mut some_cf_statistics`, one is `&mut some_cf_statistics.perf_statistics`, which won't work.

2. Why `Cursor` accepts an optional `PerfStatistics`, i.e. `Option<PerfStatistics>`, unlike `CFStatistics`?

   Consider following scenario, `Cursor.get()`:

   ```
   Cursor.get
       Cursor.near_seek
           Cursor.seek
               Iterator.seek
           Cursor.next
               Iterator.next
       Cursor.near_seek_for_prev
       ...
   ```

   We record the count at the beginning of `Cursor.get()`, and record the count at the end of `Cursor.get()`, like this (pseudo code):

   ```
   Cursor.get
       perf_statistics = current_statistics();
       Cursor.near_seek
           Cursor.seek
               Iterator.seek
           Cursor.next
               Iterator.next
       Cursor.near_seek_for_prev
       ...
       delta_perf_statistics = current_statistics() - perf_statistics();
       add_perf_statistics(delta_perf_statistics);
   ```

   In this pattern, inner functions, like `Cursor.near_seek` should **NOT** contribute to perf_statistics again. Otherwise counters will be counted for multiple times.

   As you can see, naturally, we have two usages, one we collect perf statistics, one we don't.

3. Why not embed `PerfContextCollector` as a field of `Cursor`, and retrieve it for once after an operation?

   Good idea! But, `PerfContextCollector` is `!Send` && `!Sync`, so we cannot put it into a `Cursor: Send + Sync`, otherwise `Send + Sync` will break.

4. Why is `PerfContextCollector` not `Send` and not `Sync`?

   Because RocksDB's PerfContext is thread local.

## What are the type of the changes? (mandatory)

- New feature (non-breaking change which adds functionality)

## How has this PR been tested? (mandatory)

Unit test has been added to verify that we can actually get the perf values.

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No. Metrics will not be changed in this PR.

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

Work in progress.

## Add a few positive/negative examples (optional)

