### PR TITLE
circleci: Bump the Tarpaulin version.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       RUST_BACKTRACE: "1"
       RUSTFLAGS: "-Dwarnings"
       FAIL_POINT: "1"
-      TARPAULIN_VERSION: "0.6.0"
+      TARPAULIN_VERSION: "0.6.1"
     steps:
       - run:
           name: Updating PATH and Define Environment Variable at Runtime


### PR DESCRIPTION
Now that #3208 is merged we need to make tarpaulin a different version or otherwise force a build. Since we're using an old version right now we can bump it.