### PR TITLE
import: add PrepareJob to split and scatter regions

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -469,8 +469,6 @@
 # key-path = ""
 
 [import]
-# the directory to store importing kv data.
-# import-dir = "/tmp/tikv/import"
 # number of threads to handle RPC requests.
 # num-threads = 8
 # stream channel window size, stream will be blocked on channel full.

--- a/etc/tikv-importer.toml
+++ b/etc/tikv-importer.toml
@@ -41,5 +41,11 @@ compression-per-level = ["lz4", "no", "no", "no", "no", "no", "zstd"]
 import-dir = "/tmp/tikv/import"
 # number of threads to handle RPC requests.
 num-threads = 16
+# number of concurrent import jobs.
+num-import-jobs = 24
+# maximum duration to prepare regions.
+# max-prepare-duration = "5m"
+# split regions into this size according to the importing data.
+# region-split-size = "96MB"
 # stream channel window size, stream will be blocked on channel full.
-stream-channel-window = 128
+# stream-channel-window = 128

--- a/src/import/client.rs
+++ b/src/import/client.rs
@@ -1,0 +1,26 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use kvproto::kvrpcpb::*;
+
+use pd::RegionInfo;
+
+use super::Result;
+
+pub trait ImportClient: Send + Sync + Clone + 'static {
+    fn get_region(&self, _: &[u8]) -> Result<RegionInfo>;
+
+    fn split_region(&self, _: &RegionInfo, _: &[u8]) -> Result<SplitRegionResponse>;
+
+    fn scatter_region(&self, _: &RegionInfo) -> Result<()>;
+}

