### PR TITLE
codec/table: refactor encode_row_key

### DIFF
--- a/benches/bin/utils.rs
+++ b/benches/bin/utils.rs
@@ -29,7 +29,7 @@ pub fn next_ts() -> u64 {
 pub fn generate_row_keys(table_id: i64, start_id: i64, count: usize) -> Vec<Vec<u8>> {
     let mut result = Vec::with_capacity(count);
     for i in (start_id)..(start_id + count as i64) {
-        let key = encode_row_key(table_id, i as i64);
+        let key = encode_row_key(table_id, i);
         result.push(key);
     }
     result

--- a/benches/bin/utils.rs
+++ b/benches/bin/utils.rs
@@ -29,9 +29,7 @@ pub fn next_ts() -> u64 {
 pub fn generate_row_keys(table_id: i64, start_id: i64, count: usize) -> Vec<Vec<u8>> {
     let mut result = Vec::with_capacity(count);
     for i in (start_id)..(start_id + count as i64) {
-        let mut handle = Vec::with_capacity(8);
-        handle.encode_i64(i as i64).unwrap();
-        let key = encode_row_key(table_id, &handle);
+        let key = encode_row_key(table_id, i as i64);
         result.push(key);
     }
     result

--- a/src/coprocessor/dag/executor/topn.rs
+++ b/src/coprocessor/dag/executor/topn.rs
@@ -363,9 +363,7 @@ pub mod test {
         for cols in rows.iter() {
             let col_values: Vec<_> = cols.to_vec();
             let value = table::encode_row(col_values, &col_ids).unwrap();
-            let mut buf = vec![];
-            buf.encode_i64(cols[0].i64()).unwrap();
-            let key = table::encode_row_key(tid, &buf);
+            let key = table::encode_row_key(tid, cols[0].i64());
             kv_data.push((key, value));
         }
         kv_data

--- a/src/raftstore/coprocessor/split_observer.rs
+++ b/src/raftstore/coprocessor/split_observer.rs
@@ -95,7 +95,6 @@ mod test {
     use raftstore::coprocessor::AdminObserver;
     use raftstore::coprocessor::ObserverContext;
     use util::codec::bytes::encode_bytes;
-    use util::codec::number::NumberEncoder;
 
     fn new_split_request(key: &[u8]) -> AdminRequest {
         let mut req = AdminRequest::new();
@@ -107,9 +106,7 @@ mod test {
     }
 
     fn new_row_key(table_id: i64, row_id: i64, column_id: u64, version_id: u64) -> Vec<u8> {
-        let mut buf = Vec::with_capacity(table::ID_LEN);
-        buf.encode_i64(row_id).unwrap();
-        let mut key = table::encode_row_key(table_id, &buf);
+        let mut key = table::encode_row_key(table_id, row_id);
         if column_id > 0 {
             key.write_u64::<BigEndian>(column_id).unwrap();
         }


### PR DESCRIPTION
## What have you changed? (mandatory)

Now the function in master is defined as follows:

```
/// `encode_row_key` encodes the table id and record handle into a byte array.
pub fn encode_row_key(table_id: i64, encoded_handle: &[u8]) -> Vec<u8>
```

And this PR defined it like following to make it more easy to use

```
/// `encode_row_key` encodes the table id and record handle into a byte array.
pub fn encode_row_key(table_id: i64, handle: i64) -> Vec<u8>
```


## What are the type of the changes? (mandatory)

The currently defined types are listed below, please pick one of the types for this PR by removing the others:

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

unit test

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

no

## Does this PR affect tidb-ansible update? (mandatory)

no

## Refer to a related PR or issue link (optional)

https://github.com/pingcap/tikv/issues/3157


@BusyJay @breeswish PTAL
