### PR TITLE
tests: relax channel timeout check

### DIFF
--- a/src/util/mpsc.rs
+++ b/src/util/mpsc.rs
@@ -249,7 +249,8 @@ mod tests {
             rx.recv_timeout(Duration::from_millis(100)),
             Err(RecvTimeoutError::Timeout)
         );
-        assert!((i64::from(timer.elapsed().subsec_nanos()) - 100_000_000).abs() < 1_000_000);
+        let elapsed = timer.elapsed();
+        assert!(elapsed >= Duration::from_millis(100), "{:?}", elapsed);
 
         drop(rx);
         assert_eq!(tx.send(2), Err(SendError(2)));
@@ -278,10 +279,12 @@ mod tests {
         });
         let timer = Instant::now();
         assert_eq!(rx1.recv(), Ok(10));
-        assert!((i64::from(timer.elapsed().subsec_nanos()) - 100_000_000).abs() < 1_000_000);
+        let elapsed = timer.elapsed();
+        assert!(elapsed >= Duration::from_millis(100), "{:?}", elapsed);
         let timer = Instant::now();
         tx2.send(2).unwrap();
-        assert!(timer.elapsed() > Duration::from_millis(50));
+        let elapsed = timer.elapsed();
+        assert!(elapsed >= Duration::from_millis(50), "{:?}", elapsed);
     }
 
     #[test]
@@ -298,7 +301,8 @@ mod tests {
             rx.recv_timeout(Duration::from_millis(100)),
             Err(RecvTimeoutError::Timeout)
         );
-        assert!((i64::from(timer.elapsed().subsec_nanos()) - 100_000_000).abs() < 1_000_000);
+        let elapsed = timer.elapsed();
+        assert!(elapsed >= Duration::from_millis(100), "{:?}", elapsed);
 
         drop(rx);
         assert_eq!(tx.send(2), Err(SendError(2)));
@@ -320,7 +324,8 @@ mod tests {
         });
         let timer = Instant::now();
         assert_eq!(rx.recv(), Ok(10));
-        assert!((i64::from(timer.elapsed().subsec_nanos()) - 100_000_000).abs() < 1_000_000);
+        let elapsed = timer.elapsed();
+        assert!(elapsed >= Duration::from_millis(100), "{:?}", elapsed);
     }
 
     #[test]
@@ -351,7 +356,8 @@ mod tests {
             rx.recv_timeout(Duration::from_millis(100)),
             Err(RecvTimeoutError::Timeout)
         );
-        assert!((i64::from(timer.elapsed().subsec_nanos()) - 100_000_000).abs() < 1_000_000);
+        let elapsed = timer.elapsed();
+        assert!(elapsed >= Duration::from_millis(100), "{:?}", elapsed);
 
         tx.force_send(1).unwrap();
         drop(rx);
@@ -379,6 +385,7 @@ mod tests {
         });
         let timer = Instant::now();
         assert_eq!(rx.recv(), Ok(10));
-        assert!((i64::from(timer.elapsed().subsec_nanos()) - 100_000_000).abs() < 1_000_000);
+        let elapsed = timer.elapsed();
+        assert!(elapsed >= Duration::from_millis(100), "{:?}", elapsed);
     }
 }


### PR DESCRIPTION
Timeout is not precise on Mac OS. This pr relax it by only checking the lower bound.

Close #3298.