### PR TITLE
tests: fix tracing test

### DIFF
--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -11,14 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rand::{self, Rng, ThreadRng};
-use slog::{self, Drain, OwnedKVList, Record};
-use slog_async;
 use std::env;
 use std::fs::File;
 use std::io::{self, Write};
 use std::path::PathBuf;
 use std::sync::Mutex;
+
+use rand::{self, Rng, ThreadRng};
+use slog::{self, Drain, OwnedKVList, Record};
 use time;
 
 use tikv::util;
@@ -114,7 +114,14 @@ fn init_log() {
     let writer = output.map(|f| Mutex::new(File::create(f).unwrap()));
     // we don't mind set it multiple times.
     let drain = CaseTraceLogger { f: writer };
-    let drain = slog_async::Async::new(drain).build().fuse();
+    // CaseTraceLogger relies on test's thread name, however slog_async has
+    // its own thread, and the name is "".
+    // TODO: Enable the slog_async when the [Custom test frameworks][1] is mature,
+    //       and hook the slog_async logger to every test cases.
+    //
+    // [1]: https://github.com/rust-lang/rfcs/blob/master/text/2318-custom-test-frameworks.md
+    //
+    // let drain = slog_async::Async::new(drain).build().fuse();
     let logger = slog::Logger::root_typed(drain, slog_o!());
     let _ = logger::init_log_for_tikv_only(logger, level);
 }


### PR DESCRIPTION
CaseTraceLogger relies on test's thread name, however slog_async has
its own thread, and the name is "".
TODO: Enable the slog_async when the [Custom test frameworks][1] is mature,
       and hook the slog_async logger to every test cases.

[1]: https://github.com/rust-lang/rfcs/blob/master/text/2318-custom-test-frameworks.md