### PR TITLE
try to split at next key when split key is region start key

### DIFF
--- a/src/raftstore/coprocessor/split_observer.rs
+++ b/src/raftstore/coprocessor/split_observer.rs
@@ -47,11 +47,19 @@ impl SplitObserver {
             key.truncate(table::PREFIX_LEN + table::ID_LEN);
         }
 
-        let region_start_key = ctx.region().get_start_key();
+        let mut region_start_key = ctx.region().get_start_key();
 
-        let key = encode_bytes(&key);
+        let mut key = encode_bytes(&key);
         if *key <= *region_start_key {
-            return Err("no need to split".to_owned());
+            // Try next key
+            let mut next_key = bytes::decode_bytes(&mut region_start_key, false).unwrap();
+            next_key.push(0 as u8);
+            key = encode_bytes(&next_key);
+
+            let region_end_key = ctx.region().get_end_key();
+            if !region_end_key.is_empty() && *key >= *region_end_key {
+                return Err("no need to split".to_owned());
+            }
         }
 
         split.set_split_key(key);
@@ -204,6 +212,16 @@ mod test {
         expect_key = encode_bytes(b"t\x80\x00\x00\x00\x00\x00\x00\xea");
         req = new_split_request(&expect_key);
         observer.pre_propose_admin(&mut ctx, &mut req).unwrap();
+        assert_eq!(req.get_split().get_split_key(), &*expect_key);
+
+        // Split at next key
+        let mut region = Region::new();
+        let start_key = encode_bytes(b"start");
+        region.set_start_key(start_key.clone());
+        let mut ctx = ObserverContext::new(&region);
+        req = new_split_request(&start_key);
+        observer.pre_propose_admin(&mut ctx, &mut req).unwrap();
+        let expect_key = encode_bytes(b"start\x00");
         assert_eq!(req.get_split().get_split_key(), &*expect_key);
     }
 }


### PR DESCRIPTION
## What have you changed? (mandatory)
Try to split at next key when the current split key is region start key after adjusted. After batch split has imported, we will don't need this feature any more.

## What are the type of the changes? (mandatory)
Improvement

## How has this PR been tested? (mandatory)
Unit tests

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
No

## Does this PR affect tidb-ansible update? (mandatory)
No

