### PR TITLE
raftstore: print split key as escaped format

### DIFF
--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -3244,8 +3244,9 @@ impl<T: Transport, C: PdClient> mio::Handler for Store<T, C> {
                 callback,
             } => {
                 info!(
-                    "[region {}] on split region at key {:?}.",
-                    region_id, split_key
+                    "[region {}] on split region at key {}.",
+                    region_id,
+                    escape(split_key)
                 );
                 self.on_prepare_split_region(region_id, region_epoch, split_key, callback);
             }


### PR DESCRIPTION
## What have you changed? (mandatory)
Change split key format in a log. Now it's escaped so that we can analyze log easily.

## What are the type of the changes? (mandatory)
Improvement.

## How has this PR been tested? (mandatory)
make dev.

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
No.

## Does this PR affect tidb-ansible update? (mandatory)
No.

