### PR TITLE
tests: tweak lease tests configurations

### DIFF
--- a/tests/coprocessor/test_select.rs
+++ b/tests/coprocessor/test_select.rs
@@ -17,7 +17,6 @@ use std::collections::{BTreeMap, HashMap};
 use std::i64;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
-use std::time::Duration;
 use std::{cmp, mem};
 
 use kvproto::coprocessor::{KeyRange, Request, Response};
@@ -36,7 +35,6 @@ use tipb::expression::{ByItem, Expr, ExprType, ScalarFuncSig};
 use tipb::schema::{self, ColumnInfo};
 use tipb::select::{Chunk, DAGRequest, EncodeType, SelectResponse, StreamResponse};
 
-use raftstore::util::MAX_LEADER_LEASE;
 use storage::sync_storage::SyncStorage;
 use storage::util::new_raft_engine;
 
@@ -892,12 +890,12 @@ fn test_select_after_lease() {
     ];
 
     let product = ProductTable::new();
-    let (_cluster, raft_engine, ctx) = new_raft_engine(1, "");
+    let (cluster, raft_engine, ctx) = new_raft_engine(1, "");
     let (_, mut end_point) =
         init_data_with_engine_and_commit(ctx.clone(), raft_engine, &product, &data, true);
 
     // Sleep until the leader lease is expired.
-    thread::sleep(Duration::from_millis(MAX_LEADER_LEASE));
+    thread::sleep(cluster.cfg.raft_store.raft_store_max_leader_lease.0);
     let req = DAGSelect::from(&product.table).build_with(ctx.clone(), &[0]);
     let mut resp = handle_select(&end_point, req);
     let spliter = DAGChunkSpliter::new(resp.take_chunks().into_vec(), 3);

