### PR TITLE
Run tests after uploading cache in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,18 +115,6 @@ jobs:
           paths:
             - ~/tikv_cache_cargo
       - run:
-          name: Testing
-          command: make trace_test
-          no_output_timeout: 1800s
-      - run:
-          name: Calculating code coverage (master branch only)
-          command: |
-            if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
-              cargo tarpaulin --no-count --skip-clean --out Xml
-              bash <(curl -s https://codecov.io/bash)
-            fi
-          no_output_timeout: 1800s
-      - run:
           name: Caching ./target (master branch only)
           command: |
             rm -rf ~/tikv_cache_build
@@ -144,6 +132,18 @@ jobs:
           key: v3-target-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - ~/tikv_cache_build
+      - run:
+          name: Testing
+          command: make trace_test
+          no_output_timeout: 1800s
+      - run:
+          name: Calculating code coverage (master branch only)
+          command: |
+            if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
+              cargo tarpaulin --no-count --skip-clean --out Xml
+              bash <(curl -s https://codecov.io/bash)
+            fi
+          no_output_timeout: 1800s
 workflows:
   version: 2
   ci-test:


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/pingcap/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Previously, we uploads ./target cache only after testing successfully. However as our test is not very stable, tests are likely to fail. When test fails, `./target` cache is not uploaded, which will slow down PR's build time if there is some notable changes in master (especially when rocksdb or grpc dependency is changed).

This PR adjusts the order of steps in CI, so that upload happens before testing. In this way, failed tests will not affect master's build cache.

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

Let's see the CI result of this PR.

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

