### PR TITLE
coprocessor: collect row count for each index prefix

### DIFF
--- a/src/coprocessor/codec/table.rs
+++ b/src/coprocessor/codec/table.rs
@@ -336,7 +336,7 @@ impl RowColsDict {
     }
 
     // get binary of cols, keep the origin order, return one slice and cols' end offsets.
-    pub fn get_column_values_and_offsets(&self) -> (&[u8], Vec<usize>) {
+    pub fn get_column_values_and_end_offsets(&self) -> (&[u8], Vec<usize>) {
         let mut start = self.value.len();
         let mut length = 0;
         for meta in self.cols.values() {
@@ -345,12 +345,12 @@ impl RowColsDict {
             }
             length += meta.length;
         }
-        let offsets = self.cols
+        let end_offsets = self.cols
             .values()
             .into_iter()
             .map(|meta| meta.offset + meta.length - start)
             .collect();
-        (&self.value[start..start + length], offsets)
+        (&self.value[start..start + length], end_offsets)
     }
 }
 

--- a/src/coprocessor/codec/table.rs
+++ b/src/coprocessor/codec/table.rs
@@ -335,8 +335,8 @@ impl RowColsDict {
         self.cols.insert(cid, RowColMeta::new(offset, length));
     }
 
-    // get binary of cols, keep the origin order and return one slice.
-    pub fn get_column_values(&self) -> &[u8] {
+    // get binary of cols, keep the origin order, return one slice and cols' end offsets.
+    pub fn get_column_values_and_offsets(&self) -> (&[u8], Vec<usize>) {
         let mut start = self.value.len();
         let mut length = 0;
         for meta in self.cols.values() {
@@ -345,7 +345,12 @@ impl RowColsDict {
             }
             length += meta.length;
         }
-        &self.value[start..start + length]
+        let offsets = self.cols
+            .values()
+            .into_iter()
+            .map(|meta| meta.offset + meta.length - start)
+            .collect();
+        (&self.value[start..start + length], offsets)
     }
 }
 

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -87,10 +87,12 @@ impl AnalyzeContext {
             req.get_cmsketch_width() as usize,
         );
         while let Some(row) = scanner.next()? {
-            let bytes = row.data.get_column_values();
+            let (bytes, offsets) = row.data.get_column_values_and_offsets();
             hist.append(bytes);
             if let Some(c) = cms.as_mut() {
-                c.insert(bytes)
+                for offset in offsets {
+                    c.insert(&bytes[..offset])
+                }
             }
         }
         let mut res = analyze::AnalyzeIndexResp::new();

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -87,11 +87,11 @@ impl AnalyzeContext {
             req.get_cmsketch_width() as usize,
         );
         while let Some(row) = scanner.next()? {
-            let (bytes, offsets) = row.data.get_column_values_and_offsets();
+            let (bytes, end_offsets) = row.data.get_column_values_and_end_offsets();
             hist.append(bytes);
             if let Some(c) = cms.as_mut() {
-                for offset in offsets {
-                    c.insert(&bytes[..offset])
+                for end_offset in end_offsets {
+                    c.insert(&bytes[..end_offset])
                 }
             }
         }

--- a/tests/coprocessor/test_analyze.rs
+++ b/tests/coprocessor/test_analyze.rs
@@ -203,7 +203,7 @@ fn test_analyze_index() {
     let rows = analyze_resp.get_cms().get_rows();
     assert_eq!(rows.len(), 4);
     let sum: u32 = rows.first().unwrap().get_counters().iter().sum();
-    assert_eq!(sum, 4);
+    assert_eq!(sum, 8);
     end_point.stop().unwrap().join().unwrap();
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/pingcap/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

In the before, we only record the row count for the whole index, this pr also records the row count for each index prefix. Therefore, for an index (a, b, c), not only could we know the row count for (a = 1 and b = 1 and c = 1), but also the row count for (a = 1) or (a = 1 and b = 1).

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

unit test and integration test with tidb.

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.

PTAL @AndreMouche @coocood 