--- a/src/import/common.rs
+++ b/src/import/common.rs
@@ -1,0 +1,205 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ops::Deref;
+use std::sync::Arc;
+
+use kvproto::import_sstpb::*;
+use kvproto::kvrpcpb::*;
+use kvproto::metapb::*;
+
+use pd::RegionInfo;
+
+use super::client::*;
+
+// Just used as a mark, don't use them in comparison.
+pub const RANGE_MIN: &[u8] = &[];
+pub const RANGE_MAX: &[u8] = &[];
+
+pub fn new_range(start: &[u8], end: &[u8]) -> Range {
+    let mut range = Range::new();
+    range.set_start(start.to_owned());
+    range.set_end(end.to_owned());
+    range
+}
+
+pub fn before_end(key: &[u8], end: &[u8]) -> bool {
+    key < end || end == RANGE_MAX
+}
+
+pub fn inside_region(key: &[u8], region: &Region) -> bool {
+    key >= region.get_start_key() && before_end(key, region.get_end_key())
+}
+
+#[derive(Clone, Debug)]
+pub struct RangeInfo {
+    pub range: Range,
+    pub size: usize,
+}
+
+impl RangeInfo {
+    pub fn new(start: &[u8], end: &[u8], size: usize) -> RangeInfo {
+        RangeInfo {
+            range: new_range(start, end),
+            size,
+        }
+    }
+}
+
+impl Deref for RangeInfo {
+    type Target = Range;
+
+    fn deref(&self) -> &Self::Target {
+        &self.range
+    }
+}
+
+pub struct RangeContext<Client> {
+    client: Arc<Client>,
+    region: Option<RegionInfo>,
+    raw_size: usize,
+    limit_size: usize,
+}
+
+impl<Client: ImportClient> RangeContext<Client> {
+    pub fn new(client: Arc<Client>, limit_size: usize) -> RangeContext<Client> {
+        RangeContext {
+            client,
+            region: None,
+            raw_size: 0,
+            limit_size,
+        }
+    }
+
+    pub fn add(&mut self, size: usize) {
+        self.raw_size += size;
+    }
+
+    /// Reset size and region for the next key.
+    pub fn reset(&mut self, key: &[u8]) {
+        self.raw_size = 0;
+        if let Some(ref region) = self.region {
+            if before_end(key, region.get_end_key()) {
+                // Still belongs in this region, no need to update.
+                return;
+            }
+        }
+        self.region = match self.client.get_region(key) {
+            Ok(region) => Some(region),
+            Err(e) => {
+                error!("get region: {:?}", e);
+                None
+            }
+        }
+    }
+
+    pub fn raw_size(&self) -> usize {
+        self.raw_size
+    }
+
+    /// Check size and region range to see if we should stop before this key.
+    pub fn should_stop_before(&self, key: &[u8]) -> bool {
+        if self.raw_size >= self.limit_size {
+            return true;
+        }
+        match self.region {
+            Some(ref region) => !before_end(key, region.get_end_key()),
+            None => false,
+        }
+    }
+}
+
+pub fn new_context(region: &RegionInfo) -> Context {
+    let peer = if let Some(ref leader) = region.leader {
+        leader.clone()
+    } else {
+        // We don't know the leader, just choose the first one.
+        region.get_peers().first().unwrap().clone()
+    };
+
+    let mut ctx = Context::new();
+    ctx.set_region_id(region.get_id());
+    ctx.set_region_epoch(region.get_region_epoch().clone());
+    ctx.set_peer(peer.clone());
+    ctx
+}
+
+pub fn find_region_peer(region: &Region, store_id: u64) -> Option<Peer> {
+    region
+        .get_peers()
+        .iter()
+        .find(|p| p.get_store_id() == store_id)
+        .cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use import::test_helpers::*;
+
+    #[test]
+    fn test_before_end() {
+        assert!(before_end(b"ab", b"bc"));
+        assert!(!before_end(b"ab", b"ab"));
+        assert!(!before_end(b"cd", b"bc"));
+        assert!(before_end(b"cd", RANGE_MAX));
+    }
+
+    fn new_region_range(start: &[u8], end: &[u8]) -> Region {
+        let mut r = Region::new();
+        r.set_start_key(start.to_vec());
+        r.set_end_key(end.to_vec());
+        r
+    }
+
+    #[test]
+    fn test_inside_region() {
+        assert!(inside_region(&[], &new_region_range(&[], &[])));
+        assert!(inside_region(&[1], &new_region_range(&[], &[])));
+        assert!(inside_region(&[1], &new_region_range(&[], &[2])));
+        assert!(inside_region(&[1], &new_region_range(&[0], &[])));
+        assert!(inside_region(&[1], &new_region_range(&[1], &[])));
+        assert!(inside_region(&[1], &new_region_range(&[0], &[2])));
+        assert!(!inside_region(&[2], &new_region_range(&[], &[2])));
+        assert!(!inside_region(&[2], &new_region_range(&[3], &[])));
+        assert!(!inside_region(&[2], &new_region_range(&[0], &[1])));
+    }
+
+    #[test]
+    fn test_range_context() {
+        let mut client = MockClient::new();
+        client.add_region_range(b"", b"k4");
+        client.add_region_range(b"k4", b"");
+
+        let mut ctx = RangeContext::new(Arc::new(client), 8);
+
+        ctx.add(4);
+        assert!(!ctx.should_stop_before(b"k2"));
+        ctx.add(4);
+        assert_eq!(ctx.raw_size(), 8);
+        // Reach size limit.
+        assert!(ctx.should_stop_before(b"k3"));
+
+        ctx.reset(b"k3");
+        assert_eq!(ctx.raw_size(), 0);
+        ctx.add(4);
+        assert_eq!(ctx.raw_size(), 4);
+        // Reach region end.
+        assert!(ctx.should_stop_before(b"k4"));
+
+        ctx.reset(b"k4");
+        assert_eq!(ctx.raw_size(), 0);
+        ctx.add(4);
+        assert!(!ctx.should_stop_before(b"k5"));
+    }
+}

--- a/src/import/config.rs
+++ b/src/import/config.rs
@@ -14,12 +14,19 @@
 use std::error::Error;
 use std::result::Result;
 
+use raftstore::coprocessor::config::SPLIT_SIZE_MB;
+use util::config::{ReadableDuration, ReadableSize};
+
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
     pub import_dir: String,
     pub num_threads: usize,
+    pub num_import_jobs: usize,
+    pub num_import_sst_jobs: usize,
+    pub max_prepare_duration: ReadableDuration,
+    pub region_split_size: ReadableSize,
     pub stream_channel_window: usize,
 }
 
