### PR TITLE
raftstore: disable PreVote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ See also [TiDB Changelog](https://github.com/pingcap/tidb/blob/master/CHANGELOG.
 ## [2.1.0-beta]
 ### Features
 * Upgrade Rust to the `nightly-2018-06-14` version
-* Enable `Raft PreVote` to avoid leader reelection generated when network recovers after network isolation
+* Provide a `Raft PreVote` configuration to avoid leader reelection generated when network recovers after network isolation
 * Add a metric to display the number of files and `ingest` related information in each layer of RocksDB
 * Print `key` with too many versions when GC works
 ### Performance

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -122,7 +122,7 @@
 # sync-log = true
 
 # minimizes disruption when a partitioned node rejoins the cluster by using a two phase election.
-# prevote = true
+# prevote = false
 
 # set the path to raftdb directory, default value is data-dir/raft
 # raftdb-path = ""

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -131,7 +131,7 @@ impl Default for Config {
         let split_size = ReadableSize::mb(coprocessor::config::SPLIT_SIZE_MB);
         Config {
             sync_log: true,
-            prevote: true,
+            prevote: false,
             raftdb_path: String::new(),
             capacity: ReadableSize(0),
             raft_base_tick_interval: ReadableDuration::secs(1),


### PR DESCRIPTION
There is a bug when we enable both check_quorum and prevote, which leads no leader. In order to release a stable 2.1-beta, we should disable prevote temporary.

See more: https://github.com/coreos/etcd/issues/9586