### PR TITLE
tests: fix some tests

### DIFF
--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -343,7 +343,7 @@ impl<T: Simulator> Cluster<T> {
         }
         self.reset_leader_of_region(region_id);
         let mut leader = None;
-        let mut retry_cnt = 30;
+        let mut retry_cnt = 500;
 
         let node_ids = self.sim.rl().get_node_ids();
         let mut count = 0;

--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -343,7 +343,7 @@ impl<T: Simulator> Cluster<T> {
         }
         self.reset_leader_of_region(region_id);
         let mut leader = None;
-        let mut retry_cnt = 500;
+        let mut retry_cnt = 30;
 
         let node_ids = self.sim.rl().get_node_ids();
         let mut count = 0;
@@ -357,7 +357,7 @@ impl<T: Simulator> Cluster<T> {
                     count += 1;
                     continue;
                 }
-                let l = self.query_leader(*store_id, region_id, Duration::from_millis(10));
+                let l = self.query_leader(*store_id, region_id, Duration::from_secs(1));
                 if l.is_none() {
                     continue;
                 }

--- a/tests/raftstore_cases/test_conf_change.rs
+++ b/tests/raftstore_cases/test_conf_change.rs
@@ -776,5 +776,5 @@ fn test_learner_with_slow_snapshot() {
     // Transfer leader so that peer 3 can report to pd with `Peer` in memory.
     pd_client.transfer_leader(r1, new_peer(3, 3));
     pd_client.region_leader_must_be(r1, new_peer(3, 3));
-    assert_eq!(count.load(Ordering::SeqCst), 1);
+    assert!(count.load(Ordering::SeqCst) > 0);
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/pingcap/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

- Allow more one snapshots to be sent to fix `test_learner_with_slow_snapshot`
- Enlarge the timeout for `query_leader` to fix "can't get leader of
  region xxx" in some tests

## What are the type of the changes? (mandatory)

- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)

- Unit tests

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.

## Refer to a related PR or issue link (optional)

https://github.com/pingcap/tikv/pull/3211

