### PR TITLE
circleci: Specify tarpaulin version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       RUST_BACKTRACE: "1"
       RUSTFLAGS: "-Dwarnings"
       FAIL_POINT: "1"
-      TARPAULIN_VERSION: "0.5.6"
+      TARPAULIN_VERSION: "0.6.0"
     steps:
       - run:
           name: Updating PATH and Define Environment Variable at Runtime
@@ -80,7 +80,8 @@ jobs:
             echo "Tarpaulin version is now: ${CURRENT_TARPAULIN_VERSION}"
             echo "Tarpaulin version should be: ${TARPAULIN_VERSION}"
             if [[ "${CURRENT_TARPAULIN_VERSION}" != "${TARPAULIN_VERSION}" ]]; then
-                RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo +${RUST_TOOLCHAIN} install cargo-tarpaulin --force --version ${TARPAULIN_VERSION};
+                # To understand why this Git is used please see https://github.com/pingcap/tikv/pull/3241#issuecomment-399768547
+                RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo +${RUST_TOOLCHAIN} install cargo-tarpaulin --git https://github.com/xd009642/tarpaulin --tag ${TARPAULIN_VERSION} --force
             fi
       - restore_cache:
           name: Restoring ./target Cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
             echo "Tarpaulin version is now: ${CURRENT_TARPAULIN_VERSION}"
             echo "Tarpaulin version should be: ${TARPAULIN_VERSION}"
             if [[ "${CURRENT_TARPAULIN_VERSION}" != "${TARPAULIN_VERSION}" ]]; then
-                cargo +${RUST_TOOLCHAIN} install cargo-tarpaulin --force --version ${TARPAULIN_VERSION};
+                RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo +${RUST_TOOLCHAIN} install cargo-tarpaulin --force --version ${TARPAULIN_VERSION};
             fi
       - restore_cache:
           name: Restoring ./target Cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,11 +75,12 @@ jobs:
       - run:
           name: Installing tarpaulin
           command: |
-            CURRENT_TARPAULIN_VERSION=`cargo tarpaulin --version | awk '{ print $3 }'`
-            echo "Tarpaulin is now: ${CURRENT_TARPAULIN_VERSION}"
-            echo "Tarpaulin should be: ${TARPAULIN_VERSION}"
+            RUST_TOOLCHAIN=`tail -n 1 RUST_VERSION`
+            CURRENT_TARPAULIN_VERSION=`cargo +${RUST_TOOLCHAIN} tarpaulin --version | awk '{ print $3 }'`
+            echo "Tarpaulin version is now: ${CURRENT_TARPAULIN_VERSION}"
+            echo "Tarpaulin version should be: ${TARPAULIN_VERSION}"
             if [[ "${CURRENT_TARPAULIN_VERSION}" != "${TARPAULIN_VERSION}" ]]; then
-                cargo install cargo-tarpaulin --force --version ${TARPAULIN_VERSION};
+                cargo +${RUST_TOOLCHAIN} install cargo-tarpaulin --force --version ${TARPAULIN_VERSION};
             fi
       - restore_cache:
           name: Restoring ./target Cache
@@ -109,7 +110,8 @@ jobs:
       - run:
           name: Calculating code coverage
           command: |
-            cargo tarpaulin --no-count --skip-clean --out Xml
+            RUST_TOOLCHAIN=`tail -n 1 RUST_VERSION`
+            cargo +${RUST_TOOLCHAIN} tarpaulin --no-count --skip-clean --out Xml
             bash <(curl -s https://codecov.io/bash)
           no_output_timeout: 1800s
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
       RUST_BACKTRACE: "1"
       RUSTFLAGS: "-Dwarnings"
       FAIL_POINT: "1"
+      TARPAULIN_VERSION: "0.5.6"
     steps:
       - run:
           name: Updating PATH and Define Environment Variable at Runtime
@@ -75,7 +76,7 @@ jobs:
           name: Installing tarpaulin
           command: |
             if [[ ! -e $HOME/.cargo/bin/cargo-tarpaulin ]]; then
-                RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin;
+                RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin --version $TARPAULIN_VERSION;
             fi
       - restore_cache:
           name: Restoring ./target Cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,8 +75,11 @@ jobs:
       - run:
           name: Installing tarpaulin
           command: |
-            if [[ ! -e $HOME/.cargo/bin/cargo-tarpaulin ]]; then
-                RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin --version $TARPAULIN_VERSION;
+            CURRENT_TARPAULIN_VERSION=`cargo tarpaulin --version | awk '{ print $3 }'`
+            echo "Tarpaulin is now: ${CURRENT_TARPAULIN_VERSION}"
+            echo "Tarpaulin should be: ${TARPAULIN_VERSION}"
+            if [[ "${CURRENT_TARPAULIN_VERSION}" != "${TARPAULIN_VERSION}" ]]; then
+                cargo install cargo-tarpaulin --force --version ${TARPAULIN_VERSION};
             fi
       - restore_cache:
           name: Restoring ./target Cache


### PR DESCRIPTION
Specifies the version of Tarpaulin to triage the CI breaking.

See https://circleci.com/gh/pingcap/tikv/11095

You can see that in the last week `cargo-tarpaulin` (https://github.com/xd009642/tarpaulin/releases) updated a few times. This has resulted in a recent build breakage on our particular version of nightly. This might be able to be refined in #3066 .

## What are the type of the changes? (mandatory)

- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)

By the CI (which had a build error!)

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

I do not expect it to.

## Does this PR affect tidb-ansible update? (mandatory)

It should not.

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

