### PR TITLE
import: implement ImportKV APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,7 +478,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/huachaohuang/kvproto.git?branch=import-kv#7cf6563e0e3d74e33b98bf09566b3fc3181a06d7"
+source = "git+https://github.com/pingcap/kvproto.git#571f9af5d76b04b49e7812e4d5fe190c2da61904"
 dependencies = [
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1278,7 +1278,7 @@ dependencies = [
  "grpcio 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)",
- "kvproto 0.0.1 (git+https://github.com/huachaohuang/kvproto.git?branch=import-kv)",
+ "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1620,7 +1620,7 @@ dependencies = [
 "checksum jemalloc-sys 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum kvproto 0.0.1 (git+https://github.com/huachaohuang/kvproto.git?branch=import-kv)" = "<none>"
+"checksum kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)" = "<none>"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,7 +478,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git#571f9af5d76b04b49e7812e4d5fe190c2da61904"
+source = "git+https://github.com/pingcap/kvproto.git#716bb0d730ba0dbc7249a5b157bef5669027ae4f"
 dependencies = [
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,7 +478,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git#917529a2f2adb0f23c86860d9107df3b6c2046ab"
+source = "git+https://github.com/huachaohuang/kvproto.git?branch=import-kv#7cf6563e0e3d74e33b98bf09566b3fc3181a06d7"
 dependencies = [
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1278,7 +1278,7 @@ dependencies = [
  "grpcio 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)",
- "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto 0.0.1 (git+https://github.com/huachaohuang/kvproto.git?branch=import-kv)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1620,7 +1620,7 @@ dependencies = [
 "checksum jemalloc-sys 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)" = "<none>"
+"checksum kvproto 0.0.1 (git+https://github.com/huachaohuang/kvproto.git?branch=import-kv)" = "<none>"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,8 +91,7 @@ git = "https://github.com/pingcap/murmur3.git"
 git = "https://github.com/pingcap/rust-rocksdb.git"
 
 [dependencies.kvproto]
-git = "https://github.com/huachaohuang/kvproto.git"
-branch = "import-kv"
+git = "https://github.com/pingcap/kvproto.git"
 
 [dependencies.tipb]
 git = "https://github.com/pingcap/tipb.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,8 @@ git = "https://github.com/pingcap/murmur3.git"
 git = "https://github.com/pingcap/rust-rocksdb.git"
 
 [dependencies.kvproto]
-git = "https://github.com/pingcap/kvproto.git"
+git = "https://github.com/huachaohuang/kvproto.git"
+branch = "import-kv"
 
 [dependencies.tipb]
 git = "https://github.com/pingcap/tipb.git"

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -474,8 +474,6 @@
 # key-path = ""
 
 [import]
-# the directory to store importing kv data.
-# import-dir = "/tmp/tikv/import"
 # number of threads to handle RPC requests.
 # num-threads = 8
 # stream channel window size, stream will be blocked on channel full.

--- a/etc/tikv-importer.toml
+++ b/etc/tikv-importer.toml
@@ -41,5 +41,11 @@ compression-per-level = ["lz4", "no", "no", "no", "no", "no", "zstd"]
 import-dir = "/tmp/tikv/import"
 # number of threads to handle RPC requests.
 num-threads = 16
+# number of concurrent import jobs.
+num-import-jobs = 24
+# maximum duration to prepare regions.
+# max-prepare-duration = "5m"
+# split regions into this size according to the importing data.
+# region-split-size = "96MB"
 # stream channel window size, stream will be blocked on channel full.
-stream-channel-window = 128
+# stream-channel-window = 128

--- a/src/import/client.rs
+++ b/src/import/client.rs
@@ -1,0 +1,287 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::{Cursor, Read};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use futures::future;
+use futures::{Async, Future, Poll, Stream};
+use grpc::{CallOption, Channel, ChannelBuilder, EnvBuilder, Environment, WriteFlags};
+
+use kvproto::import_sstpb::*;
+use kvproto::import_sstpb_grpc::*;
+use kvproto::kvrpcpb::*;
+use kvproto::tikvpb_grpc::*;
+
+use pd::{Config as PdConfig, PdClient, RegionInfo, RpcClient};
+use storage::types::Key;
+use util::collections::{HashMap, HashMapEntry};
+use util::security::SecurityManager;
+
+use super::common::*;
+use super::{Error, Result};
+
+pub trait ImportClient: Send + Sync + Clone + 'static {
+    fn get_region(&self, _: &[u8]) -> Result<RegionInfo> {
+        unimplemented!()
+    }
+
+    fn split_region(&self, _: &RegionInfo, _: &[u8]) -> Result<SplitRegionResponse> {
+        unimplemented!()
+    }
+
+    fn scatter_region(&self, _: &RegionInfo) -> Result<()> {
+        unimplemented!()
+    }
+
+    fn upload_sst(&self, _: u64, _: UploadStream) -> Result<UploadResponse> {
+        unimplemented!()
+    }
+
+    fn ingest_sst(&self, _: u64, _: IngestRequest) -> Result<IngestResponse> {
+        unimplemented!()
+    }
+}
+
+pub struct Client {
+    pd: Arc<RpcClient>,
+    env: Arc<Environment>,
+    channels: Mutex<HashMap<u64, Channel>>,
+}
+
+impl Client {
+    pub fn new(pd_addr: &str, cq_count: usize) -> Result<Client> {
+        let cfg = PdConfig {
+            endpoints: vec![pd_addr.to_owned()],
+        };
+        let sec_mgr = SecurityManager::default();
+        let rpc_client = RpcClient::new(&cfg, Arc::new(sec_mgr))?;
+        let env = EnvBuilder::new()
+            .name_prefix("import-client")
+            .cq_count(cq_count)
+            .build();
+        Ok(Client {
+            pd: Arc::new(rpc_client),
+            env: Arc::new(env),
+            channels: Mutex::new(HashMap::default()),
+        })
+    }
+
+    fn option(&self, timeout: Duration) -> CallOption {
+        let write_flags = WriteFlags::default().buffer_hint(true);
+        CallOption::default()
+            .timeout(timeout)
+            .write_flags(write_flags)
+    }
+
+    fn resolve(&self, store_id: u64) -> Result<Channel> {
+        let mut channels = self.channels.lock().unwrap();
+        match channels.entry(store_id) {
+            HashMapEntry::Occupied(e) => Ok(e.get().clone()),
+            HashMapEntry::Vacant(e) => {
+                let store = self.pd.get_store(store_id)?;
+                let builder = ChannelBuilder::new(Arc::clone(&self.env));
+                let channel = builder.connect(store.get_address());
+                Ok(e.insert(channel).clone())
+            }
+        }
+    }
+
+    fn post_resolve<T>(&self, store_id: u64, res: Result<T>) -> Result<T> {
+        res.map_err(|e| {
+            self.channels.lock().unwrap().remove(&store_id);
+            e
+        })
+    }
+
+    pub fn switch_stores(&self, req: &SwitchModeRequest) -> Result<()> {
+        let mut futures = Vec::new();
+        for store in self.pd.get_all_stores()? {
+            let ch = match self.resolve(store.get_id()) {
+                Ok(v) => v,
+                Err(e) => {
+                    error!("switch store {:?}: {:?}", store, e);
+                    continue;
+                }
+            };
+            let client = ImportSstClient::new(ch);
+            let future = match client.switch_mode_async(req) {
+                Ok(v) => v,
+                Err(e) => {
+                    error!("switch store {:?}: {:?}", store, e);
+                    continue;
+                }
+            };
+            futures.push(future);
+        }
+
+        future::join_all(futures)
+            .wait()
+            .map(|_| ())
+            .map_err(Error::from)
+    }
+
+    pub fn compact_stores(&self, req: &CompactRequest) -> Result<()> {
+        let mut futures = Vec::new();
+        for store in self.pd.get_all_stores()? {
+            let ch = match self.resolve(store.get_id()) {
+                Ok(v) => v,
+                Err(e) => {
+                    error!("compact store {:?}: {:?}", store, e);
+                    continue;
+                }
+            };
+            let client = ImportSstClient::new(ch);
+            let future = match client.compact_async(req) {
+                Ok(v) => v,
+                Err(e) => {
+                    error!("compact store {:?}: {:?}", store, e);
+                    continue;
+                }
+            };
+            futures.push(future);
+        }
+
+        future::join_all(futures)
+            .wait()
+            .map(|_| ())
+            .map_err(Error::from)
+    }
+}
+
+impl Clone for Client {
+    fn clone(&self) -> Client {
+        Client {
+            pd: Arc::clone(&self.pd),
+            env: Arc::clone(&self.env),
+            channels: Mutex::new(HashMap::default()),
+        }
+    }
+}
+
+impl ImportClient for Client {
+    fn get_region(&self, key: &[u8]) -> Result<RegionInfo> {
+        self.pd.get_region_info(key).map_err(Error::from)
+    }
+
+    fn split_region(&self, region: &RegionInfo, split_key: &[u8]) -> Result<SplitRegionResponse> {
+        let ctx = new_context(region);
+        let store_id = ctx.get_peer().get_store_id();
+
+        let mut req = SplitRegionRequest::new();
+        req.set_context(ctx);
+        req.set_split_key(Key::from_encoded(split_key.to_owned()).raw()?);
+
+        let ch = self.resolve(store_id)?;
+        let client = TikvClient::new(ch);
+        let res = client.split_region_opt(&req, self.option(Duration::from_secs(3)));
+        self.post_resolve(store_id, res.map_err(Error::from))
+    }
+
+    fn scatter_region(&self, region: &RegionInfo) -> Result<()> {
+        self.pd.scatter_region(region.clone()).map_err(Error::from)
+    }
+
+    fn upload_sst(&self, store_id: u64, req: UploadStream) -> Result<UploadResponse> {
+        let ch = self.resolve(store_id)?;
+        let client = ImportSstClient::new(ch);
+        let (tx, rx) = client.upload_opt(self.option(Duration::from_secs(30)))?;
+        let res = req.forward(tx).and_then(|_| rx.map_err(Error::from)).wait();
+        self.post_resolve(store_id, res.map_err(Error::from))
+    }
+
+    fn ingest_sst(&self, store_id: u64, req: IngestRequest) -> Result<IngestResponse> {
+        let ch = self.resolve(store_id)?;
+        let client = ImportSstClient::new(ch);
+        let res = client.ingest_opt(&req, self.option(Duration::from_secs(30)));
+        self.post_resolve(store_id, res.map_err(Error::from))
+    }
+}
+
+pub struct UploadStream<'a> {
+    meta: Option<SSTMeta>,
+    size: usize,
+    cursor: Cursor<&'a [u8]>,
+}
+
+impl<'a> UploadStream<'a> {
+    pub fn new(meta: SSTMeta, data: &[u8]) -> UploadStream {
+        UploadStream {
+            meta: Some(meta),
+            size: data.len(),
+            cursor: Cursor::new(data),
+        }
+    }
+}
+
+const UPLOAD_CHUNK_SIZE: usize = 1024 * 1024;
+
+impl<'a> Stream for UploadStream<'a> {
+    type Item = (UploadRequest, WriteFlags);
+    type Error = Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Error> {
+        let flags = WriteFlags::default().buffer_hint(true);
+
+        if let Some(meta) = self.meta.take() {
+            let mut chunk = UploadRequest::new();
+            chunk.set_meta(meta);
+            return Ok(Async::Ready(Some((chunk, flags))));
+        }
+
+        let mut buf = match self.size - self.cursor.position() as usize {
+            0 => return Ok(Async::Ready(None)),
+            n if n > UPLOAD_CHUNK_SIZE => vec![0; UPLOAD_CHUNK_SIZE],
+            n => vec![0; n],
+        };
+
+        self.cursor.read_exact(buf.as_mut_slice())?;
+        let mut chunk = UploadRequest::new();
+        chunk.set_data(buf);
+        Ok(Async::Ready(Some((chunk, flags))))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::{self, Rng};
+
+    #[test]
+    fn test_upload_stream() {
+        let mut meta = SSTMeta::new();
+        meta.set_crc32(123);
+        meta.set_length(321);
+
+        let mut data = vec![0u8; UPLOAD_CHUNK_SIZE * 4];
+        rand::thread_rng().fill_bytes(&mut data);
+
+        let mut stream = UploadStream::new(meta.clone(), &data);
+
+        // Check meta.
+        if let Async::Ready(Some((upload, _))) = stream.poll().unwrap() {
+            assert_eq!(upload.get_meta().get_crc32(), meta.get_crc32());
+            assert_eq!(upload.get_meta().get_length(), meta.get_length());
+        } else {
+            panic!("can not poll upload meta");
+        }
+
+        // Check data.
+        let mut buf: Vec<u8> = Vec::with_capacity(UPLOAD_CHUNK_SIZE * 4);
+        while let Async::Ready(Some((upload, _))) = stream.poll().unwrap() {
+            buf.extend(upload.get_data());
+        }
+        assert_eq!(buf, data);
+    }
+}

--- a/src/import/client.rs
+++ b/src/import/client.rs
@@ -105,7 +105,7 @@ impl Client {
         })
     }
 
-    pub fn switch_stores(&self, req: &SwitchModeRequest) -> Result<()> {
+    pub fn switch_cluster(&self, req: &SwitchModeRequest) -> Result<()> {
         let mut futures = Vec::new();
         for store in self.pd.get_all_stores()? {
             let ch = match self.resolve(store.get_id()) {
@@ -132,7 +132,7 @@ impl Client {
             .map_err(Error::from)
     }
 
-    pub fn compact_stores(&self, req: &CompactRequest) -> Result<()> {
+    pub fn compact_cluster(&self, req: &CompactRequest) -> Result<()> {
         let mut futures = Vec::new();
         for store in self.pd.get_all_stores()? {
             let ch = match self.resolve(store.get_id()) {

--- a/src/import/common.rs
+++ b/src/import/common.rs
@@ -1,0 +1,205 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ops::Deref;
+use std::sync::Arc;
+
+use kvproto::import_sstpb::*;
+use kvproto::kvrpcpb::*;
+use kvproto::metapb::*;
+
+use pd::RegionInfo;
+
+use super::client::*;
+
+// Just used as a mark, don't use them in comparison.
+pub const RANGE_MIN: &[u8] = &[];
+pub const RANGE_MAX: &[u8] = &[];
+
+pub fn new_range(start: &[u8], end: &[u8]) -> Range {
+    let mut range = Range::new();
+    range.set_start(start.to_owned());
+    range.set_end(end.to_owned());
+    range
+}
+
+pub fn before_end(key: &[u8], end: &[u8]) -> bool {
+    key < end || end == RANGE_MAX
+}
+
+pub fn inside_region(key: &[u8], region: &Region) -> bool {
+    key >= region.get_start_key() && before_end(key, region.get_end_key())
+}
+
+#[derive(Clone, Debug)]
+pub struct RangeInfo {
+    pub range: Range,
+    pub size: usize,
+}
+
+impl RangeInfo {
+    pub fn new(start: &[u8], end: &[u8], size: usize) -> RangeInfo {
+        RangeInfo {
+            range: new_range(start, end),
+            size,
+        }
+    }
+}
+
+impl Deref for RangeInfo {
+    type Target = Range;
+
+    fn deref(&self) -> &Self::Target {
+        &self.range
+    }
+}
+
+pub struct RangeContext<Client> {
+    client: Arc<Client>,
+    region: Option<RegionInfo>,
+    raw_size: usize,
+    limit_size: usize,
+}
+
+impl<Client: ImportClient> RangeContext<Client> {
+    pub fn new(client: Arc<Client>, limit_size: usize) -> RangeContext<Client> {
+        RangeContext {
+            client,
+            region: None,
+            raw_size: 0,
+            limit_size,
+        }
+    }
+
+    pub fn add(&mut self, size: usize) {
+        self.raw_size += size;
+    }
+
+    /// Reset size and region for the next key.
+    pub fn reset(&mut self, key: &[u8]) {
+        self.raw_size = 0;
+        if let Some(ref region) = self.region {
+            if before_end(key, region.get_end_key()) {
+                // Still belongs in this region, no need to update.
+                return;
+            }
+        }
+        self.region = match self.client.get_region(key) {
+            Ok(region) => Some(region),
+            Err(e) => {
+                error!("get region: {:?}", e);
+                None
+            }
+        }
+    }
+
+    pub fn raw_size(&self) -> usize {
+        self.raw_size
+    }
+
+    /// Check size and region range to see if we should stop before this key.
+    pub fn should_stop_before(&self, key: &[u8]) -> bool {
+        if self.raw_size >= self.limit_size {
+            return true;
+        }
+        match self.region {
+            Some(ref region) => !before_end(key, region.get_end_key()),
+            None => false,
+        }
+    }
+}
+
+pub fn new_context(region: &RegionInfo) -> Context {
+    let peer = if let Some(ref leader) = region.leader {
+        leader.clone()
+    } else {
+        // We don't know the leader, just choose the first one.
+        region.get_peers().first().unwrap().clone()
+    };
+
+    let mut ctx = Context::new();
+    ctx.set_region_id(region.get_id());
+    ctx.set_region_epoch(region.get_region_epoch().clone());
+    ctx.set_peer(peer.clone());
+    ctx
+}
+
+pub fn find_region_peer(region: &Region, store_id: u64) -> Option<Peer> {
+    region
+        .get_peers()
+        .iter()
+        .find(|p| p.get_store_id() == store_id)
+        .cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use import::test_helpers::*;
+
+    #[test]
+    fn test_before_end() {
+        assert!(before_end(b"ab", b"bc"));
+        assert!(!before_end(b"ab", b"ab"));
+        assert!(!before_end(b"cd", b"bc"));
+        assert!(before_end(b"cd", RANGE_MAX));
+    }
+
+    fn new_region_range(start: &[u8], end: &[u8]) -> Region {
+        let mut r = Region::new();
+        r.set_start_key(start.to_vec());
+        r.set_end_key(end.to_vec());
+        r
+    }
+
+    #[test]
+    fn test_inside_region() {
+        assert!(inside_region(&[], &new_region_range(&[], &[])));
+        assert!(inside_region(&[1], &new_region_range(&[], &[])));
+        assert!(inside_region(&[1], &new_region_range(&[], &[2])));
+        assert!(inside_region(&[1], &new_region_range(&[0], &[])));
+        assert!(inside_region(&[1], &new_region_range(&[1], &[])));
+        assert!(inside_region(&[1], &new_region_range(&[0], &[2])));
+        assert!(!inside_region(&[2], &new_region_range(&[], &[2])));
+        assert!(!inside_region(&[2], &new_region_range(&[3], &[])));
+        assert!(!inside_region(&[2], &new_region_range(&[0], &[1])));
+    }
+
+    #[test]
+    fn test_range_context() {
+        let mut client = MockClient::new();
+        client.add_region_range(b"", b"k4");
+        client.add_region_range(b"k4", b"");
+
+        let mut ctx = RangeContext::new(Arc::new(client), 8);
+
+        ctx.add(4);
+        assert!(!ctx.should_stop_before(b"k2"));
+        ctx.add(4);
+        assert_eq!(ctx.raw_size(), 8);
+        // Reach size limit.
+        assert!(ctx.should_stop_before(b"k3"));
+
+        ctx.reset(b"k3");
+        assert_eq!(ctx.raw_size(), 0);
+        ctx.add(4);
+        assert_eq!(ctx.raw_size(), 4);
+        // Reach region end.
+        assert!(ctx.should_stop_before(b"k4"));
+
+        ctx.reset(b"k4");
+        assert_eq!(ctx.raw_size(), 0);
+        ctx.add(4);
+        assert!(!ctx.should_stop_before(b"k5"));
+    }
+}

--- a/src/import/config.rs
+++ b/src/import/config.rs
@@ -14,12 +14,19 @@
 use std::error::Error;
 use std::result::Result;
 
+use raftstore::coprocessor::config::SPLIT_SIZE_MB;
+use util::config::{ReadableDuration, ReadableSize};
+
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
     pub import_dir: String,
     pub num_threads: usize,
+    pub num_import_jobs: usize,
+    pub num_import_sst_jobs: usize,
+    pub max_prepare_duration: ReadableDuration,
+    pub region_split_size: ReadableSize,
     pub stream_channel_window: usize,
 }
 
@@ -28,6 +35,10 @@ impl Default for Config {
         Config {
             import_dir: "/tmp/tikv/import".to_owned(),
             num_threads: 8,
+            num_import_jobs: 8,
+            num_import_sst_jobs: 2,
+            max_prepare_duration: ReadableDuration::minutes(5),
+            region_split_size: ReadableSize::mb(SPLIT_SIZE_MB),
             stream_channel_window: 128,
         }
     }
@@ -37,6 +48,15 @@ impl Config {
     pub fn validate(&self) -> Result<(), Box<Error>> {
         if self.num_threads == 0 {
             return Err("import.num_threads can not be 0".into());
+        }
+        if self.num_import_jobs == 0 {
+            return Err("import.num_import_jobs can not be 0".into());
+        }
+        if self.num_import_sst_jobs == 0 {
+            return Err("import.num_import_sst_jobs can not be 0".into());
+        }
+        if self.region_split_size.0 == 0 {
+            return Err("import.region_split_size can not be 0".into());
         }
         if self.stream_channel_window == 0 {
             return Err("import.stream_channel_window can not be 0".into());

--- a/src/import/engine.rs
+++ b/src/import/engine.rs
@@ -14,6 +14,7 @@
 use std::cmp;
 use std::fmt;
 use std::i32;
+use std::io::Read;
 use std::ops::Deref;
 use std::path::Path;
 use std::sync::Arc;
@@ -21,23 +22,29 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 use kvproto::import_kvpb::*;
-use rocksdb::{BlockBasedOptions, ColumnFamilyOptions, DBOptions, Writable, WriteBatch as RawBatch,
+use kvproto::import_sstpb::*;
+use rocksdb::{BlockBasedOptions, ColumnFamilyOptions, DBIterator, DBOptions, Env, EnvOptions,
+              ExternalSstFileInfo, ReadOptions, SstFileWriter, Writable, WriteBatch as RawBatch,
               DB};
 
 use config::DbConfig;
-use storage::CF_DEFAULT;
-use storage::types::Key;
+use raftstore::store::keys;
+use storage::mvcc::{Write, WriteType};
+use storage::types::{split_encoded_key_on_ts, Key};
+use storage::{is_short_value, CF_DEFAULT, CF_WRITE};
 use util::config::MB;
-use util::rocksdb::properties::SizePropertiesCollectorFactory;
+use util::rocksdb::properties::{SizeProperties, SizePropertiesCollectorFactory};
 use util::rocksdb::{new_engine_opt, CFOptions};
 
 use super::Result;
+use super::common::*;
 
 /// Engine wraps rocksdb::DB with customized options to support efficient bulk
 /// write.
 pub struct Engine {
     db: Arc<DB>,
     uuid: Uuid,
+    opts: DbConfig,
 }
 
 impl Engine {
@@ -49,6 +56,7 @@ impl Engine {
         Ok(Engine {
             db: Arc::new(db),
             uuid,
+            opts,
         })
     }
 
@@ -75,6 +83,28 @@ impl Engine {
 
         Ok(size)
     }
+
+    pub fn new_iter(&self, verify_checksum: bool) -> DBIterator<Arc<DB>> {
+        let mut ropts = ReadOptions::new();
+        ropts.fill_cache(false);
+        ropts.set_verify_checksums(verify_checksum);
+        DBIterator::new(Arc::clone(&self.db), ropts)
+    }
+
+    pub fn new_sst_writer(&self) -> Result<SSTWriter> {
+        SSTWriter::new(&self.opts)
+    }
+
+    pub fn get_size_properties(&self) -> Result<SizeProperties> {
+        let mut res = SizeProperties::default();
+        let collection = self.get_properties_of_all_tables()?;
+        for (_, v) in &*collection {
+            let props = SizeProperties::decode(v.user_collected_properties())?;
+            res.total_size += props.total_size;
+            res.index_handles.extend(props.index_handles.clone());
+        }
+        Ok(res)
+    }
 }
 
 impl Deref for Engine {
@@ -92,6 +122,126 @@ impl fmt::Debug for Engine {
             .field("path", &self.path().to_owned())
             .finish()
     }
+}
+
+pub struct SSTInfo {
+    pub data: Vec<u8>,
+    pub range: Range,
+    pub cf_name: String,
+}
+
+impl SSTInfo {
+    pub fn new(env: Arc<Env>, info: ExternalSstFileInfo, cf_name: &str) -> Result<SSTInfo> {
+        let mut data = Vec::new();
+        let path = info.file_path();
+        let mut f = env.new_sequential_file(path.to_str().unwrap(), EnvOptions::new())?;
+        f.read_to_end(&mut data)?;
+        assert_eq!(data.len(), info.file_size() as usize);
+
+        // This range doesn't contain the data prefix, like the region range.
+        let mut range = Range::new();
+        range.set_start(keys::origin_key(info.smallest_key()).to_owned());
+        range.set_end(keys::origin_key(info.largest_key()).to_owned());
+
+        Ok(SSTInfo {
+            data,
+            range,
+            cf_name: cf_name.to_owned(),
+        })
+    }
+}
+
+pub struct SSTWriter {
+    env: Arc<Env>,
+    default: SstFileWriter,
+    default_entries: u64,
+    write: SstFileWriter,
+    write_entries: u64,
+}
+
+impl SSTWriter {
+    pub fn new(cfg: &DbConfig) -> Result<SSTWriter> {
+        let env = Arc::new(Env::new_mem());
+
+        let mut default_opts = cfg.defaultcf.build_opt();
+        default_opts.set_env(Arc::clone(&env));
+        let mut default = SstFileWriter::new(EnvOptions::new(), default_opts);
+        default.open(CF_DEFAULT)?;
+
+        let mut write_opts = cfg.writecf.build_opt();
+        write_opts.set_env(Arc::clone(&env));
+        let mut write = SstFileWriter::new(EnvOptions::new(), write_opts);
+        write.open(CF_WRITE)?;
+
+        Ok(SSTWriter {
+            env,
+            default,
+            default_entries: 0,
+            write,
+            write_entries: 0,
+        })
+    }
+
+    pub fn put(&mut self, key: &[u8], value: &[u8]) -> Result<()> {
+        let k = keys::data_key(key);
+        let (_, commit_ts) = split_encoded_key_on_ts(key)?;
+        if is_short_value(value) {
+            let w = Write::new(WriteType::Put, commit_ts, Some(value.to_vec()));
+            self.write.put(&k, &w.to_bytes())?;
+            self.write_entries += 1;
+        } else {
+            let w = Write::new(WriteType::Put, commit_ts, None);
+            self.write.put(&k, &w.to_bytes())?;
+            self.write_entries += 1;
+            self.default.put(&k, value)?;
+            self.default_entries += 1;
+        }
+        Ok(())
+    }
+
+    pub fn finish(&mut self) -> Result<Vec<SSTInfo>> {
+        let mut infos = Vec::new();
+        if self.default_entries > 0 {
+            let info = self.default.finish()?;
+            infos.push(SSTInfo::new(Arc::clone(&self.env), info, CF_DEFAULT)?);
+        }
+        if self.write_entries > 0 {
+            let info = self.write.finish()?;
+            infos.push(SSTInfo::new(Arc::clone(&self.env), info, CF_WRITE)?);
+        }
+        Ok(infos)
+    }
+}
+
+pub fn get_approximate_ranges(
+    props: &SizeProperties,
+    max_ranges: usize,
+    min_range_size: usize,
+) -> Vec<RangeInfo> {
+    let range_size = (props.total_size as usize + max_ranges - 1) / max_ranges;
+    let range_size = cmp::max(range_size, min_range_size);
+
+    let mut size = 0;
+    let mut start = RANGE_MIN;
+    let mut ranges = Vec::new();
+    for (i, (k, v)) in props.index_handles.iter().enumerate() {
+        size += v.size as usize;
+        let end = if i == (props.index_handles.len() - 1) {
+            // Index range end is inclusive, so we need to use RANGE_MAX as
+            // the last range end.
+            RANGE_MAX
+        } else {
+            k
+        };
+        if size >= range_size || i == (props.index_handles.len() - 1) {
+            let range = RangeInfo::new(start, end, size);
+            ranges.push(range);
+            size = 0;
+            start = end;
+        }
+    }
+
+    ranges
 }
 
 fn tune_dboptions_for_bulk_load(opts: &DbConfig) -> (DBOptions, CFOptions) {
@@ -132,7 +282,16 @@ fn tune_dboptions_for_bulk_load(opts: &DbConfig) -> (DBOptions, CFOptions) {
 mod tests {
     use super::*;
 
+    use kvproto::kvrpcpb::IsolationLevel;
+    use kvproto::metapb::{Peer, Region};
+    use rocksdb::IngestExternalFileOptions;
+    use std::fs::File;
+    use std::io::Write;
     use tempdir::TempDir;
+
+    use raftstore::store::RegionSnapshot;
+    use storage::mvcc::MvccReader;
+    use util::rocksdb::new_engine_opt;
 
     fn new_engine() -> (TempDir, Engine) {
         let dir = TempDir::new("test_import_engine").unwrap();
@@ -172,5 +331,118 @@ mod tests {
             let key = new_encoded_key(i, commit_ts);
             assert_eq!(engine.get(&key).unwrap().unwrap(), &[i]);
         }
+    }
+
+    #[test]
+    fn test_sst_writer() {
+        test_sst_writer_with(1, &[CF_WRITE]);
+        test_sst_writer_with(1024, &[CF_DEFAULT, CF_WRITE]);
+    }
+
+    fn test_sst_writer_with(value_size: usize, cf_names: &[&str]) {
+        let temp_dir = TempDir::new("_test_sst_writer").unwrap();
+
+        let cfg = DbConfig::default();
+        let db_opts = cfg.build_opt();
+        let cfs_opts = cfg.build_cf_opts();
+        let db = new_engine_opt(temp_dir.path().to_str().unwrap(), db_opts, cfs_opts).unwrap();
+        let db = Arc::new(db);
+
+        let n = 10;
+        let commit_ts = 10;
+        let mut w = SSTWriter::new(&cfg).unwrap();
+
+        // Write some keys.
+        let value = vec![1u8; value_size];
+        for i in 0..n {
+            let key = new_encoded_key(i, commit_ts);
+            w.put(&key, &value).unwrap();
+        }
+
+        let infos = w.finish().unwrap();
+        assert_eq!(infos.len(), cf_names.len());
+
+        for (info, cf_name) in infos.iter().zip(cf_names.iter()) {
+            // Check SSTInfo
+            let start = new_encoded_key(0, commit_ts);
+            let end = new_encoded_key(n - 1, commit_ts);
+            assert_eq!(info.range.get_start(), start.as_slice());
+            assert_eq!(info.range.get_end(), end.as_slice());
+            assert_eq!(info.cf_name, cf_name.to_owned());
+
+            // Write the data to a file and ingest it to the engine.
+            let path = Path::new(db.path()).join("test.sst");
+            File::create(&path).unwrap().write_all(&info.data).unwrap();
+            let mut opts = IngestExternalFileOptions::new();
+            opts.move_files(true);
+            let handle = db.cf_handle(cf_name).unwrap();
+            db.ingest_external_file_cf(handle, &opts, &[path.to_str().unwrap()])
+                .unwrap();
+        }
+
+        // Make a fake region snapshot.
+        let mut region = Region::new();
+        region.set_id(1);
+        region.mut_peers().push(Peer::new());
+        let snap = Box::new(RegionSnapshot::from_raw(Arc::clone(&db), region));
+
+        let mut reader = MvccReader::new(snap, None, false, None, None, IsolationLevel::SI);
+        // Make sure that all kvs are right.
+        for i in 0..n {
+            let k = Key::from_raw(&[i]);
+            let v = reader.get(&k, commit_ts).unwrap().unwrap();
+            assert_eq!(&v, &value);
+        }
+        // Make sure that no extra keys are added.
+        let (keys, _) = reader.scan_keys(None, (n + 1) as usize).unwrap();
+        assert_eq!(keys.len(), n as usize);
+        for (i, expected) in keys.iter().enumerate() {
+            let k = Key::from_raw(&[i as u8]);
+            assert_eq!(k.encoded(), expected.encoded());
+        }
+    }
+
+    const SIZE_INDEX_DISTANCE: usize = 4 * 1024 * 1024;
+
+    #[test]
+    fn test_approximate_ranges() {
+        let (_dir, engine) = new_engine();
+
+        let num_files = 3;
+        let num_entries = 3;
+        for i in 0..num_files {
+            for j in 0..num_entries {
+                // (0, 3, 6), (1, 4, 7), (2, 5, 8)
+                let k = [i + j * num_files];
+                let v = vec![0u8; SIZE_INDEX_DISTANCE - k.len()];
+                engine.put(&k, &v).unwrap();
+                engine.flush(true).unwrap();
+            }
+        }
+
+        let props = engine.get_size_properties().unwrap();
+
+        let ranges = get_approximate_ranges(&props, 1, 0);
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].start, RANGE_MIN.to_owned());
+        assert_eq!(ranges[0].end, RANGE_MAX.to_owned());
+
+        let ranges = get_approximate_ranges(&props, 3, 0);
+        assert_eq!(ranges.len(), 3);
+        assert_eq!(ranges[0].start, RANGE_MIN.to_owned());
+        assert_eq!(ranges[0].end, vec![2]);
+        assert_eq!(ranges[1].start, vec![2]);
+        assert_eq!(ranges[1].end, vec![5]);
+        assert_eq!(ranges[2].start, vec![5]);
+        assert_eq!(ranges[2].end, RANGE_MAX.to_owned());
+
+        let ranges = get_approximate_ranges(&props, 4, SIZE_INDEX_DISTANCE * 4);
+        assert_eq!(ranges.len(), 3);
+        assert_eq!(ranges[0].start, RANGE_MIN.to_owned());
+        assert_eq!(ranges[0].end, vec![3]);
+        assert_eq!(ranges[1].start, vec![3]);
+        assert_eq!(ranges[1].end, vec![7]);
+        assert_eq!(ranges[2].start, vec![7]);
+        assert_eq!(ranges[2].end, RANGE_MAX.to_owned());
     }
 }

--- a/src/import/import.rs
+++ b/src/import/import.rs
@@ -1,0 +1,384 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use kvproto::import_sstpb::*;
+use uuid::Uuid;
+
+use pd::RegionInfo;
+
+use super::client::*;
+use super::common::*;
+use super::engine::*;
+use super::prepare::*;
+use super::stream::*;
+use super::{Config, Error, Result};
+
+const MAX_RETRY_TIMES: u64 = 5;
+const RETRY_INTERVAL_SECS: u64 = 3;
+
+pub struct ImportJob<Client> {
+    tag: String,
+    cfg: Config,
+    client: Client,
+    engine: Arc<Engine>,
+    counter: Arc<AtomicUsize>,
+}
+
+impl<Client: ImportClient> ImportJob<Client> {
+    pub fn new(cfg: Config, client: Client, engine: Engine) -> ImportJob<Client> {
+        ImportJob {
+            tag: format!("[ImportJob {}]", engine.uuid()),
+            cfg,
+            client,
+            engine: Arc::new(engine),
+            counter: Arc::new(AtomicUsize::new(1)),
+        }
+    }
+
+    pub fn run(&self) -> Result<()> {
+        let start = Instant::now();
+        info!("{} start", self.tag);
+
+        let job = PrepareJob::new(
+            self.cfg.clone(),
+            self.client.clone(),
+            Arc::clone(&self.engine),
+        );
+        let ranges = job.run()?;
+        let handles = self.run_import_threads(ranges);
+
+        // Join and check results.
+        let mut res = Ok(());
+        for h in handles {
+            if let Err(e) = h.join().unwrap() {
+                res = Err(e)
+            }
+        }
+
+        match res {
+            Ok(_) => {
+                info!("{} takes {:?}", self.tag, start.elapsed());
+                Ok(())
+            }
+            Err(e) => {
+                error!("{}: {:?}", self.tag, e);
+                Err(e)
+            }
+        }
+    }
+
+    fn new_import_thread(&self, id: u64, range: RangeInfo) -> JoinHandle<Result<()>> {
+        let cfg = self.cfg.clone();
+        let client = self.client.clone();
+        let engine = Arc::clone(&self.engine);
+        let counter = Arc::clone(&self.counter);
+
+        thread::Builder::new()
+            .name("import-job".to_owned())
+            .spawn(move || {
+                let job = SubImportJob::new(id, cfg, range, client, engine, counter);
+                job.run()
+            })
+            .unwrap()
+    }
+
+    fn run_import_threads(&self, ranges: Vec<RangeInfo>) -> Vec<JoinHandle<Result<()>>> {
+        let mut handles = Vec::new();
+        for (i, range) in ranges.into_iter().enumerate() {
+            handles.push(self.new_import_thread(i as u64, range));
+        }
+        handles
+    }
+}
+
+struct SubImportJob<Client> {
+    id: u64,
+    tag: String,
+    cfg: Config,
+    range: RangeInfo,
+    client: Arc<Client>,
+    engine: Arc<Engine>,
+    counter: Arc<AtomicUsize>,
+    num_errors: Arc<AtomicUsize>,
+    finished_ranges: Arc<Mutex<Vec<Range>>>,
+}
+
+impl<Client: ImportClient> SubImportJob<Client> {
+    fn new(
+        id: u64,
+        cfg: Config,
+        range: RangeInfo,
+        client: Client,
+        engine: Arc<Engine>,
+        counter: Arc<AtomicUsize>,
+    ) -> SubImportJob<Client> {
+        SubImportJob {
+            id,
+            tag: format!("[SubImportJob {}:{}]", engine.uuid(), id),
+            cfg,
+            range,
+            client: Arc::new(client),
+            engine,
+            counter,
+            num_errors: Arc::new(AtomicUsize::new(0)),
+            finished_ranges: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn run(&self) -> Result<()> {
+        let start = Instant::now();
+        info!("{} start {:?}", self.tag, self.range);
+
+        for i in 0..MAX_RETRY_TIMES {
+            if i != 0 {
+                thread::sleep(Duration::from_secs(RETRY_INTERVAL_SECS));
+            }
+
+            let (tx, rx) = mpsc::sync_channel(self.cfg.num_import_sst_jobs);
+            let handles = self.run_import_threads(rx);
+            if let Err(e) = self.run_import_stream(tx) {
+                error!("{} import stream: {:?}", self.tag, e);
+                continue;
+            }
+            for h in handles {
+                h.join().unwrap();
+            }
+            // Check and reset number of errors.
+            if self.num_errors.swap(0, Ordering::SeqCst) > 0 {
+                continue;
+            }
+
+            // Make sure that we don't miss some ranges.
+            let mut stream = self.new_import_stream();
+            assert!(stream.next().unwrap().is_none());
+
+            let range_count = self.finished_ranges.lock().unwrap().len();
+            info!(
+                "{} import {} ranges takes {:?}",
+                self.tag,
+                range_count,
+                start.elapsed(),
+            );
+
+            return Ok(());
+        }
+
+        error!("{} run out of time", self.tag);
+        Err(Error::ImportJobFailed(self.tag.clone()))
+    }
+
+    fn new_import_stream(&self) -> SSTFileStream<Client> {
+        SSTFileStream::new(
+            self.cfg.clone(),
+            Arc::clone(&self.client),
+            Arc::clone(&self.engine),
+            self.range.range.clone(),
+            self.finished_ranges.lock().unwrap().clone(),
+        )
+    }
+
+    fn run_import_stream(&self, tx: mpsc::SyncSender<SSTRange>) -> Result<()> {
+        let mut stream = self.new_import_stream();
+        while let Some(info) = stream.next()? {
+            tx.send(info).unwrap();
+        }
+        Ok(())
+    }
+
+    fn run_import_threads(&self, rx: mpsc::Receiver<SSTRange>) -> Vec<JoinHandle<()>> {
+        let mut handles = Vec::new();
+        let rx = Arc::new(Mutex::new(rx));
+        for _ in 0..self.cfg.num_import_sst_jobs {
+            handles.push(self.new_import_thread(Arc::clone(&rx)));
+        }
+        handles
+    }
+
+    fn new_import_thread(&self, rx: Arc<Mutex<mpsc::Receiver<SSTRange>>>) -> JoinHandle<()> {
+        let sub_id = self.id;
+        let client = Arc::clone(&self.client);
+        let engine = Arc::clone(&self.engine);
+        let counter = Arc::clone(&self.counter);
+        let num_errors = Arc::clone(&self.num_errors);
+        let finished_ranges = Arc::clone(&self.finished_ranges);
+
+        thread::Builder::new()
+            .name("import-sst-job".to_owned())
+            .spawn(move || {
+                'OUTER_LOOP: while let Ok((range, ssts)) = rx.lock().unwrap().recv() {
+                    for sst in ssts {
+                        let id = counter.fetch_add(1, Ordering::SeqCst);
+                        let tag = format!("[ImportSSTJob {}:{}:{}]", engine.uuid(), sub_id, id);
+                        let mut job = ImportSSTJob::new(tag, sst, Arc::clone(&client));
+                        if job.run().is_err() {
+                            num_errors.fetch_add(1, Ordering::SeqCst);
+                            continue 'OUTER_LOOP;
+                        }
+                    }
+                    finished_ranges.lock().unwrap().push(range);
+                }
+            })
+            .unwrap()
+    }
+}
+
+struct ImportSSTJob<Client> {
+    tag: String,
+    sst: SSTFile,
+    client: Arc<Client>,
+}
+
+impl<Client: ImportClient> ImportSSTJob<Client> {
+    fn new(tag: String, sst: SSTFile, client: Arc<Client>) -> ImportSSTJob<Client> {
+        ImportSSTJob { tag, sst, client }
+    }
+
+    fn run(&mut self) -> Result<()> {
+        let start = Instant::now();
+        info!("{} start {:?}", self.tag, self.sst);
+
+        for i in 0..MAX_RETRY_TIMES {
+            if i != 0 {
+                thread::sleep(Duration::from_secs(RETRY_INTERVAL_SECS));
+            }
+
+            let range = self.sst.meta.get_range().clone();
+            let mut region = match self.client.get_region(range.get_start()) {
+                Ok(region) => if self.sst.inside_region(&region) {
+                    region
+                } else {
+                    warn!("{} outside of {:?}", self.tag, region);
+                    return Err(Error::ImportSSTJobFailed(self.tag.clone()));
+                },
+                Err(e) => {
+                    warn!("{}: {:?}", self.tag, e);
+                    continue;
+                }
+            };
+
+            for _ in 0..MAX_RETRY_TIMES {
+                match self.import(region) {
+                    Ok(_) => {
+                        info!("{} takes {:?}", self.tag, start.elapsed());
+                        return Ok(());
+                    }
+                    Err(Error::UpdateRegion(new_region)) => {
+                        region = new_region;
+                        continue;
+                    }
+                    Err(_) => break,
+                }
+            }
+        }
+
+        error!("{} run out of time", self.tag);
+        Err(Error::ImportSSTJobFailed(self.tag.clone()))
+    }
+
+    fn import(&mut self, mut region: RegionInfo) -> Result<()> {
+        info!("{} import to {:?}", self.tag, region);
+
+        // Update SST meta for this region.
+        {
+            let meta = &mut self.sst.meta;
+            // Uuid can not be reused, we must generate a new uuid here.
+            meta.set_uuid(Uuid::new_v4().as_bytes().to_vec());
+            meta.set_region_id(region.get_id());
+            meta.set_region_epoch(region.get_region_epoch().clone());
+        }
+
+        self.upload(&region)?;
+
+        match self.ingest(&region) {
+            Ok(_) => Ok(()),
+            Err(Error::NotLeader(new_leader)) => {
+                region.leader = new_leader;
+                Err(Error::UpdateRegion(region))
+            }
+            Err(Error::StaleEpoch(new_regions)) => {
+                let new_region = new_regions
+                    .iter()
+                    .find(|&r| self.sst.inside_region(r))
+                    .cloned();
+                match new_region {
+                    Some(new_region) => {
+                        let new_leader = region
+                            .leader
+                            .and_then(|p| find_region_peer(&new_region, p.get_store_id()));
+                        Err(Error::UpdateRegion(RegionInfo::new(new_region, new_leader)))
+                    }
+                    None => {
+                        warn!("{} stale epoch {:?}", self.tag, new_regions);
+                        Err(Error::StaleEpoch(new_regions))
+                    }
+                }
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    fn upload(&self, region: &RegionInfo) -> Result<()> {
+        for peer in region.get_peers() {
+            let upload = UploadStream::new(self.sst.meta.clone(), &self.sst.data);
+            let store_id = peer.get_store_id();
+            match self.client.upload_sst(store_id, upload) {
+                Ok(_) => {
+                    info!("{} upload to store {}", self.tag, store_id);
+                }
+                Err(e) => {
+                    warn!("{} upload to store {}: {:?}", self.tag, store_id, e);
+                    return Err(e);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn ingest(&self, region: &RegionInfo) -> Result<()> {
+        let ctx = new_context(region);
+        let store_id = ctx.get_peer().get_store_id();
+
+        let mut ingest = IngestRequest::new();
+        ingest.set_context(ctx);
+        ingest.set_sst(self.sst.meta.clone());
+
+        let res = match self.client.ingest_sst(store_id, ingest) {
+            Ok(mut resp) => if !resp.has_error() {
+                Ok(())
+            } else {
+                match Error::from(resp.take_error()) {
+                    e @ Error::NotLeader(_) | e @ Error::StaleEpoch(_) => return Err(e),
+                    e => Err(e),
+                }
+            },
+            Err(e) => Err(e),
+        };
+
+        match res {
+            Ok(_) => {
+                info!("{} ingest to store {}", self.tag, store_id);
+                Ok(())
+            }
+            Err(e) => {
+                warn!("{} ingest to store {}: {:?}", self.tag, store_id, e);
+                Err(e)
+            }
+        }
+    }
+}

--- a/src/import/kv_importer.rs
+++ b/src/import/kv_importer.rs
@@ -22,35 +22,47 @@ use uuid::Uuid;
 use config::DbConfig;
 use util::collections::HashMap;
 
+use super::client::*;
 use super::engine::*;
+use super::import::*;
 use super::{Config, Error, Result};
+
+pub struct Inner {
+    engines: HashMap<Uuid, Arc<EngineFile>>,
+    import_jobs: HashMap<Uuid, Arc<ImportJob<Client>>>,
+}
 
 /// KVImporter manages all engines according to UUID.
 pub struct KVImporter {
+    cfg: Config,
     dir: EngineDir,
-    engines: Mutex<HashMap<Uuid, Arc<EngineFile>>>,
+    inner: Mutex<Inner>,
 }
 
 impl KVImporter {
     pub fn new(cfg: Config, opts: DbConfig) -> Result<KVImporter> {
         let dir = EngineDir::new(&cfg.import_dir, opts)?;
         Ok(KVImporter {
+            cfg,
             dir,
-            engines: Mutex::new(HashMap::default()),
+            inner: Mutex::new(Inner {
+                engines: HashMap::default(),
+                import_jobs: HashMap::default(),
+            }),
         })
     }
 
     /// Open the engine.
     pub fn open_engine(&self, uuid: Uuid) -> Result<()> {
-        let mut engines = self.engines.lock().unwrap();
-        if engines.contains_key(&uuid) {
+        let mut inner = self.inner.lock().unwrap();
+        if inner.engines.contains_key(&uuid) {
             return Ok(());
         }
 
         match self.dir.open(uuid) {
             Ok(engine) => {
                 info!("open {:?}", engine);
-                engines.insert(uuid, Arc::new(engine));
+                inner.engines.insert(uuid, Arc::new(engine));
                 Ok(())
             }
             Err(e) => {
@@ -62,8 +74,8 @@ impl KVImporter {
 
     /// Returns an opened engine reference for write.
     pub fn bind_engine(&self, uuid: Uuid) -> Result<Arc<EngineFile>> {
-        let engines = self.engines.lock().unwrap();
-        match engines.get(&uuid) {
+        let inner = self.inner.lock().unwrap();
+        match inner.engines.get(&uuid) {
             Some(engine) => Ok(Arc::clone(engine)),
             None => Err(Error::EngineNotFound(uuid)),
         }
@@ -73,15 +85,15 @@ impl KVImporter {
     /// Engine can not be closed when it is writing.
     pub fn close_engine(&self, uuid: Uuid) -> Result<()> {
         let mut engine = {
-            let mut engines = self.engines.lock().unwrap();
-            let engine = match engines.remove(&uuid) {
+            let mut inner = self.inner.lock().unwrap();
+            let engine = match inner.engines.remove(&uuid) {
                 Some(engine) => engine,
                 None => return Err(Error::EngineNotFound(uuid)),
             };
             match Arc::try_unwrap(engine) {
                 Ok(engine) => engine,
                 Err(engine) => {
-                    engines.insert(uuid, engine);
+                    inner.engines.insert(uuid, engine);
                     return Err(Error::EngineInUse(uuid));
                 }
             }
@@ -94,6 +106,70 @@ impl KVImporter {
             }
             Err(e) => {
                 error!("close {:?}: {:?}", engine, e);
+                Err(e)
+            }
+        }
+    }
+
+    /// Import the engine to TiKV stores.
+    /// Engine can not be imported before it is closed.
+    pub fn import_engine(&self, uuid: Uuid, pd_addr: &str) -> Result<()> {
+        let client = Client::new(pd_addr, self.cfg.num_import_jobs)?;
+        let job = {
+            let mut inner = self.inner.lock().unwrap();
+            if inner.engines.contains_key(&uuid) || inner.import_jobs.contains_key(&uuid) {
+                return Err(Error::EngineInUse(uuid));
+            }
+            let engine = self.dir.import(uuid)?;
+            let job = Arc::new(ImportJob::new(self.cfg.clone(), client, engine));
+            inner.import_jobs.insert(uuid, Arc::clone(&job));
+            job
+        };
+
+        let res = job.run();
+        self.inner.lock().unwrap().import_jobs.remove(&uuid);
+
+        match res {
+            Ok(_) => {
+                info!("import {}", uuid);
+                Ok(())
+            }
+            Err(e) => {
+                error!("import {}: {:?}", uuid, e);
+                Err(e)
+            }
+        }
+    }
+
+    /// Clean up the engine.
+    /// Engine can not be cleaned up when it is writing or importing.
+    pub fn cleanup_engine(&self, uuid: Uuid) -> Result<()> {
+        // Drop the engine outside of the lock.
+        let _ = {
+            let mut inner = self.inner.lock().unwrap();
+            if inner.import_jobs.contains_key(&uuid) {
+                return Err(Error::EngineInUse(uuid));
+            }
+            if let Some(engine) = inner.engines.remove(&uuid) {
+                match Arc::try_unwrap(engine) {
+                    Ok(engine) => Some(engine),
+                    Err(engine) => {
+                        inner.engines.insert(uuid, engine);
+                        return Err(Error::EngineInUse(uuid));
+                    }
+                }
+            } else {
+                None
+            }
+        };
+
+        match self.dir.cleanup(uuid) {
+            Ok(_) => {
+                info!("cleanup {}", uuid);
+                Ok(())
+            }
+            Err(e) => {
+                error!("cleanup {}: {:?}", uuid, e);
                 Err(e)
             }
         }
@@ -116,9 +192,10 @@ impl EngineDir {
     fn new<P: AsRef<Path>>(root: P, opts: DbConfig) -> Result<EngineDir> {
         let root_dir = root.as_ref().to_owned();
         let temp_dir = root_dir.join(Self::TEMP_DIR);
-        if !temp_dir.exists() {
-            fs::create_dir_all(&temp_dir)?;
+        if temp_dir.exists() {
+            fs::remove_dir_all(&temp_dir)?;
         }
+        fs::create_dir_all(&temp_dir)?;
         Ok(EngineDir {
             opts,
             root_dir,
@@ -142,6 +219,22 @@ impl EngineDir {
             return Err(Error::FileExists(path.save));
         }
         EngineFile::new(uuid, path, self.opts.clone())
+    }
+
+    fn import(&self, uuid: Uuid) -> Result<Engine> {
+        let path = self.join(uuid);
+        Engine::new(&path.save, uuid, self.opts.clone())
+    }
+
+    fn cleanup(&self, uuid: Uuid) -> Result<EnginePath> {
+        let path = self.join(uuid);
+        if path.save.exists() {
+            fs::remove_dir_all(&path.save)?;
+        }
+        if path.temp.exists() {
+            fs::remove_dir_all(&path.temp)?;
+        }
+        Ok(path)
     }
 }
 

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -28,10 +28,15 @@
 //! thread to notify it of the ingesting operation.  This service is running
 //! inside TiKV because it needs to interact with raftstore.
 
+mod client;
+mod common;
 mod config;
 mod engine;
 mod errors;
+mod import;
 mod metrics;
+mod prepare;
+mod stream;
 #[macro_use]
 mod service;
 mod import_mode;

--- a/src/import/prepare.rs
+++ b/src/import/prepare.rs
@@ -1,0 +1,412 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cmp;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use kvproto::metapb::*;
+
+use pd::RegionInfo;
+use util::escape;
+use util::rocksdb::properties::SizeProperties;
+
+use super::client::*;
+use super::common::*;
+use super::engine::*;
+use super::{Config, Error, Result};
+
+const MAX_RETRY_TIMES: u64 = 3;
+const RETRY_INTERVAL_SECS: u64 = 1;
+
+pub struct PrepareJob<Client> {
+    tag: String,
+    cfg: Config,
+    client: Arc<Client>,
+    engine: Arc<Engine>,
+    counter: AtomicUsize,
+}
+
+impl<Client: ImportClient> PrepareJob<Client> {
+    pub fn new(cfg: Config, client: Client, engine: Arc<Engine>) -> PrepareJob<Client> {
+        PrepareJob {
+            tag: format!("[PrepareJob {}]", engine.uuid()),
+            cfg,
+            client: Arc::new(client),
+            engine,
+            counter: AtomicUsize::new(0),
+        }
+    }
+
+    pub fn run(&self) -> Result<Vec<RangeInfo>> {
+        let start = Instant::now();
+        info!("{} start", self.tag);
+
+        let props = match self.engine.get_size_properties() {
+            Ok(v) => {
+                info!("{} approximate size {}", self.tag, v.total_size);
+                v
+            }
+            Err(e) => {
+                error!("{} get size properties: {:?}", self.tag, e);
+                return Err(e);
+            }
+        };
+
+        let num_prepares = self.prepare(&props);
+
+        // PD needs some time to scatter regions. But we don't know how much
+        // time it should take, so we just calculate an approximate duration.
+        let wait_duration = Duration::from_millis(num_prepares as u64 * 100);
+        let wait_duration = cmp::min(wait_duration, self.cfg.max_prepare_duration.0);
+        info!(
+            "{} prepare {} ranges waits {:?}",
+            self.tag, num_prepares, wait_duration,
+        );
+        thread::sleep(wait_duration);
+
+        info!(
+            "{} prepare {} ranges takes {:?}",
+            self.tag,
+            num_prepares,
+            start.elapsed(),
+        );
+
+        Ok(get_approximate_ranges(
+            &props,
+            self.cfg.num_import_jobs,
+            self.cfg.region_split_size.0 as usize,
+        ))
+    }
+
+    fn prepare(&self, props: &SizeProperties) -> usize {
+        let split_size = self.cfg.region_split_size.0 as usize;
+        let mut ctx = RangeContext::new(Arc::clone(&self.client), split_size);
+
+        let mut num_prepares = 0;
+        let mut start = Vec::new();
+        for (k, v) in props.index_handles.iter() {
+            ctx.add(v.size as usize);
+            if !ctx.should_stop_before(k) {
+                continue;
+            }
+
+            let range = RangeInfo::new(&start, k, ctx.raw_size());
+            if let Ok(true) = self.run_prepare_job(range) {
+                num_prepares += 1;
+            }
+
+            start = k.to_owned();
+            ctx.reset(k);
+        }
+
+        num_prepares
+    }
+
+    fn run_prepare_job(&self, range: RangeInfo) -> Result<bool> {
+        let id = self.counter.fetch_add(1, Ordering::SeqCst);
+        let tag = format!("[PrepareRangeJob {}:{}]", self.engine.uuid(), id);
+        let job = PrepareRangeJob::new(tag, range, Arc::clone(&self.client));
+        job.run()
+    }
+}
+
+struct PrepareRangeJob<Client> {
+    tag: String,
+    range: RangeInfo,
+    client: Arc<Client>,
+}
+
+impl<Client: ImportClient> PrepareRangeJob<Client> {
+    fn new(tag: String, range: RangeInfo, client: Arc<Client>) -> PrepareRangeJob<Client> {
+        PrepareRangeJob { tag, range, client }
+    }
+
+    fn run(&self) -> Result<bool> {
+        let start = Instant::now();
+        info!("{} start {:?}", self.tag, self.range);
+
+        for i in 0..MAX_RETRY_TIMES {
+            if i != 0 {
+                thread::sleep(Duration::from_secs(RETRY_INTERVAL_SECS));
+            }
+
+            let mut region = match self.client.get_region(self.range.get_start()) {
+                Ok(region) => region,
+                Err(e) => {
+                    warn!("{}: {:?}", self.tag, e);
+                    continue;
+                }
+            };
+
+            for _ in 0..MAX_RETRY_TIMES {
+                match self.prepare(region) {
+                    Ok(v) => {
+                        info!("{} takes {:?}", self.tag, start.elapsed());
+                        return Ok(v);
+                    }
+                    Err(Error::UpdateRegion(new_region)) => {
+                        region = new_region;
+                        continue;
+                    }
+                    Err(_) => break,
+                }
+            }
+        }
+
+        error!("{} run out of time", self.tag);
+        Err(Error::PrepareRangeJobFailed(self.tag.clone()))
+    }
+
+    fn prepare(&self, mut region: RegionInfo) -> Result<bool> {
+        if !self.need_split(&region) {
+            return Ok(false);
+        }
+        match self.split_region(&region) {
+            Ok(new_region) => {
+                self.scatter_region(&new_region)?;
+                Ok(true)
+            }
+            Err(Error::NotLeader(new_leader)) => {
+                region.leader = new_leader;
+                Err(Error::UpdateRegion(region))
+            }
+            Err(Error::StaleEpoch(new_regions)) => {
+                let new_region = new_regions.iter().find(|&r| self.need_split(r)).cloned();
+                match new_region {
+                    Some(new_region) => {
+                        let new_leader = region
+                            .leader
+                            .and_then(|p| find_region_peer(&new_region, p.get_store_id()));
+                        Err(Error::UpdateRegion(RegionInfo::new(new_region, new_leader)))
+                    }
+                    None => {
+                        warn!("{} stale epoch {:?}", self.tag, new_regions);
+                        Err(Error::StaleEpoch(new_regions))
+                    }
+                }
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    fn need_split(&self, region: &Region) -> bool {
+        let split_key = self.range.get_end();
+        if split_key.is_empty() {
+            return false;
+        }
+        if split_key <= region.get_start_key() {
+            return false;
+        }
+        before_end(split_key, region.get_end_key())
+    }
+
+    fn split_region(&self, region: &RegionInfo) -> Result<RegionInfo> {
+        let split_key = self.range.get_end();
+        let res = match self.client.split_region(region, split_key) {
+            Ok(mut resp) => if !resp.has_region_error() {
+                Ok(resp)
+            } else {
+                match Error::from(resp.take_region_error()) {
+                    e @ Error::NotLeader(_) | e @ Error::StaleEpoch(_) => return Err(e),
+                    e => Err(e),
+                }
+            },
+            Err(e) => Err(e),
+        };
+
+        match res {
+            Ok(mut resp) => {
+                info!("{} split {:?} at {:?}", self.tag, region, escape(split_key));
+                // Just assume that the leader will be at the same store.
+                let left = resp.take_left();
+                let leader = match region.leader {
+                    Some(ref p) => find_region_peer(&left, p.get_store_id()),
+                    None => None,
+                };
+                Ok(RegionInfo::new(left, leader))
+            }
+            Err(e) => {
+                warn!(
+                    "{} split {:?} at {:?}: {:?}",
+                    self.tag,
+                    region,
+                    escape(split_key),
+                    e
+                );
+                Err(e)
+            }
+        }
+    }
+
+    fn scatter_region(&self, region: &RegionInfo) -> Result<()> {
+        match self.client.scatter_region(region) {
+            Ok(_) => {
+                info!("{} scatter region {}", self.tag, region.get_id());
+                Ok(())
+            }
+            Err(e) => {
+                warn!("{} scatter region {}: {:?}", self.tag, region.get_id(), e);
+                Err(e)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use import::test_helpers::*;
+
+    use rocksdb::Writable;
+    use tempdir::TempDir;
+    use uuid::Uuid;
+
+    use config::DbConfig;
+    use storage::types::Key;
+
+    fn new_encoded_key(k: &[u8]) -> Vec<u8> {
+        if k.is_empty() {
+            vec![]
+        } else {
+            Key::from_raw(k).encoded().to_owned()
+        }
+    }
+
+    #[test]
+    fn test_prepare_job() {
+        let dir = TempDir::new("test_import_prepare_job").unwrap();
+        let uuid = Uuid::new_v4();
+        let opts = DbConfig::default();
+        let engine = Arc::new(Engine::new(dir.path(), uuid, opts).unwrap());
+
+        // Generate entries to prepare.
+        let (n, m) = (4, 4);
+        // This size if pre-calculated.
+        let index_size = 10;
+        for i in 0..n {
+            for j in 0..m {
+                let v = &[i + j * n + 1];
+                let k = new_encoded_key(v);
+                engine.put(&k, v).unwrap();
+                assert_eq!(k.len() + v.len(), index_size);
+                engine.flush(true).unwrap();
+            }
+        }
+
+        let mut cfg = Config::default();
+        // We have n * m = 16 entries and 4 jobs.
+        cfg.num_import_jobs = 4;
+        // Each region contains at most 3 entries.
+        cfg.region_split_size.0 = index_size as u64 * 3;
+
+        // Expected ranges returned by the prepare job.
+        let ranges = vec![
+            (vec![], vec![4]),
+            (vec![4], vec![8]),
+            (vec![8], vec![12]),
+            (vec![12], vec![]),
+        ];
+
+        // Test with an empty range.
+        {
+            let mut client = MockClient::new();
+            client.add_region_range(b"", b"");
+            // Expected region ranges returned by the prepare job.
+            let region_ranges = vec![
+                (vec![], vec![3], true),
+                (vec![3], vec![6], true),
+                (vec![6], vec![9], true),
+                (vec![9], vec![12], true),
+                (vec![12], vec![15], true),
+                (vec![15], vec![], false),
+            ];
+            run_and_check_prepare_job(
+                cfg.clone(),
+                client,
+                Arc::clone(&engine),
+                &ranges,
+                &region_ranges,
+            );
+        }
+
+        // Test with some segmented region ranges.
+        {
+            let mut client = MockClient::new();
+            let keys = vec![
+                // [0, 3), [3, 5)
+                5,
+                // [5, 7)
+                7,
+                // [7, 10), [10, 13), [13, 15)
+                15,
+            ];
+            let mut last = Vec::new();
+            for i in keys {
+                let k = new_encoded_key(&[i]);
+                client.add_region_range(&last, &k);
+                last = k.clone();
+            }
+            client.add_region_range(&last, b"");
+            // Expected region ranges returned by the prepare job.
+            let region_ranges = vec![
+                (vec![], vec![3], true),
+                (vec![3], vec![5], false),
+                (vec![5], vec![7], false),
+                (vec![7], vec![10], true),
+                (vec![10], vec![13], true),
+                (vec![13], vec![15], false),
+                (vec![15], vec![], false),
+            ];
+            run_and_check_prepare_job(
+                cfg.clone(),
+                client,
+                Arc::clone(&engine),
+                &ranges,
+                &region_ranges,
+            );
+        }
+    }
+
+    fn run_and_check_prepare_job(
+        cfg: Config,
+        client: MockClient,
+        engine: Arc<Engine>,
+        expected_ranges: &[(Vec<u8>, Vec<u8>)],
+        expected_region_ranges: &[(Vec<u8>, Vec<u8>, bool)],
+    ) {
+        let job = PrepareJob::new(cfg, client.clone(), Arc::clone(&engine));
+
+        let ranges = job.run().unwrap();
+        assert_eq!(ranges.len(), expected_ranges.len());
+        for (range, &(ref start, ref end)) in ranges.iter().zip(expected_ranges.iter()) {
+            let start_key = new_encoded_key(start);
+            let end_key = new_encoded_key(end);
+            assert_eq!(range.get_start(), start_key.as_slice());
+            assert_eq!(range.get_end(), end_key.as_slice());
+        }
+
+        for &(ref start, ref end, should_scatter) in expected_region_ranges {
+            let start_key = new_encoded_key(start);
+            let end_key = new_encoded_key(end);
+            let region = client.get_region(&start_key).unwrap();
+            assert_eq!(region.get_start_key(), start_key.as_slice());
+            assert_eq!(region.get_end_key(), end_key.as_slice());
+            if should_scatter {
+                client.get_scatter_region(region.get_id()).unwrap();
+            }
+        }
+    }
+}

--- a/src/import/stream.rs
+++ b/src/import/stream.rs
@@ -1,0 +1,500 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+use std::sync::Arc;
+
+use crc::crc32::{self, Hasher32};
+use uuid::Uuid;
+
+use kvproto::import_sstpb::*;
+use kvproto::metapb::*;
+use rocksdb::{DBIterator, SeekKey, DB};
+
+use super::client::*;
+use super::common::*;
+use super::engine::*;
+use super::{Config, Result};
+
+pub struct SSTFile {
+    pub meta: SSTMeta,
+    pub data: Vec<u8>,
+}
+
+impl SSTFile {
+    pub fn inside_region(&self, region: &Region) -> bool {
+        let range = self.meta.get_range();
+        assert!(range.get_start() <= range.get_end());
+        inside_region(range.get_start(), region) && inside_region(range.get_end(), region)
+    }
+}
+
+impl fmt::Debug for SSTFile {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let uuid = Uuid::from_bytes(self.meta.get_uuid()).unwrap();
+        f.debug_struct("SSTFile")
+            .field("uuid", &uuid)
+            .field("range", self.meta.get_range())
+            .field("length", &self.meta.get_length())
+            .field("cf_name", &self.meta.get_cf_name().to_owned())
+            .finish()
+    }
+}
+
+pub type SSTRange = (Range, Vec<SSTFile>);
+
+pub struct SSTFileStream<Client> {
+    ctx: RangeContext<Client>,
+    iter: RangeIterator,
+    engine: Arc<Engine>,
+    stream_range: Range,
+}
+
+impl<Client: ImportClient> SSTFileStream<Client> {
+    pub fn new(
+        cfg: Config,
+        client: Arc<Client>,
+        engine: Arc<Engine>,
+        stream_range: Range,
+        finished_ranges: Vec<Range>,
+    ) -> SSTFileStream<Client> {
+        let ctx = RangeContext::new(client, cfg.region_split_size.0 as usize);
+        let engine_iter = engine.new_iter(true);
+        let iter = RangeIterator::new(engine_iter, stream_range.clone(), finished_ranges);
+
+        SSTFileStream {
+            ctx,
+            iter,
+            engine,
+            stream_range,
+        }
+    }
+
+    pub fn next(&mut self) -> Result<Option<SSTRange>> {
+        if !self.iter.valid() {
+            return Ok(None);
+        }
+
+        let mut w = self.engine.new_sst_writer()?;
+        let start = self.iter.key().to_owned();
+        self.ctx.reset(&start);
+
+        loop {
+            {
+                let k = self.iter.key();
+                let v = self.iter.value();
+                w.put(k, v)?;
+                self.ctx.add(k.len() + v.len());
+            }
+            if !self.iter.next() || self.ctx.should_stop_before(self.iter.key()) {
+                break;
+            }
+        }
+
+        let end = if self.iter.valid() {
+            self.iter.key()
+        } else {
+            self.stream_range.get_end()
+        };
+        let range = new_range(&start, end);
+
+        let infos = w.finish()?;
+        let mut ssts = Vec::new();
+        for info in infos {
+            ssts.push(self.new_sst_file(info));
+        }
+
+        Ok(Some((range, ssts)))
+    }
+
+    fn new_sst_file(&self, info: SSTInfo) -> SSTFile {
+        let mut digest = crc32::Digest::new(crc32::IEEE);
+        digest.write(&info.data);
+        let crc32 = digest.sum32();
+        let length = info.data.len() as u64;
+
+        let mut meta = SSTMeta::new();
+        meta.set_uuid(Uuid::new_v4().as_bytes().to_vec());
+        meta.set_range(info.range.clone());
+        meta.set_crc32(crc32);
+        meta.set_length(length);
+        meta.set_cf_name(info.cf_name.clone());
+
+        SSTFile {
+            meta,
+            data: info.data,
+        }
+    }
+}
+
+pub struct RangeIterator {
+    iter: DBIterator<Arc<DB>>,
+    ranges: Vec<Range>,
+    ranges_index: usize,
+}
+
+impl RangeIterator {
+    pub fn new(
+        iter: DBIterator<Arc<DB>>,
+        range: Range,
+        mut finished_ranges: Vec<Range>,
+    ) -> RangeIterator {
+        finished_ranges.sort_by(|a, b| a.get_start().cmp(b.get_start()));
+
+        // Collect unfinished ranges.
+        let mut ranges = Vec::new();
+        let mut last_end = range.get_start();
+        let mut reach_end = false;
+        for range in &finished_ranges {
+            if last_end < range.get_start() {
+                ranges.push(new_range(last_end, range.get_start()));
+            }
+            if before_end(last_end, range.get_end()) {
+                last_end = range.get_end();
+            }
+            if last_end == RANGE_MAX {
+                reach_end = true;
+                break;
+            }
+        }
+        // Handle the last unfinished range.
+        if !reach_end && before_end(last_end, range.get_end()) {
+            ranges.push(new_range(last_end, range.get_end()));
+        }
+
+        let mut res = RangeIterator {
+            iter,
+            ranges,
+            ranges_index: 0,
+        };
+
+        // Seek to the first valid range.
+        res.seek_next();
+        res
+    }
+
+    pub fn next(&mut self) -> bool {
+        if !self.iter.next() {
+            return false;
+        }
+        {
+            let range = &self.ranges[self.ranges_index];
+            if before_end(self.iter.key(), range.get_end()) {
+                return true;
+            }
+            self.ranges_index += 1;
+        }
+        self.seek_next()
+    }
+
+    fn seek_next(&mut self) -> bool {
+        while let Some(range) = self.ranges.get(self.ranges_index) {
+            if !self.iter.seek(SeekKey::Key(range.get_start())) {
+                break;
+            }
+            assert!(self.iter.key() >= range.get_start());
+            if before_end(self.iter.key(), range.get_end()) {
+                break;
+            }
+            self.ranges_index += 1;
+        }
+        self.valid()
+    }
+
+    pub fn key(&self) -> &[u8] {
+        self.iter.key()
+    }
+
+    pub fn value(&self) -> &[u8] {
+        self.iter.value()
+    }
+
+    pub fn valid(&self) -> bool {
+        self.iter.valid() && self.ranges_index < self.ranges.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use import::test_helpers::*;
+
+    use std::path::Path;
+    use std::sync::Arc;
+
+    use rocksdb::{DBIterator, DBOptions, ReadOptions, Writable, DB};
+    use tempdir::TempDir;
+
+    use config::DbConfig;
+    use storage::types::Key;
+
+    fn open_db<P: AsRef<Path>>(path: P) -> Arc<DB> {
+        let path = path.as_ref().to_str().unwrap();
+        let mut opts = DBOptions::new();
+        opts.create_if_missing(true);
+        let db = DB::open(opts, path).unwrap();
+        Arc::new(db)
+    }
+
+    fn new_int_range(start: Option<i32>, end: Option<i32>) -> Range {
+        let mut range = Range::new();
+        if let Some(start) = start {
+            let k = format!("k-{:04}", start);
+            range.set_start(k.as_bytes().to_owned());
+        }
+        if let Some(end) = end {
+            let k = format!("k-{:04}", end);
+            range.set_end(k.as_bytes().to_owned());
+        }
+        range
+    }
+
+    fn new_range_iter(db: Arc<DB>, range: Range, skip_ranges: Vec<Range>) -> RangeIterator {
+        let ropts = ReadOptions::new();
+        let iter = DBIterator::new(Arc::clone(&db), ropts);
+        RangeIterator::new(iter, range, skip_ranges)
+    }
+
+    fn check_range_iter(iter: &mut RangeIterator, start: i32, end: i32) {
+        for i in start..end {
+            let k = format!("k-{:04}", i);
+            let v = format!("v-{:04}", i);
+            assert!(iter.valid());
+            assert_eq!(iter.key(), k.as_bytes());
+            assert_eq!(iter.value(), v.as_bytes());
+            iter.next();
+        }
+    }
+
+    fn test_range_iterator_with(
+        db: Arc<DB>,
+        range_opt: (Option<i32>, Option<i32>),
+        finished_ranges_opt: &[(Option<i32>, Option<i32>)],
+        unfinished_ranges: &[(i32, i32)],
+    ) {
+        let range = new_int_range(range_opt.0, range_opt.1);
+        let mut finished_ranges = Vec::new();
+        for &(start, end) in finished_ranges_opt {
+            finished_ranges.push(new_int_range(start, end));
+        }
+        let mut iter = new_range_iter(db, range, finished_ranges);
+        for &(start, end) in unfinished_ranges {
+            check_range_iter(&mut iter, start, end);
+        }
+        assert!(!iter.valid());
+    }
+
+    #[test]
+    fn test_range_iterator() {
+        let dir = TempDir::new("_tikv_test_tmp_db").unwrap();
+        let db = open_db(dir.path());
+
+        for i in 0..100 {
+            let k = format!("k-{:04}", i);
+            let v = format!("v-{:04}", i);
+            db.put(k.as_bytes(), v.as_bytes()).unwrap();
+        }
+
+        // No finished ranges.
+        test_range_iterator_with(Arc::clone(&db), (None, None), &[], &[(0, 100)]);
+        test_range_iterator_with(Arc::clone(&db), (None, Some(25)), &[], &[(0, 25)]);
+        test_range_iterator_with(Arc::clone(&db), (Some(0), Some(25)), &[], &[(0, 25)]);
+        test_range_iterator_with(Arc::clone(&db), (Some(25), Some(75)), &[], &[(25, 75)]);
+        test_range_iterator_with(Arc::clone(&db), (Some(75), Some(100)), &[], &[(75, 100)]);
+        test_range_iterator_with(Arc::clone(&db), (Some(75), None), &[], &[(75, 100)]);
+
+        // Range [None, None) with some finished ranges.
+        test_range_iterator_with(Arc::clone(&db), (None, None), &[(None, None)], &[]);
+        test_range_iterator_with(
+            Arc::clone(&db),
+            (None, None),
+            &[(None, Some(25)), (Some(50), Some(75))],
+            &[(25, 50), (75, 100)],
+        );
+        test_range_iterator_with(
+            Arc::clone(&db),
+            (None, None),
+            &[(Some(25), Some(50)), (Some(75), None)],
+            &[(0, 25), (50, 75)],
+        );
+        test_range_iterator_with(
+            Arc::clone(&db),
+            (None, None),
+            &[
+                (Some(0), Some(25)),
+                (Some(50), Some(60)),
+                (Some(60), Some(70)),
+            ],
+            &[(25, 50), (70, 100)],
+        );
+        test_range_iterator_with(
+            Arc::clone(&db),
+            (None, None),
+            &[
+                (Some(10), Some(30)),
+                (Some(50), Some(70)),
+                (Some(80), Some(90)),
+                (Some(20), Some(40)),
+                (Some(60), Some(80)),
+                (Some(70), Some(100)),
+            ],
+            &[(0, 10), (40, 50)],
+        );
+
+        // Range [25, 75) with some finished ranges.
+        test_range_iterator_with(Arc::clone(&db), (Some(25), Some(75)), &[(None, None)], &[]);
+        test_range_iterator_with(
+            Arc::clone(&db),
+            (Some(25), Some(75)),
+            &[(None, Some(30)), (Some(50), Some(75))],
+            &[(30, 50)],
+        );
+        test_range_iterator_with(
+            Arc::clone(&db),
+            (Some(25), Some(75)),
+            &[(Some(30), Some(50)), (Some(60), None)],
+            &[(25, 30), (50, 60)],
+        );
+        test_range_iterator_with(
+            Arc::clone(&db),
+            (Some(25), Some(75)),
+            &[
+                (Some(25), Some(30)),
+                (Some(50), Some(60)),
+                (Some(60), Some(70)),
+            ],
+            &[(30, 50), (70, 75)],
+        );
+        test_range_iterator_with(
+            Arc::clone(&db),
+            (Some(25), Some(75)),
+            &[
+                (Some(35), Some(45)),
+                (Some(55), Some(60)),
+                (Some(70), Some(75)),
+                (Some(30), Some(40)),
+                (Some(50), Some(65)),
+                (Some(60), Some(75)),
+            ],
+            &[(25, 30), (45, 50)],
+        );
+    }
+
+    fn new_encoded_range(start: u8, end: u8) -> Range {
+        let k1 = Key::from_raw(&[start]).append_ts(0);
+        let k2 = Key::from_raw(&[end]).append_ts(0);
+        new_range(k1.encoded(), k2.encoded())
+    }
+
+    #[test]
+    fn test_sst_file_stream() {
+        let dir = TempDir::new("test_import_sst_file_stream").unwrap();
+        let uuid = Uuid::new_v4();
+        let opts = DbConfig::default();
+        let engine = Arc::new(Engine::new(dir.path(), uuid, opts).unwrap());
+
+        for i in 0..16 {
+            let k = Key::from_raw(&[i]).append_ts(0);
+            assert_eq!(k.encoded().len(), 17);
+            engine.put(k.encoded(), k.encoded()).unwrap();
+        }
+
+        let mut cfg = Config::default();
+        cfg.region_split_size.0 = 128; // An SST contains at most 4 entries.
+
+        let mut client = MockClient::new();
+        let keys = vec![
+            // [0, 3], [4, 6]
+            7,
+            // [7, 9]
+            10,
+            // [10, 13], [14, 15]
+        ];
+        let mut last = vec![];
+        for i in keys {
+            let k = Key::from_raw(&[i]).append_ts(0);
+            client.add_region_range(&last, k.encoded());
+            last = k.encoded().clone();
+        }
+        // Add an unrelated range.
+        client.add_region_range(&last, b"abc");
+        client.add_region_range(b"abc", b"");
+
+        let client = Arc::new(client);
+
+        // Test all ranges.
+        {
+            let sst_range = new_range(RANGE_MIN, RANGE_MAX);
+            let finished_ranges = Vec::new();
+            let expected_ranges = vec![
+                (0, 3, Some(4)),
+                (4, 6, Some(7)),
+                (7, 9, Some(10)),
+                (10, 13, Some(14)),
+                (14, 15, None),
+            ];
+            run_and_check_stream(
+                cfg.clone(),
+                Arc::clone(&client),
+                Arc::clone(&engine),
+                sst_range,
+                finished_ranges,
+                expected_ranges,
+            );
+        }
+
+        // Test sst range [1, 15) with finished ranges [3, 5), [7, 10).
+        {
+            let sst_range = new_encoded_range(1, 15);
+            let mut finished_ranges = Vec::new();
+            finished_ranges.push(new_encoded_range(3, 5));
+            finished_ranges.push(new_encoded_range(7, 11));
+            let expected_ranges = vec![(1, 6, Some(11)), (11, 14, Some(15))];
+            run_and_check_stream(
+                cfg.clone(),
+                Arc::clone(&client),
+                Arc::clone(&engine),
+                sst_range,
+                finished_ranges,
+                expected_ranges,
+            );
+        }
+    }
+
+    fn run_and_check_stream(
+        cfg: Config,
+        client: Arc<MockClient>,
+        engine: Arc<Engine>,
+        sst_range: Range,
+        finished_ranges: Vec<Range>,
+        expected_ranges: Vec<(u8, u8, Option<u8>)>,
+    ) {
+        let mut stream = SSTFileStream::new(cfg, client, engine, sst_range, finished_ranges);
+        for (start, end, range_end) in expected_ranges {
+            let (range, ssts) = stream.next().unwrap().unwrap();
+            let start = Key::from_raw(&[start]).append_ts(0).encoded().clone();
+            let end = Key::from_raw(&[end]).append_ts(0).encoded().clone();
+            let range_end = match range_end {
+                Some(v) => Key::from_raw(&[v]).append_ts(0).encoded().clone(),
+                None => RANGE_MAX.to_owned(),
+            };
+            assert_eq!(range.get_start(), start.as_slice());
+            assert_eq!(range.get_end(), range_end.as_slice());
+            for sst in ssts {
+                assert_eq!(sst.meta.get_range().get_start(), start.as_slice());
+                assert_eq!(sst.meta.get_range().get_end(), end.as_slice());
+            }
+        }
+        assert!(stream.next().unwrap().is_none());
+    }
+}

--- a/src/import/test_helpers.rs
+++ b/src/import/test_helpers.rs
@@ -11,16 +11,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 
 use crc::crc32::{self, Hasher32};
 use kvproto::import_sstpb::*;
+use kvproto::kvrpcpb::*;
+use kvproto::metapb::*;
 use rocksdb::{ColumnFamilyOptions, EnvOptions, SstFileWriter, DB};
 use uuid::Uuid;
 
+use pd::RegionInfo;
 use raftstore::store::keys;
+
+use super::Result;
+use super::client::*;
+use super::common::*;
 
 pub fn calc_data_crc32(data: &[u8]) -> u32 {
     let mut digest = crc32::Digest::new(crc32::IEEE);
@@ -64,4 +74,92 @@ pub fn read_sst_file<P: AsRef<Path>>(path: P, range: (u8, u8)) -> (SSTMeta, Vec<
     meta.set_cf_name("default".to_owned());
 
     (meta, data)
+}
+
+#[derive(Clone)]
+pub struct MockClient {
+    counter: Arc<AtomicUsize>,
+    regions: Arc<Mutex<HashMap<u64, Region>>>,
+    scatter_regions: Arc<Mutex<HashMap<u64, Region>>>,
+}
+
+impl MockClient {
+    pub fn new() -> MockClient {
+        MockClient {
+            counter: Arc::new(AtomicUsize::new(1)),
+            regions: Arc::new(Mutex::new(HashMap::new())),
+            scatter_regions: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    fn alloc_id(&self) -> u64 {
+        self.counter.fetch_add(1, Ordering::SeqCst) as u64
+    }
+
+    pub fn add_region_range(&mut self, start: &[u8], end: &[u8]) {
+        let mut r = Region::new();
+        r.set_id(self.alloc_id());
+        r.set_start_key(start.to_owned());
+        r.set_end_key(end.to_owned());
+        let mut peer = Peer::new();
+        peer.set_id(self.alloc_id());
+        peer.set_store_id(self.alloc_id());
+        r.mut_peers().push(peer);
+        let mut regions = self.regions.lock().unwrap();
+        regions.insert(r.get_id(), r);
+    }
+
+    pub fn get_scatter_region(&self, id: u64) -> Option<RegionInfo> {
+        let regions = self.scatter_regions.lock().unwrap();
+        regions.get(&id).map(|r| RegionInfo::new(r.clone(), None))
+    }
+}
+
+impl ImportClient for MockClient {
+    fn get_region(&self, key: &[u8]) -> Result<RegionInfo> {
+        let mut found = None;
+        for region in self.regions.lock().unwrap().values() {
+            if inside_region(key, region) {
+                found = Some(region.clone());
+                break;
+            }
+        }
+        Ok(RegionInfo::new(found.unwrap(), None))
+    }
+
+    fn split_region(&self, _: &RegionInfo, split_key: &[u8]) -> Result<SplitRegionResponse> {
+        let mut regions = self.regions.lock().unwrap();
+
+        let region = regions
+            .iter()
+            .map(|(_, r)| r)
+            .find(|r| {
+                split_key >= r.get_start_key()
+                    && (split_key < r.get_end_key() || r.get_end_key().is_empty())
+            })
+            .unwrap()
+            .clone();
+
+        regions.remove(&region.get_id());
+
+        let mut left = region.clone();
+        left.set_id(self.alloc_id());
+        left.set_end_key(split_key.to_vec());
+        regions.insert(left.get_id(), left.clone());
+
+        let mut right = region.clone();
+        right.set_start_key(split_key.to_vec());
+        regions.insert(right.get_id(), right.clone());
+
+        let mut resp = SplitRegionResponse::new();
+        resp.set_left(left);
+        resp.set_right(right);
+        Ok(resp)
+    }
+
+    fn scatter_region(&self, region: &RegionInfo) -> Result<()> {
+        let mut regions = self.scatter_regions.lock().unwrap();
+        regions.insert(region.get_id(), region.region.clone());
+        Ok(())
+    }
 }

--- a/src/pd/mod.rs
+++ b/src/pd/mod.rs
@@ -47,7 +47,7 @@ pub struct RegionStat {
     pub last_report_ts: u64,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct RegionInfo {
     pub region: metapb::Region,
     pub leader: Option<metapb::Peer>,

--- a/src/util/security.rs
+++ b/src/util/security.rs
@@ -80,6 +80,7 @@ impl SecurityConfig {
     }
 }
 
+#[derive(Default)]
 pub struct SecurityManager {
     ca: Vec<u8>,
     cert: Vec<u8>,

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -416,6 +416,10 @@ fn test_serde_custom_tikv_config() {
     value.import = ImportConfig {
         import_dir: "/abc".to_owned(),
         num_threads: 123,
+        num_import_jobs: 123,
+        num_import_sst_jobs: 123,
+        max_prepare_duration: ReadableDuration::minutes(12),
+        region_split_size: ReadableSize::mb(123),
         stream_channel_window: 123,
     };
 

--- a/tests/config/test-custom.toml
+++ b/tests/config/test-custom.toml
@@ -357,4 +357,8 @@ key-path = "invalid path"
 [import]
 import-dir = "/abc"
 num-threads = 123
+num-import-jobs = 123
+num-import-sst-jobs = 123
+max-prepare-duration = "12m"
+region-split-size = "123MB"
 stream-channel-window = 123


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/pingcap/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Implement remained ImportKV APIs.

- SwitchMode: switch the target cluster to normal/import mode
- Compact: compact the target cluster to a specific output level
- Import: import the data in the engine to the target cluster
- Cleanup: clean up the data in the engine

## What are the type of the changes? (mandatory)

- New feature (non-breaking change which adds functionality)

## How has this PR been tested? (mandatory)

- Unit tests
- Integration tests with tidb-lightning in a test environment

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.

## Refer to a related PR or issue link (optional)

https://github.com/pingcap/kvproto/pull/279

## Note

The code in this PR has been used by different users for quite a long time unofficially as a custom tikv-importer binary.
However, this PR is huge and may never be reviewed thoroughly, but customers will use it whenever necessary. Since this PR is only related to tikv-importer and has nothing to do with tikv-server, it will be merged after @DorianZheng has reviewed it.