### PR TITLE
split_check/size: fix bug when region_max_size=region_split_size

### DIFF
--- a/src/raftstore/coprocessor/split_check/size.rs
+++ b/src/raftstore/coprocessor/split_check/size.rs
@@ -43,7 +43,7 @@ impl SplitChecker for Checker {
         if self.current_size > self.split_size && self.split_key.is_none() {
             self.split_key = Some(key.to_vec());
         }
-        self.current_size >= self.max_size
+        self.current_size > self.max_size
     }
 
     fn split_key(&mut self) -> Option<Vec<u8>> {
@@ -146,6 +146,8 @@ mod tests {
     use rocksdb::{ColumnFamilyOptions, DBOptions};
     use tempdir::TempDir;
 
+    use super::Checker;
+    use raftstore::coprocessor::{Config, CoprocessorHost, ObserverContext, SplitChecker};
     use raftstore::store::{keys, Msg, SplitCheckRunner, SplitCheckTask};
     use storage::ALL_CFS;
     use util::config::ReadableSize;
@@ -153,8 +155,6 @@ mod tests {
     use util::rocksdb::{new_engine_opt, CFOptions};
     use util::transport::RetryableSendCh;
     use util::worker::Runnable;
-
-    use raftstore::coprocessor::{Config, CoprocessorHost};
 
     #[test]
     fn test_split_check() {
@@ -275,5 +275,20 @@ mod tests {
         drop(rx);
         // It should be safe even the result can't be sent back.
         runnable.run(SplitCheckTask::new(region, true));
+    }
+
+    #[test]
+    fn test_checker_with_same_max_and_split_size() {
+        let mut checker = Checker::new(24, 24);
+        let region = Region::default();
+        let mut ctx = ObserverContext::new(&region);
+        loop {
+            let data = b"xxxx";
+            if checker.on_kv(&mut ctx, data, data.len() as u64) {
+                break;
+            }
+        }
+
+        assert!(checker.split_key().is_some());
     }
 }


### PR DESCRIPTION

## What have you changed? (mandatory)

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

     When `region-max-size` is equal to `region_split_size`, for `Checker` of `SizeCheckObserver`, the `split_key` may empty when `on_kv` returns true. Which means when the size of the region is already bigger than `region-max-size`, split by size may be failed in this situation.
This PR will fix it by adjusting the condition in the function `on_kv`

## What are the type of the changes? (mandatory)

- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)

unit test

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

no 

## Does this PR affect tidb-ansible update? (mandatory)

no

@huachaohuang @overvenus PTAL

