### PR TITLE
ci: enable clippy check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,13 +94,7 @@ jobs:
           no_output_timeout: 1800s
       - run:
           name: Clippy check
-          command: |
-            if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
-              echo "Current branch is $CIRCLE_BRANCH, skip"
-            else
-              echo "Current branch is $CIRCLE_BRANCH, running clippy..."
-              make clippy
-            fi
+          command: make clippy
       - run:
           name: Building
           command: env SKIP_TESTS=true make trace_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,15 @@ jobs:
             fi
           no_output_timeout: 1800s
       - run:
+          name: Clippy check
+          command: |
+            if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
+              echo "Current branch is $CIRCLE_BRANCH, skip"
+            else
+              echo "Current branch is $CIRCLE_BRANCH, running clippy..."
+              make clippy
+            fi
+      - run:
           name: Building
           command: env SKIP_TESTS=true make trace_test
           no_output_timeout: 1800s

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,9 +93,6 @@ jobs:
             fi
           no_output_timeout: 1800s
       - run:
-          name: Clippy check
-          command: make clippy
-      - run:
           name: Building
           command: env SKIP_TESTS=true make trace_test
           no_output_timeout: 1800s

--- a/ci-build/test.sh
+++ b/ci-build/test.sh
@@ -32,6 +32,8 @@ if [[ "$TRAVIS" = "true" ]]; then
 fi
 export RUSTFLAGS=-Dwarnings
 
+make clippy
+
 if [[ "$SKIP_TESTS" != "true" ]]; then
     make test 2>&1 | tee tests.out
 else

--- a/src/coprocessor/codec/datum.rs
+++ b/src/coprocessor/codec/datum.rs
@@ -870,7 +870,6 @@ impl<T: Write> DatumEncoder for T {}
 /// Get the approximate needed buffer size of values.
 ///
 /// This function ensures that encoded values must fit in the given buffer size.
-#[cfg_attr(feature = "cargo-clippy", allow(match_some_arms))]
 pub fn approximate_size(values: &[Datum], comparable: bool) -> usize {
     values
         .iter()
@@ -1813,7 +1812,7 @@ mod test {
         let tests = vec![
             (Datum::I64(1), f64::from(1)),
             (Datum::U64(1), f64::from(1)),
-            (Datum::F64(3.3), f64::from(3.3)),
+            (Datum::F64(3.3), 3.3),
             (Datum::Bytes(b"Hello,world".to_vec()), f64::from(0)),
             (Datum::Bytes(b"123".to_vec()), f64::from(123)),
             (
@@ -1830,7 +1829,7 @@ mod test {
             ),
             (
                 Datum::Dec(Decimal::from_bytes(b"11.2").unwrap().unwrap()),
-                f64::from(11.2),
+                11.2,
             ),
             (
                 Datum::Json(Json::from_str(r#"false"#).unwrap()),

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -2157,7 +2157,7 @@ mod tests {
                 self.applied_to_index_term
             }
             fn inspect_lease(&mut self) -> LeaseState {
-                self.lease_state.clone()
+                self.lease_state
             }
         }
 

--- a/src/util/mpsc.rs
+++ b/src/util/mpsc.rs
@@ -194,7 +194,7 @@ mod tests {
             rx.recv_timeout(Duration::from_millis(100)),
             Err(RecvTimeoutError::Timeout)
         );
-        assert!((timer.elapsed().subsec_nanos() as i64 - 100_000_000).abs() < 1_000_000);
+        assert!((i64::from(timer.elapsed().subsec_nanos()) - 100_000_000).abs() < 1_000_000);
 
         drop(rx);
         assert_eq!(tx.send(2), Err(SendError(2)));
@@ -223,7 +223,7 @@ mod tests {
         });
         let timer = Instant::now();
         assert_eq!(rx1.recv(), Ok(10));
-        assert!((timer.elapsed().subsec_nanos() as i64 - 100_000_000).abs() < 1_000_000);
+        assert!((i64::from(timer.elapsed().subsec_nanos()) - 100_000_000).abs() < 1_000_000);
         let timer = Instant::now();
         tx2.send(2).unwrap();
         assert!(timer.elapsed() > Duration::from_millis(50));
@@ -243,7 +243,7 @@ mod tests {
             rx.recv_timeout(Duration::from_millis(100)),
             Err(RecvTimeoutError::Timeout)
         );
-        assert!((timer.elapsed().subsec_nanos() as i64 - 100_000_000).abs() < 1_000_000);
+        assert!((i64::from(timer.elapsed().subsec_nanos()) - 100_000_000).abs() < 1_000_000);
 
         drop(rx);
         assert_eq!(tx.send(2), Err(SendError(2)));
@@ -265,6 +265,6 @@ mod tests {
         });
         let timer = Instant::now();
         assert_eq!(rx.recv(), Ok(10));
-        assert!((timer.elapsed().subsec_nanos() as i64 - 100_000_000).abs() < 1_000_000);
+        assert!((i64::from(timer.elapsed().subsec_nanos()) - 100_000_000).abs() < 1_000_000);
     }
 }


### PR DESCRIPTION
Turns out clippy check is disabled at some point in CI, now I can see several warnings in master branch. This pr enables the check again.

close #3292.