### PR TITLE
Enlarge the total slots of scheduler latch

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -95,7 +95,7 @@
 # scheduler-messages-per-tick = 1024
 
 # the number of slots in scheduler latches, concurrency control for write.
-# scheduler-concurrency = 102400
+# scheduler-concurrency = 1024000
 
 # scheduler's worker pool size, should increase it in heavy write cases,
 # also should less than total cpu cores.

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -95,7 +95,7 @@
 # scheduler-messages-per-tick = 1024
 
 # the number of slots in scheduler latches, concurrency control for write.
-# scheduler-concurrency = 1024000
+# scheduler-concurrency = 2048000
 
 # scheduler's worker pool size, should increase it in heavy write cases,
 # also should less than total cpu cores.

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -22,7 +22,7 @@ pub const DEFAULT_ROCKSDB_SUB_DIR: &str = "db";
 const DEFAULT_GC_RATIO_THRESHOLD: f64 = 1.1;
 const DEFAULT_MAX_KEY_SIZE: usize = 4 * 1024;
 const DEFAULT_SCHED_CAPACITY: usize = 10240;
-const DEFAULT_SCHED_CONCURRENCY: usize = 102400;
+const DEFAULT_SCHED_CONCURRENCY: usize = 1024000;
 
 // According to "Little's law", assuming you can write 100MB per
 // second, and it takes about 100ms to process the write requests

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -22,7 +22,7 @@ pub const DEFAULT_ROCKSDB_SUB_DIR: &str = "db";
 const DEFAULT_GC_RATIO_THRESHOLD: f64 = 1.1;
 const DEFAULT_MAX_KEY_SIZE: usize = 4 * 1024;
 const DEFAULT_SCHED_CAPACITY: usize = 10240;
-const DEFAULT_SCHED_CONCURRENCY: usize = 1024000;
+const DEFAULT_SCHED_CONCURRENCY: usize = 2048000;
 
 // According to "Little's law", assuming you can write 100MB per
 // second, and it takes about 100ms to process the write requests


### PR DESCRIPTION
## What have you changed? (mandatory)

Enlarge the default value of the latch's total slots.

In loading data scenario, we found the default value of total slots of latch is not large enough, it will limit the loading speed because of waiting latch. After we enlarged the total slots,  it became fast.

Currently, the default value of `scheduler-pending-write-threshold` is 100MB, it means there is at most 100MB bytes data is writing or going to be writing, all of the related keys need to occupy the latch. Let's assume the average size of each key value pair is 64 bytes, there are will be about 1.5 million keys. To reduce the probability of waiting latch, the total slots of the latch should large enough. We enlarge the default value of latch slots to 2 million, the latch takes about 100MB memory.

## What are the type of the changes? (mandatory)
Improvement

## How has this PR been tested? (mandatory)
CI

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No
