### PR TITLE
(release-2.0) tests: Move failpoint of test_storage_1gc

### DIFF
--- a/tests/failpoints_cases/test_storage.rs
+++ b/tests/failpoints_cases/test_storage.rs
@@ -28,8 +28,8 @@ use tikv::util::worker::FutureWorker;
 #[test]
 fn test_storage_1gc() {
     let _guard = ::setup();
-    let snapshot_fp = "raftkv_async_snapshot_finish";
-    let batch_snapshot_fp = "raftkv_async_batch_snapshot_finish";
+    let snapshot_fp = "raftkv_async_snapshot";
+    let batch_snapshot_fp = "raftkv_async_batch_snapshot";
     let (_cluster, engine, ctx) = new_raft_engine(3, "");
     let pd_worker = FutureWorker::new("test future worker");
     let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {


### PR DESCRIPTION
## What have you changed? (mandatory)

Changed the failpoint which `tests::failpoint_cases::test_storage_1gc` uses. The reason was stated [here](https://github.com/pingcap/tikv/pull/3304#issuecomment-404360973).

[The PR "Move GC out of Scheduler"](https://github.com/pingcap/tikv/commit/a95dc9a122e91249bc7cffbe1d40cb6760d89297) can't be merged to release-2.0 unless we merge the PR ["Remove Box<> around Cursor, Snapshot and Engine"](https://github.com/pingcap/tikv/commit/a32ddaf514bb7ca01de2f1f44a102e12318b6eb8) first. So I submitted this PR to solve it.

## What are the type of the changes? (mandatory)

- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)

By the CI.

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No
