### PR TITLE
Revert "Release 2.1.0-beta (#3264)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,6 @@
 All notable changes to this project are documented in this file.
 See also [TiDB Changelog](https://github.com/pingcap/tidb/blob/master/CHANGELOG.md) and [PD Changelog](https://github.com/pingcap/pd/blob/master/CHANGELOG.md).
 
-## [2.1.0-beta]
-### Features
-* Upgrade Rust to the `nightly-2018-06-14` version
-* Enable `Raft PreVote` to avoid leader reelection generated when network recovers after network isolation
-* Add a metric to display the number of files and `ingest` related information in each layer of RocksDB
-* Print `key` with too many versions when GC works
-### Performance
-* Use `static metric` to optimize multi-label metric performance (YCSB `raw get` is improved by 3%)
-* Remove `box` in multiple modules and use patterns to improve the operating performance (YCSB `raw get` is improved by 3%)
-* Use `asynchronous log` to improve the performance of writing logs
-* Add a metric to collect the thread status
-* Decease memory copy times by decreasing `box` used in the application to improve the performance
-
 ## [2.0.4]
 ### Features
 * Add the RocksDB `PerfContext` interface for debugging

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "tikv"
-version = "2.1.0-beta"
+version = "2.1.0-alpha.1"
 dependencies = [
  "backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1223,7 +1223,7 @@ name = "tikv-fuzz"
 version = "0.0.1"
 dependencies = [
  "libfuzzer-sys 0.1.0 (git+https://github.com/rust-fuzz/libfuzzer-sys.git)",
- "tikv 2.1.0-beta",
+ "tikv 2.1.0-alpha.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tikv"
-version = "2.1.0-beta"
+version = "2.1.0-alpha.1"
 keywords = ["KV", "distributed-systems", "raft"]
 build = "build.rs"
 


### PR DESCRIPTION
We need to disable Prevote and update the CHANGELOG.