--- a/tests/failpoints_cases/test_stale_read.rs
+++ b/tests/failpoints_cases/test_stale_read.rs
@@ -27,10 +27,8 @@ fn stale_read_during_splitting(right_derive: bool) {
 
     let count = 3;
     let mut cluster = new_node_cluster(0, count);
-    configure_for_lease_read(&mut cluster);
     cluster.cfg.raft_store.right_derive_when_split = right_derive;
-    let base_tick = cluster.cfg.raft_store.raft_base_tick_interval.0;
-    let election_timeout = base_tick * cluster.cfg.raft_store.raft_election_timeout_ticks as u32;
+    let election_timeout = configure_for_lease_read(&mut cluster, None, None);
     cluster.run();
 
     // Write the initial values.

--- a/tests/raftstore/util.rs
+++ b/tests/raftstore/util.rs
@@ -42,8 +42,6 @@ use super::cluster::{Cluster, Simulator};
 
 pub use tikv::raftstore::store::util::{find_peer, new_learner_peer, new_peer};
 
-pub const MAX_LEADER_LEASE: u64 = 250; // 250ms
-
 pub fn must_get(engine: &Arc<DB>, cf: &str, key: &[u8], value: Option<&[u8]>) {
     for _ in 1..300 {
         let res = engine.get_value_cf(cf, &keys::data_key(key)).unwrap();
@@ -106,7 +104,7 @@ pub fn new_store_cfg() -> Config {
         pd_heartbeat_tick_interval: ReadableDuration::millis(20),
         region_split_check_diff: ReadableSize(10000),
         report_region_flow_interval: ReadableDuration::millis(100),
-        raft_store_max_leader_lease: ReadableDuration::millis(MAX_LEADER_LEASE),
+        raft_store_max_leader_lease: ReadableDuration::millis(250),
         clean_stale_peer_delay: ReadableDuration::secs(0),
         allow_remove_leader: true,
         ..Config::default()
@@ -498,13 +496,28 @@ pub fn configure_for_merge<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.cfg.raft_store.merge_check_tick_interval = ReadableDuration::millis(100);
 }
 
-pub fn configure_for_lease_read<T: Simulator>(cluster: &mut Cluster<T>) {
-    let base_tick = cluster.cfg.raft_store.raft_base_tick_interval.0;
-    let election_timeout = base_tick * cluster.cfg.raft_store.raft_election_timeout_ticks as u32;
+pub fn configure_for_lease_read<T: Simulator>(
+    cluster: &mut Cluster<T>,
+    base_tick_ms: Option<u64>,
+    election_ticks: Option<usize>,
+) -> Duration {
+    if let Some(base_tick_ms) = base_tick_ms {
+        cluster.cfg.raft_store.raft_base_tick_interval = ReadableDuration::millis(base_tick_ms);
+    }
+    let base_tick_interval = cluster.cfg.raft_store.raft_base_tick_interval.0;
+    if let Some(election_ticks) = election_ticks {
+        cluster.cfg.raft_store.raft_election_timeout_ticks = election_ticks;
+    }
+    let election_ticks = cluster.cfg.raft_store.raft_election_timeout_ticks as u32;
+    let election_timeout = base_tick_interval * election_ticks;
+    // Adjust max leader lease.
+    cluster.cfg.raft_store.raft_store_max_leader_lease = ReadableDuration(election_timeout);
     // Use large peer check interval, abnormal and max leader missing duration to make a valid config,
     // that is election timeout x 2 < peer stale state check < abnormal < max leader missing duration.
     cluster.cfg.raft_store.peer_stale_state_check_interval = ReadableDuration(election_timeout * 3);
     cluster.cfg.raft_store.abnormal_leader_missing_duration =
         ReadableDuration(election_timeout * 4);
     cluster.cfg.raft_store.max_leader_missing_duration = ReadableDuration(election_timeout * 5);
+
+    election_timeout
 }

--- a/tests/raftstore_cases/test_lease_read.rs
+++ b/tests/raftstore_cases/test_lease_read.rs
@@ -47,11 +47,9 @@ fn test_renew_lease<T: Simulator>(cluster: &mut Cluster<T>) {
     // Avoid triggering the log compaction in this test case.
     cluster.cfg.raft_store.raft_log_gc_threshold = 100;
     // Increase the Raft tick interval to make this test case running reliably.
-    cluster.cfg.raft_store.raft_base_tick_interval = ReadableDuration::millis(50);
     // Use large election timeout to make leadership stable.
-    cluster.cfg.raft_store.raft_election_timeout_ticks = 10_000;
-    configure_for_lease_read(cluster);
-
+    configure_for_lease_read(cluster, Some(50), Some(10_000));
+    // Override max leader lease to 2 seconds.
     let max_lease = Duration::from_secs(2);
     cluster.cfg.raft_store.raft_store_max_leader_lease = ReadableDuration(max_lease);
 
@@ -141,12 +139,8 @@ fn test_lease_expired<T: Simulator>(cluster: &mut Cluster<T>) {
     // Avoid triggering the log compaction in this test case.
     cluster.cfg.raft_store.raft_log_gc_threshold = 100;
     // Increase the Raft tick interval to make this test case running reliably.
-    // The election timeout is 25_000ms
-    cluster.cfg.raft_store.raft_base_tick_interval = ReadableDuration::millis(50);
-    configure_for_lease_read(cluster);
+    let election_timeout = configure_for_lease_read(cluster, Some(50), None);
 
-    let election_timeout = cluster.cfg.raft_store.raft_base_tick_interval.0
-        * cluster.cfg.raft_store.raft_election_timeout_ticks as u32;
     let node_id = 3u64;
     let store_id = 3u64;
     let peer = new_peer(store_id, node_id);
@@ -192,11 +186,7 @@ fn test_lease_unsafe_during_leader_transfers<T: Simulator>(cluster: &mut Cluster
     // Avoid triggering the log compaction in this test case.
     cluster.cfg.raft_store.raft_log_gc_threshold = 100;
     // Increase the Raft tick interval to make this test case running reliably.
-    cluster.cfg.raft_store.raft_base_tick_interval = ReadableDuration::millis(50);
-    configure_for_lease_read(cluster);
-
-    let base_tick = cluster.cfg.raft_store.raft_base_tick_interval.0;
-    let election_timeout = base_tick * cluster.cfg.raft_store.raft_election_timeout_ticks as u32;
+    let election_timeout = configure_for_lease_read(cluster, Some(50), None);
     cluster.cfg.raft_store.raft_store_max_leader_lease = ReadableDuration(election_timeout);
 
     let store_id = 1u64;

--- a/tests/storage_cases/test_raft_storage.rs
+++ b/tests/storage_cases/test_raft_storage.rs
@@ -69,7 +69,7 @@ fn test_raft_storage() {
 
 #[test]
 fn test_raft_storage_get_after_lease() {
-    let (_cluster, storage, ctx) = new_raft_storage();
+    let (cluster, storage, ctx) = new_raft_storage();
     let key = b"key";
     let value = b"value";
     assert_eq!(
@@ -90,7 +90,7 @@ fn test_raft_storage_get_after_lease() {
     );
 
     // Sleep until the leader lease is expired.
-    thread::sleep(Duration::from_millis(MAX_LEADER_LEASE));
+    thread::sleep(cluster.cfg.raft_store.raft_store_max_leader_lease.0);
     assert_eq!(
         storage
             .raw_get(ctx.clone(), "".to_string(), key.to_vec())

--- a/tests/storage_cases/test_raftkv.rs
+++ b/tests/storage_cases/test_raftkv.rs
@@ -1,6 +1,5 @@
 use std::sync::mpsc::channel;
 use std::thread;
-use std::time::Duration;
 
 use kvproto::kvrpcpb::Context;
 use raftstore::server::new_server_cluster;
@@ -11,8 +10,6 @@ use tikv::storage::{CFStatistics, CfName, Key, CF_DEFAULT};
 use tikv::util::HandyRwLock;
 use tikv::util::codec::bytes;
 use tikv::util::escape;
-
-use raftstore::util::MAX_LEADER_LEASE;
 
 #[test]
 fn test_raftkv() {
@@ -102,7 +99,7 @@ fn test_batch_snapshot() {
         assert!(s.is_some());
     }
     // sleep util leader lease is expired.
-    thread::sleep(Duration::from_millis(MAX_LEADER_LEASE));
+    thread::sleep(cluster.cfg.raft_store.raft_store_max_leader_lease.0);
     let batch = vec![ctx; size];
     let snapshots = must_batch_snapshot(batch, storage.as_ref());
     assert_eq!(size, snapshots.len());


### PR DESCRIPTION
This PR tweaks configurations for lease read tests,
 * Removes hard coded `MAX_LEADER_LEASE`.
 * Adjust election timeout and max leader lease via `configure_for_lease_read`. 