@@ -28,6 +35,10 @@ impl Default for Config {
         Config {
             import_dir: "/tmp/tikv/import".to_owned(),
             num_threads: 8,
+            num_import_jobs: 8,
+            num_import_sst_jobs: 2,
+            max_prepare_duration: ReadableDuration::minutes(5),
+            region_split_size: ReadableSize::mb(SPLIT_SIZE_MB),
             stream_channel_window: 128,
         }
     }
@@ -37,6 +48,15 @@ impl Config {
     pub fn validate(&self) -> Result<(), Box<Error>> {
         if self.num_threads == 0 {
             return Err("import.num_threads can not be 0".into());
+        }
+        if self.num_import_jobs == 0 {
+            return Err("import.num_import_jobs can not be 0".into());
+        }
+        if self.num_import_sst_jobs == 0 {
+            return Err("import.num_import_sst_jobs can not be 0".into());
+        }
+        if self.region_split_size.0 == 0 {
+            return Err("import.region_split_size can not be 0".into());
         }
         if self.stream_channel_window == 0 {
             return Err("import.stream_channel_window can not be 0".into());

--- a/src/import/engine.rs
+++ b/src/import/engine.rs
@@ -28,10 +28,11 @@ use config::DbConfig;
 use storage::CF_DEFAULT;
 use storage::types::Key;
 use util::config::MB;
-use util::rocksdb::properties::SizePropertiesCollectorFactory;
+use util::rocksdb::properties::{SizeProperties, SizePropertiesCollectorFactory};
 use util::rocksdb::{new_engine_opt, CFOptions};
 
 use super::Result;
+use super::common::*;
 
 /// Engine wraps rocksdb::DB with customized options to support efficient bulk
 /// write.
@@ -75,6 +76,17 @@ impl Engine {
 
         Ok(size)
     }
+
+    pub fn get_size_properties(&self) -> Result<SizeProperties> {
+        let mut res = SizeProperties::default();
+        let collection = self.get_properties_of_all_tables()?;
+        for (_, v) in &*collection {
+            let props = SizeProperties::decode(v.user_collected_properties())?;
+            res.total_size += props.total_size;
+            res.index_handles.extend(props.index_handles.clone());
+        }
+        Ok(res)
+    }
 }
 
 impl Deref for Engine {
@@ -92,6 +104,37 @@ impl fmt::Debug for Engine {
             .field("path", &self.path().to_owned())
             .finish()
     }
+}
+
+pub fn get_approximate_ranges(
+    props: &SizeProperties,
+    max_ranges: usize,
+    min_range_size: usize,
+) -> Vec<RangeInfo> {
+    let range_size = (props.total_size as usize + max_ranges - 1) / max_ranges;
+    let range_size = cmp::max(range_size, min_range_size);
+
+    let mut size = 0;
+    let mut start = RANGE_MIN;
+    let mut ranges = Vec::new();
+    for (i, (k, v)) in props.index_handles.iter().enumerate() {
+        size += v.size as usize;
+        let end = if i == (props.index_handles.len() - 1) {
+            // Index range end is inclusive, so we need to use RANGE_MAX as
+            // the last range end.
+            RANGE_MAX
+        } else {
+            k
+        };
+        if size >= range_size || i == (props.index_handles.len() - 1) {
+            let range = RangeInfo::new(start, end, size);
+            ranges.push(range);
+            size = 0;
+            start = end;
+        }
+    }
+
+    ranges
 }
 
 fn tune_dboptions_for_bulk_load(opts: &DbConfig) -> (DBOptions, CFOptions) {
@@ -172,5 +215,49 @@ mod tests {
             let key = new_encoded_key(i, commit_ts);
             assert_eq!(engine.get(&key).unwrap().unwrap(), &[i]);
         }
+    }
+
+    const SIZE_INDEX_DISTANCE: usize = 4 * 1024 * 1024;
+
+    #[test]
+    fn test_approximate_ranges() {
+        let (_dir, engine) = new_engine();
+
+        let num_files = 3;
+        let num_entries = 3;
+        for i in 0..num_files {
+            for j in 0..num_entries {
+                // (0, 3, 6), (1, 4, 7), (2, 5, 8)
+                let k = [i + j * num_files];
+                let v = vec![0u8; SIZE_INDEX_DISTANCE - k.len()];
+                engine.put(&k, &v).unwrap();
+                engine.flush(true).unwrap();
+            }
+        }
+
+        let props = engine.get_size_properties().unwrap();
+
+        let ranges = get_approximate_ranges(&props, 1, 0);
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].start, RANGE_MIN.to_owned());
+        assert_eq!(ranges[0].end, RANGE_MAX.to_owned());
+
+        let ranges = get_approximate_ranges(&props, 3, 0);
+        assert_eq!(ranges.len(), 3);
+        assert_eq!(ranges[0].start, RANGE_MIN.to_owned());
+        assert_eq!(ranges[0].end, vec![2]);
+        assert_eq!(ranges[1].start, vec![2]);
+        assert_eq!(ranges[1].end, vec![5]);
+        assert_eq!(ranges[2].start, vec![5]);
+        assert_eq!(ranges[2].end, RANGE_MAX.to_owned());
+
+        let ranges = get_approximate_ranges(&props, 4, SIZE_INDEX_DISTANCE * 4);
+        assert_eq!(ranges.len(), 3);
+        assert_eq!(ranges[0].start, RANGE_MIN.to_owned());
+        assert_eq!(ranges[0].end, vec![3]);
+        assert_eq!(ranges[1].start, vec![3]);
+        assert_eq!(ranges[1].end, vec![7]);
+        assert_eq!(ranges[2].start, vec![7]);
+        assert_eq!(ranges[2].end, RANGE_MAX.to_owned());
     }
 }

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -28,10 +28,16 @@
 //! thread to notify it of the ingesting operation.  This service is running
 //! inside TiKV because it needs to interact with raftstore.
 
