### PR TITLE
decimal:fix bug caused by do_mul

### DIFF
--- a/src/coprocessor/codec/mysql/decimal.rs
+++ b/src/coprocessor/codec/mysql/decimal.rs
@@ -714,18 +714,18 @@ fn do_div_mod(
 /// `do_mul` multiplies two decimals.
 fn do_mul(lhs: &Decimal, rhs: &Decimal) -> Res<Decimal> {
     let (l_int_word_cnt, mut l_frac_word_cnt) = (
-        word_cnt!(lhs.int_cnt) as usize,
-        word_cnt!(lhs.frac_cnt) as usize,
+        i32::from(word_cnt!(lhs.int_cnt)),
+        i32::from(word_cnt!(lhs.frac_cnt)),
     );
     let (mut r_int_word_cnt, mut r_frac_word_cnt) = (
-        word_cnt!(rhs.int_cnt) as usize,
-        word_cnt!(rhs.frac_cnt) as usize,
+        i32::from(word_cnt!(rhs.int_cnt)),
+        i32::from(word_cnt!(rhs.frac_cnt)),
     );
     let (int_word_to, frac_word_to) = (
         word_cnt!(lhs.int_cnt + rhs.int_cnt) as usize,
         l_frac_word_cnt + r_frac_word_cnt,
     );
-    let (mut old_int_word_to, mut old_frac_word_to) = (int_word_to, frac_word_to);
+    let (mut old_int_word_to, mut old_frac_word_to) = (int_word_to as i32, frac_word_to as i32);
     let res = fix_word_cnt_err(int_word_to as u8, frac_word_to as u8, WORD_BUF_LEN);
     let (int_word_to, frac_word_to) = (res.0 as usize, res.1 as usize);
     let negative = lhs.negative != rhs.negative;
@@ -739,14 +739,14 @@ fn do_mul(lhs: &Decimal, rhs: &Decimal) -> Res<Decimal> {
 
     if !res.is_ok() {
         dec.frac_cnt = cmp::min(dec.frac_cnt, frac_word_to as u8 * DIGITS_PER_WORD);
-        if old_int_word_to > int_word_to {
-            old_int_word_to -= int_word_to;
+        if old_int_word_to > int_word_to as i32 {
+            old_int_word_to -= int_word_to as i32;
             old_frac_word_to = old_int_word_to / 2;
             r_int_word_cnt = old_int_word_to - old_frac_word_to;
             l_frac_word_cnt = 0;
             r_frac_word_cnt = 0;
         } else {
-            old_frac_word_to -= int_word_to;
+            old_frac_word_to -= int_word_to as i32;
             old_int_word_to = old_frac_word_to / 2;
             if l_frac_word_cnt <= r_frac_word_cnt {
                 l_frac_word_cnt -= old_int_word_to;
@@ -759,8 +759,9 @@ fn do_mul(lhs: &Decimal, rhs: &Decimal) -> Res<Decimal> {
     }
 
     let mut start_to = int_word_to + frac_word_to;
-    let r_start = r_int_word_cnt + r_frac_word_cnt;
-    for l_idx in (0..l_int_word_cnt + l_frac_word_cnt).rev() {
+    let r_start = cmp::max(r_int_word_cnt + r_frac_word_cnt, 0) as usize;
+    let left_stop = cmp::max(l_int_word_cnt + l_frac_word_cnt, 0) as usize;
+    for l_idx in (0..left_stop).rev() {
         assert!(start_to >= r_start);
         let (mut carry, mut idx_to) = (0, start_to);
         start_to -= 1;
@@ -2927,6 +2928,11 @@ mod test {
             ("123", "0.01", Res::Ok("1.23")),
             ("123", "0", Res::Ok("0")),
             (&a, &b, Res::Overflow("0")),
+            (
+                "0.00000000000000",
+                "0.000000000000000000000000000000000000000000000000000000000000000",
+                Res::Truncated("0.0000000000000000000000000000000"),
+            ),
         ];
 
         for (lhs_str, rhs_str, exp_str) in cases {


### PR DESCRIPTION
## What have you changed? (mandatory)

This PR fix bug in the function `do_mul` of decimal,
The master will panic in the following case:
```
0.00000000000000*0.000000000000000000000000000000000000000000000000000000000000000
```

## What are the type of the changes? (mandatory)

- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)

unit test

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

no

## Does this PR affect tidb-ansible update? (mandatory)

no

## Refer to a related PR or issue link (optional)

https://github.com/pingcap/tikv/pull/3190

The related code in tidb: https://github.com/pingcap/tidb/blob/master/types/mydecimal.go#L1725