+#[allow(dead_code)]
+mod client;
+#[allow(dead_code)]
+mod common;
 mod config;
 mod engine;
 mod errors;
 mod metrics;
+#[allow(dead_code)]
+mod prepare;
 #[macro_use]
 mod service;
 mod import_mode;

--- a/src/import/prepare.rs
+++ b/src/import/prepare.rs
@@ -1,0 +1,412 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cmp;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use kvproto::metapb::*;
+
+use pd::RegionInfo;
+use util::escape;
+use util::rocksdb::properties::SizeProperties;
+
+use super::client::*;
+use super::common::*;
+use super::engine::*;
+use super::{Config, Error, Result};
+
+const MAX_RETRY_TIMES: u64 = 3;
+const RETRY_INTERVAL_SECS: u64 = 1;
+
+pub struct PrepareJob<Client> {
+    tag: String,
+    cfg: Config,
+    client: Arc<Client>,
+    engine: Arc<Engine>,
+    counter: AtomicUsize,
+}
+
+impl<Client: ImportClient> PrepareJob<Client> {
+    pub fn new(cfg: Config, client: Client, engine: Arc<Engine>) -> PrepareJob<Client> {
+        PrepareJob {
+            tag: format!("[PrepareJob {}]", engine.uuid()),
+            cfg,
+            client: Arc::new(client),
+            engine,
+            counter: AtomicUsize::new(0),
+        }
+    }
+
+    pub fn run(&self) -> Result<Vec<RangeInfo>> {
+        let start = Instant::now();
+        info!("{} start", self.tag);
+
+        let props = match self.engine.get_size_properties() {
+            Ok(v) => {
+                info!("{} approximate size {}", self.tag, v.total_size);
+                v
+            }
+            Err(e) => {
+                error!("{} get size properties: {:?}", self.tag, e);
+                return Err(e);
+            }
+        };
+
+        let num_prepares = self.prepare(&props);
+
+        // PD needs some time to scatter regions. But we don't know how much
+        // time it should take, so we just calculate an approximate duration.
+        let wait_duration = Duration::from_millis(num_prepares as u64 * 100);
+        let wait_duration = cmp::min(wait_duration, self.cfg.max_prepare_duration.0);
+        info!(
+            "{} prepare {} ranges waits {:?}",
+            self.tag, num_prepares, wait_duration,
+        );
+        thread::sleep(wait_duration);
+
+        info!(
+            "{} prepare {} ranges takes {:?}",
+            self.tag,
+            num_prepares,
+            start.elapsed(),
+        );
+
+        Ok(get_approximate_ranges(
+            &props,
+            self.cfg.num_import_jobs,
+            self.cfg.region_split_size.0 as usize,
+        ))
+    }
+
+    fn prepare(&self, props: &SizeProperties) -> usize {
+        let split_size = self.cfg.region_split_size.0 as usize;
+        let mut ctx = RangeContext::new(Arc::clone(&self.client), split_size);
+
+        let mut num_prepares = 0;
+        let mut start = Vec::new();
+        for (k, v) in props.index_handles.iter() {
+            ctx.add(v.size as usize);
+            if !ctx.should_stop_before(k) {
+                continue;
+            }
+
+            let range = RangeInfo::new(&start, k, ctx.raw_size());
+            if let Ok(true) = self.run_prepare_job(range) {
+                num_prepares += 1;
+            }
+
+            start = k.to_owned();
+            ctx.reset(k);
+        }
+
+        num_prepares
+    }
+
+    fn run_prepare_job(&self, range: RangeInfo) -> Result<bool> {
+        let id = self.counter.fetch_add(1, Ordering::SeqCst);
+        let tag = format!("[PrepareRangeJob {}:{}]", self.engine.uuid(), id);
+        let job = PrepareRangeJob::new(tag, range, Arc::clone(&self.client));
+        job.run()
+    }
+}
+
+struct PrepareRangeJob<Client> {
+    tag: String,
+    range: RangeInfo,
+    client: Arc<Client>,
+}
+
+impl<Client: ImportClient> PrepareRangeJob<Client> {
+    fn new(tag: String, range: RangeInfo, client: Arc<Client>) -> PrepareRangeJob<Client> {
+        PrepareRangeJob { tag, range, client }
+    }
+
+    fn run(&self) -> Result<bool> {
+        let start = Instant::now();
+        info!("{} start {:?}", self.tag, self.range);
+
+        for i in 0..MAX_RETRY_TIMES {
+            if i != 0 {
+                thread::sleep(Duration::from_secs(RETRY_INTERVAL_SECS));
+            }
+
+            let mut region = match self.client.get_region(self.range.get_start()) {
+                Ok(region) => region,
+                Err(e) => {
+                    warn!("{}: {:?}", self.tag, e);
+                    continue;
+                }
+            };
+
+            for _ in 0..MAX_RETRY_TIMES {
+                match self.prepare(region) {
+                    Ok(v) => {
+                        info!("{} takes {:?}", self.tag, start.elapsed());
+                        return Ok(v);
+                    }
+                    Err(Error::UpdateRegion(new_region)) => {
+                        region = new_region;
+                        continue;
+                    }
+                    Err(_) => break,
+                }
+            }
+        }
+
+        error!("{} run out of time", self.tag);
+        Err(Error::PrepareRangeJobFailed(self.tag.clone()))
+    }
+
+    fn prepare(&self, mut region: RegionInfo) -> Result<bool> {
+        if !self.need_split(&region) {
+            return Ok(false);
+        }
+        match self.split_region(&region) {
+            Ok(new_region) => {
+                self.scatter_region(&new_region)?;
+                Ok(true)
+            }
+            Err(Error::NotLeader(new_leader)) => {
+                region.leader = new_leader;
+                Err(Error::UpdateRegion(region))
+            }
+            Err(Error::StaleEpoch(new_regions)) => {
+                let new_region = new_regions.iter().find(|&r| self.need_split(r)).cloned();
+                match new_region {
+                    Some(new_region) => {
+                        let new_leader = region
+                            .leader
+                            .and_then(|p| find_region_peer(&new_region, p.get_store_id()));
+                        Err(Error::UpdateRegion(RegionInfo::new(new_region, new_leader)))
+                    }
+                    None => {
+                        warn!("{} stale epoch {:?}", self.tag, new_regions);
+                        Err(Error::StaleEpoch(new_regions))
+                    }
+                }
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    fn need_split(&self, region: &Region) -> bool {
+        let split_key = self.range.get_end();
+        if split_key.is_empty() {
+            return false;
+        }
+        if split_key <= region.get_start_key() {
+            return false;
+        }
+        before_end(split_key, region.get_end_key())
+    }
+
+    fn split_region(&self, region: &RegionInfo) -> Result<RegionInfo> {
+        let split_key = self.range.get_end();
+        let res = match self.client.split_region(region, split_key) {
+            Ok(mut resp) => if !resp.has_region_error() {
+                Ok(resp)
+            } else {
+                match Error::from(resp.take_region_error()) {
+                    e @ Error::NotLeader(_) | e @ Error::StaleEpoch(_) => return Err(e),
+                    e => Err(e),
+                }
+            },
+            Err(e) => Err(e),
+        };
+
+        match res {
+            Ok(mut resp) => {
+                info!("{} split {:?} at {:?}", self.tag, region, escape(split_key));
+                // Just assume that the leader will be at the same store.
+                let left = resp.take_left();
+                let leader = match region.leader {
+                    Some(ref p) => find_region_peer(&left, p.get_store_id()),
+                    None => None,
+                };
+                Ok(RegionInfo::new(left, leader))
+            }
+            Err(e) => {
+                warn!(
+                    "{} split {:?} at {:?}: {:?}",
+                    self.tag,
+                    region,
+                    escape(split_key),
+                    e
+                );
+                Err(e)
+            }
+        }
+    }
+
+    fn scatter_region(&self, region: &RegionInfo) -> Result<()> {
+        match self.client.scatter_region(region) {
+            Ok(_) => {
+                info!("{} scatter region {}", self.tag, region.get_id());
+                Ok(())
+            }
+            Err(e) => {
+                warn!("{} scatter region {}: {:?}", self.tag, region.get_id(), e);
+                Err(e)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use import::test_helpers::*;
+
+    use rocksdb::Writable;
+    use tempdir::TempDir;
+    use uuid::Uuid;
+
+    use config::DbConfig;
+    use storage::types::Key;
+
+    fn new_encoded_key(k: &[u8]) -> Vec<u8> {
+        if k.is_empty() {
+            vec![]
+        } else {
+            Key::from_raw(k).encoded().to_owned()
+        }
+    }
+
+    #[test]
+    fn test_prepare_job() {
+        let dir = TempDir::new("test_import_prepare_job").unwrap();
+        let uuid = Uuid::new_v4();
+        let opts = DbConfig::default();
+        let engine = Arc::new(Engine::new(dir.path(), uuid, opts).unwrap());
+
+        // Generate entries to prepare.
+        let (n, m) = (4, 4);
+        // This size if pre-calculated.
+        let index_size = 10;
+        for i in 0..n {
+            for j in 0..m {
+                let v = &[i + j * n + 1];
+                let k = new_encoded_key(v);
+                engine.put(&k, v).unwrap();
+                assert_eq!(k.len() + v.len(), index_size);
+                engine.flush(true).unwrap();
+            }
+        }
+
+        let mut cfg = Config::default();
+        // We have n * m = 16 entries and 4 jobs.
+        cfg.num_import_jobs = 4;
+        // Each region contains at most 3 entries.
+        cfg.region_split_size.0 = index_size as u64 * 3;
+
+        // Expected ranges returned by the prepare job.
+        let ranges = vec![
+            (vec![], vec![4]),
+            (vec![4], vec![8]),
+            (vec![8], vec![12]),
+            (vec![12], vec![]),
+        ];
+
+        // Test with an empty range.
+        {
+            let mut client = MockClient::new();
+            client.add_region_range(b"", b"");
+            // Expected region ranges returned by the prepare job.
+            let region_ranges = vec![
+                (vec![], vec![3], true),
+                (vec![3], vec![6], true),
+                (vec![6], vec![9], true),
+                (vec![9], vec![12], true),
+                (vec![12], vec![15], true),
+                (vec![15], vec![], false),
+            ];
+            run_and_check_prepare_job(
+                cfg.clone(),
+                client,
+                Arc::clone(&engine),
+                &ranges,
+                &region_ranges,
+            );
+        }
+
+        // Test with some segmented region ranges.
+        {
+            let mut client = MockClient::new();
+            let keys = vec![
+                // [0, 3), [3, 5)
+                5,
+                // [5, 7)
+                7,
+                // [7, 10), [10, 13), [13, 15)
+                15,
+            ];
+            let mut last = Vec::new();
+            for i in keys {
+                let k = new_encoded_key(&[i]);
+                client.add_region_range(&last, &k);
+                last = k.clone();
+            }
+            client.add_region_range(&last, b"");
+            // Expected region ranges returned by the prepare job.
+            let region_ranges = vec![
+                (vec![], vec![3], true),
+                (vec![3], vec![5], false),
+                (vec![5], vec![7], false),
+                (vec![7], vec![10], true),
+                (vec![10], vec![13], true),
+                (vec![13], vec![15], false),
+                (vec![15], vec![], false),
+            ];
+            run_and_check_prepare_job(
+                cfg.clone(),
+                client,
+                Arc::clone(&engine),
+                &ranges,
+                &region_ranges,
+            );
+        }
+    }
+
+    fn run_and_check_prepare_job(
+        cfg: Config,
+        client: MockClient,
+        engine: Arc<Engine>,
+        expected_ranges: &[(Vec<u8>, Vec<u8>)],
+        expected_region_ranges: &[(Vec<u8>, Vec<u8>, bool)],
+    ) {
+        let job = PrepareJob::new(cfg, client.clone(), Arc::clone(&engine));
+
+        let ranges = job.run().unwrap();
+        assert_eq!(ranges.len(), expected_ranges.len());
+        for (range, &(ref start, ref end)) in ranges.iter().zip(expected_ranges.iter()) {
+            let start_key = new_encoded_key(start);
+            let end_key = new_encoded_key(end);
+            assert_eq!(range.get_start(), start_key.as_slice());
+            assert_eq!(range.get_end(), end_key.as_slice());
+        }
+
+        for &(ref start, ref end, should_scatter) in expected_region_ranges {
+            let start_key = new_encoded_key(start);
+            let end_key = new_encoded_key(end);
+            let region = client.get_region(&start_key).unwrap();
+            assert_eq!(region.get_start_key(), start_key.as_slice());
+            assert_eq!(region.get_end_key(), end_key.as_slice());
+            if should_scatter {
+                client.get_scatter_region(region.get_id()).unwrap();
+            }
+        }
+    }
+}

--- a/src/import/test_helpers.rs
+++ b/src/import/test_helpers.rs
@@ -11,16 +11,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 
 use crc::crc32::{self, Hasher32};
 use kvproto::import_sstpb::*;
+use kvproto::kvrpcpb::*;
+use kvproto::metapb::*;
 use rocksdb::{ColumnFamilyOptions, EnvOptions, SstFileWriter, DB};
 use uuid::Uuid;
 
+use pd::RegionInfo;
 use raftstore::store::keys;
+
+use super::Result;
+use super::client::*;
+use super::common::*;
 
 pub fn calc_data_crc32(data: &[u8]) -> u32 {
     let mut digest = crc32::Digest::new(crc32::IEEE);
@@ -64,4 +74,92 @@ pub fn read_sst_file<P: AsRef<Path>>(path: P, range: (u8, u8)) -> (SSTMeta, Vec<
     meta.set_cf_name("default".to_owned());
 
     (meta, data)
+}
+
+#[derive(Clone)]
+pub struct MockClient {
+    counter: Arc<AtomicUsize>,
+    regions: Arc<Mutex<HashMap<u64, Region>>>,
+    scatter_regions: Arc<Mutex<HashMap<u64, Region>>>,
+}
+
+impl MockClient {
+    pub fn new() -> MockClient {
+        MockClient {
+            counter: Arc::new(AtomicUsize::new(1)),
+            regions: Arc::new(Mutex::new(HashMap::new())),
+            scatter_regions: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    fn alloc_id(&self) -> u64 {
+        self.counter.fetch_add(1, Ordering::SeqCst) as u64
+    }
+
+    pub fn add_region_range(&mut self, start: &[u8], end: &[u8]) {
+        let mut r = Region::new();
+        r.set_id(self.alloc_id());
+        r.set_start_key(start.to_owned());
+        r.set_end_key(end.to_owned());
+        let mut peer = Peer::new();
+        peer.set_id(self.alloc_id());
+        peer.set_store_id(self.alloc_id());
+        r.mut_peers().push(peer);
+        let mut regions = self.regions.lock().unwrap();
+        regions.insert(r.get_id(), r);
+    }
+
+    pub fn get_scatter_region(&self, id: u64) -> Option<RegionInfo> {
+        let regions = self.scatter_regions.lock().unwrap();
+        regions.get(&id).map(|r| RegionInfo::new(r.clone(), None))
+    }
+}
+
+impl ImportClient for MockClient {
+    fn get_region(&self, key: &[u8]) -> Result<RegionInfo> {
+        let mut found = None;
+        for region in self.regions.lock().unwrap().values() {
+            if inside_region(key, region) {
+                found = Some(region.clone());
+                break;
+            }
+        }
+        Ok(RegionInfo::new(found.unwrap(), None))
+    }
+
+    fn split_region(&self, _: &RegionInfo, split_key: &[u8]) -> Result<SplitRegionResponse> {
+        let mut regions = self.regions.lock().unwrap();
+
+        let region = regions
+            .iter()
+            .map(|(_, r)| r)
+            .find(|r| {
+                split_key >= r.get_start_key()
+                    && (split_key < r.get_end_key() || r.get_end_key().is_empty())
+            })
+            .unwrap()
+            .clone();
+
+        regions.remove(&region.get_id());
+
+        let mut left = region.clone();
+        left.set_id(self.alloc_id());
+        left.set_end_key(split_key.to_vec());
+        regions.insert(left.get_id(), left.clone());
+
+        let mut right = region.clone();
+        right.set_start_key(split_key.to_vec());
+        regions.insert(right.get_id(), right.clone());
+
+        let mut resp = SplitRegionResponse::new();
+        resp.set_left(left);
+        resp.set_right(right);
+        Ok(resp)
+    }
+
+    fn scatter_region(&self, region: &RegionInfo) -> Result<()> {
+        let mut regions = self.scatter_regions.lock().unwrap();
+        regions.insert(region.get_id(), region.region.clone());
+        Ok(())
+    }
 }

--- a/src/pd/mod.rs
+++ b/src/pd/mod.rs
@@ -47,7 +47,7 @@ pub struct RegionStat {
     pub last_report_ts: u64,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct RegionInfo {
     pub region: metapb::Region,
     pub leader: Option<metapb::Peer>,

--- a/src/util/security.rs
+++ b/src/util/security.rs
@@ -80,6 +80,7 @@ impl SecurityConfig {
     }
 }
 
+#[derive(Default)]
 pub struct SecurityManager {
     ca: Vec<u8>,
     cert: Vec<u8>,

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -416,6 +416,10 @@ fn test_serde_custom_tikv_config() {
     value.import = ImportConfig {
         import_dir: "/abc".to_owned(),
         num_threads: 123,
+        num_import_jobs: 123,
+        num_import_sst_jobs: 123,
+        max_prepare_duration: ReadableDuration::minutes(12),
+        region_split_size: ReadableSize::mb(123),
         stream_channel_window: 123,
     };
 

--- a/tests/config/test-custom.toml
+++ b/tests/config/test-custom.toml
@@ -356,4 +356,8 @@ key-path = "invalid path"
 [import]
 import-dir = "/abc"
 num-threads = 123
+num-import-jobs = 123
+num-import-sst-jobs = 123
+max-prepare-duration = "12m"
+region-split-size = "123MB"
 stream-channel-window = 123


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/pingcap/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

PrepareJob is part of the implementation of the ImportKV::Import API.
PrepareJob will split and scatter regions according to the size
properties from the importing engine data.

We separate the code of PrepareJob to review more easily, but it is
not used yet, so I mark it as dead code in this PR.

The previous PR is closed because it is outdated https://github.com/pingcap/tikv/pull/2935.

## What are the type of the changes? (mandatory)

- New feature (non-breaking change which adds functionality)

## How has this PR been tested? (mandatory)

Unit tests and integration tests with tidb-lightning in a test environment.

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.
