### PR TITLE
*: clean up engines

### DIFF
--- a/benches/bin/raftstore.rs
+++ b/benches/bin/raftstore.rs
@@ -35,7 +35,7 @@ fn enc_write_kvs(db: &DB, kvs: &[(Vec<u8>, Vec<u8>)]) {
 fn prepare_cluster<T: Simulator>(cluster: &mut Cluster<T>, initial_kvs: &[(Vec<u8>, Vec<u8>)]) {
     cluster.run();
     for engines in cluster.engines.values() {
-        enc_write_kvs(&engines.kv_engine, initial_kvs);
+        enc_write_kvs(&engines.kv, initial_kvs);
     }
     cluster.leader_of_region(1).unwrap();
 }

--- a/src/bin/util/signal_handler.rs
+++ b/src/bin/util/signal_handler.rs
@@ -34,8 +34,8 @@ mod imp {
                     // Use SIGUSR1 to log metrics.
                     info!("{}", metrics::dump());
                     if let Some(ref engines) = engines {
-                        info!("{:?}", rocksdb_stats::dump(&engines.kv_engine));
-                        info!("{:?}", rocksdb_stats::dump(&engines.raft_engine));
+                        info!("{:?}", rocksdb_stats::dump(&engines.kv));
+                        info!("{:?}", rocksdb_stats::dump(&engines.raft));
                     }
                 }
                 SIGUSR2 => profiling::dump_prof(None),

--- a/src/raftstore/store/mod.rs
+++ b/src/raftstore/store/mod.rs
@@ -50,10 +50,9 @@ pub use self::snap::{
     check_abort, copy_snapshot, ApplyOptions, Error as SnapError, SnapEntry, SnapKey, SnapManager,
     SnapManagerBuilder, Snapshot, SnapshotDeleter, SnapshotStatistics,
 };
-pub use self::store::{
-    create_event_loop, new_compaction_listener, Engines, Store, StoreChannel, StoreStat,
-};
+pub use self::store::{create_event_loop, new_compaction_listener, Store, StoreChannel, StoreStat};
 pub use self::transport::Transport;
+pub use self::util::Engines;
 
 // Only used in tests
 #[cfg(test)]

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -41,7 +41,7 @@ use raftstore::store::engine::{Peekable, Snapshot};
 use raftstore::store::worker::apply::ApplyMetrics;
 use raftstore::store::worker::{apply, Proposal, RegionProposal};
 use raftstore::store::worker::{Apply, ApplyTask};
-use raftstore::store::{keys, Callback, Config, ReadResponse, RegionSnapshot};
+use raftstore::store::{keys, Callback, Config, Engines, ReadResponse, RegionSnapshot};
 use raftstore::{Error, Result};
 use util::collections::{HashMap, HashSet};
 use util::time::{duration_to_sec, monotonic_raw_now};
@@ -217,8 +217,7 @@ pub struct PeerStat {
 }
 
 pub struct Peer {
-    kv_engine: Arc<DB>,
-    raft_engine: Arc<DB>,
+    engines: Engines,
     cfg: Rc<Config>,
     peer_cache: RefCell<HashMap<u64, metapb::Peer>>,
     pub peer: metapb::Peer,
@@ -340,8 +339,7 @@ impl Peer {
         let tag = format!("[region {}] {}", region.get_id(), peer.get_id());
 
         let ps = PeerStorage::new(
-            store.kv_engine(),
-            store.raft_engine(),
+            store.engines(),
             region,
             sched,
             tag.clone(),
@@ -369,8 +367,7 @@ impl Peer {
 
         let raft_group = RawNode::new(&raft_cfg, ps, vec![])?;
         let mut peer = Peer {
-            kv_engine: store.kv_engine(),
-            raft_engine: store.raft_engine(),
+            engines: store.engines(),
             peer,
             region_id: region.get_id(),
             raft_group,
@@ -471,7 +468,7 @@ impl Peer {
         let raft_wb = WriteBatch::new();
         self.mut_store().clear_meta(&kv_wb, &raft_wb)?;
         write_peer_state(
-            &self.kv_engine,
+            &self.engines.kv,
             &kv_wb,
             &region,
             PeerState::Tombstone,
@@ -480,8 +477,8 @@ impl Peer {
         // write kv rocksdb first in case of restart happen between two write
         let mut write_opts = WriteOptions::new();
         write_opts.set_sync(self.cfg.sync_log);
-        self.kv_engine.write_opt(kv_wb, &write_opts)?;
-        self.raft_engine.write_opt(raft_wb, &write_opts)?;
+        self.engines.kv.write_opt(kv_wb, &write_opts)?;
+        self.engines.raft.write_opt(raft_wb, &write_opts)?;
 
         if self.get_store().is_initialized() && !keep_data {
             // If we meet panic when deleting data and raft log, the dirty data
@@ -510,12 +507,8 @@ impl Peer {
         self.get_store().is_initialized()
     }
 
-    pub fn kv_engine(&self) -> Arc<DB> {
-        Arc::clone(&self.kv_engine)
-    }
-
-    pub fn raft_engine(&self) -> Arc<DB> {
-        Arc::clone(&self.raft_engine)
+    pub fn engines(&self) -> Engines {
+        self.engines.clone()
     }
 
     #[inline]
@@ -1729,7 +1722,7 @@ impl Peer {
     }
 
     fn handle_read(&mut self, req: RaftCmdRequest) -> ReadResponse {
-        let mut resp = ReadExecutor::new(self.region(), &self.kv_engine, &self.tag)
+        let mut resp = ReadExecutor::new(self.region(), &self.engines.kv, &self.tag)
             .execute(&req)
             .unwrap_or_else(|e| {
                 match e {

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -69,28 +69,13 @@ use super::worker::{
     CompactTask, ConsistencyCheckRunner, ConsistencyCheckTask, RaftlogGcRunner, RaftlogGcTask,
     RegionRunner, RegionTask, SplitCheckRunner, SplitCheckTask, STALE_PEER_CHECK_INTERVAL,
 };
-use super::{util, Msg, SignificantMsg, SnapKey, SnapManager, SnapshotDeleter, Tick};
+use super::{util, Engines, Msg, SignificantMsg, SnapKey, SnapManager, SnapshotDeleter, Tick};
 use import::SSTImporter;
 
 type Key = Vec<u8>;
 
 const MIO_TICK_RATIO: u64 = 10;
 const PENDING_VOTES_CAP: usize = 20;
-
-#[derive(Clone)]
-pub struct Engines {
-    pub kv_engine: Arc<DB>,
-    pub raft_engine: Arc<DB>,
-}
-
-impl Engines {
-    pub fn new(kv_engine: Arc<DB>, raft_engine: Arc<DB>) -> Engines {
-        Engines {
-            kv_engine,
-            raft_engine,
-        }
-    }
-}
 
 // A helper structure to bundle all channels for messages to `Store`.
 pub struct StoreChannel {
@@ -135,8 +120,7 @@ pub struct StoreInfo {
 
 pub struct Store<T, C: 'static> {
     cfg: Rc<Config>,
-    kv_engine: Arc<DB>,
-    raft_engine: Arc<DB>,
+    engines: Engines,
     store: metapb::Store,
     sendch: SendCh<Msg>,
 
@@ -231,8 +215,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         let mut s = Store {
             cfg: Rc::new(cfg),
             store: meta,
-            kv_engine: engines.kv_engine,
-            raft_engine: engines.raft_engine,
+            engines,
             sendch,
             significant_msg_receiver: ch.significant_msg_receiver,
             region_peers: HashMap::default(),
@@ -275,7 +258,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         // Scan region meta to get saved regions.
         let start_key = keys::REGION_META_MIN_KEY;
         let end_key = keys::REGION_META_MAX_KEY;
-        let kv_engine = Arc::clone(&self.kv_engine);
+        let kv_engine = Arc::clone(&self.engines.kv);
         let mut total_count = 0;
         let mut tomebstone_count = 0;
         let mut applying_count = 0;
@@ -308,12 +291,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             if local_state.get_state() == PeerState::Applying {
                 // in case of restart happen when we just write region state to Applying,
                 // but not write raft_local_state to raft rocksdb in time.
-                peer_storage::recover_from_applying_state(
-                    &self.kv_engine,
-                    &self.raft_engine,
-                    &raft_wb,
-                    region_id,
-                )?;
+                peer_storage::recover_from_applying_state(&self.engines, &raft_wb, region_id)?;
                 applying_count += 1;
                 applying_regions.push(region.clone());
                 return Ok(true);
@@ -334,12 +312,12 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         })?;
 
         if !kv_wb.is_empty() {
-            self.kv_engine.write(kv_wb).unwrap();
-            self.kv_engine.sync_wal().unwrap();
+            self.engines.kv.write(kv_wb).unwrap();
+            self.engines.kv.sync_wal().unwrap();
         }
         if !raft_wb.is_empty() {
-            self.raft_engine.write(raft_wb).unwrap();
-            self.raft_engine.sync_wal().unwrap();
+            self.engines.raft.write(raft_wb).unwrap();
+            self.engines.raft.sync_wal().unwrap();
         }
 
         // schedule applying snapshot after raft writebatch were written.
@@ -393,22 +371,16 @@ impl<T, C> Store<T, C> {
     ) {
         let region = origin_state.get_region();
         let raft_key = keys::raft_state_key(region.get_id());
-        let raft_state = match self.raft_engine.get_msg(&raft_key).unwrap() {
+        let raft_state = match self.engines.raft.get_msg(&raft_key).unwrap() {
             // it has been cleaned up.
             None => return,
             Some(value) => value,
         };
 
-        peer_storage::clear_meta(
-            &self.kv_engine,
-            &self.raft_engine,
-            kv_wb,
-            raft_wb,
-            region.get_id(),
-            &raft_state,
-        ).unwrap();
+        peer_storage::clear_meta(&self.engines, kv_wb, raft_wb, region.get_id(), &raft_state)
+            .unwrap();
         let key = keys::region_state_key(region.get_id());
-        let handle = rocksdb::get_cf_handle(&self.kv_engine, CF_RAFT).unwrap();
+        let handle = rocksdb::get_cf_handle(&self.engines.kv, CF_RAFT).unwrap();
         kv_wb.put_msg_cf(handle, &key, origin_state).unwrap();
     }
 
@@ -426,7 +398,7 @@ impl<T, C> Store<T, C> {
         }
         ranges.push((last_start_key, keys::DATA_MAX_KEY.to_vec()));
 
-        rocksdb::roughly_cleanup_ranges(&self.kv_engine, &ranges)?;
+        rocksdb::roughly_cleanup_ranges(&self.engines.kv, &ranges)?;
 
         info!(
             "{} cleans up {} ranges garbage data, takes {:?}",
@@ -455,12 +427,16 @@ impl<T, C> Store<T, C> {
         self.apply_worker.scheduler()
     }
 
+    pub fn engines(&self) -> Engines {
+        self.engines.clone()
+    }
+
     pub fn kv_engine(&self) -> Arc<DB> {
-        Arc::clone(&self.kv_engine)
+        Arc::clone(&self.engines.kv)
     }
 
     pub fn raft_engine(&self) -> Arc<DB> {
-        Arc::clone(&self.raft_engine)
+        Arc::clone(&self.engines.raft)
     }
 
     pub fn store_id(&self) -> u64 {
@@ -548,7 +524,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         self.register_cleanup_import_sst_tick(event_loop);
 
         let split_check_runner = SplitCheckRunner::new(
-            Arc::clone(&self.kv_engine),
+            Arc::clone(&self.engines.kv),
             self.sendch.clone(),
             Arc::clone(&self.coprocessor_host),
         );
@@ -556,8 +532,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         box_try!(self.split_check_worker.start(split_check_runner));
 
         let region_runner = RegionRunner::new(
-            Arc::clone(&self.kv_engine),
-            Arc::clone(&self.raft_engine),
+            self.engines.clone(),
             self.snap_mgr.clone(),
             self.cfg.snap_apply_batch_size.0 as usize,
             self.cfg.use_delete_range,
@@ -570,14 +545,14 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         let raftlog_gc_runner = RaftlogGcRunner::new(None);
         box_try!(self.raftlog_gc_worker.start(raftlog_gc_runner));
 
-        let compact_runner = CompactRunner::new(Arc::clone(&self.kv_engine));
+        let compact_runner = CompactRunner::new(Arc::clone(&self.engines.kv));
         box_try!(self.compact_worker.start(compact_runner));
 
         let pd_runner = PdRunner::new(
             self.store_id(),
             Arc::clone(&self.pd_client),
             self.sendch.clone(),
-            Arc::clone(&self.kv_engine),
+            Arc::clone(&self.engines.kv),
         );
         box_try!(self.pd_worker.start(pd_runner));
 
@@ -936,7 +911,8 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         // no exist, check with tombstone key.
         let state_key = keys::region_state_key(region_id);
         if let Some(local_state) = self
-            .kv_engine
+            .engines
+            .kv
             .get_msg_cf::<RegionLocalState>(CF_RAFT, &state_key)?
         {
             if local_state.get_state() != PeerState::Tombstone {
@@ -1282,7 +1258,8 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             // RegionLocalState, ApplyState
             let mut write_opts = WriteOptions::new();
             write_opts.set_sync(true);
-            self.kv_engine
+            self.engines
+                .kv
                 .write_opt(kv_wb, &write_opts)
                 .unwrap_or_else(|e| {
                     panic!("{} failed to save append state result: {:?}", self.tag, e);
@@ -1294,7 +1271,8 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             // RaftLocalState, Raft Log Entry
             let mut write_opts = WriteOptions::new();
             write_opts.set_sync(self.cfg.sync_log || sync_log);
-            self.raft_engine
+            self.engines
+                .raft
                 .write_opt(raft_wb, &write_opts)
                 .unwrap_or_else(|e| {
                     panic!("{} failed to save raft append result: {:?}", self.tag, e);
@@ -1689,7 +1667,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         }
 
         let state_key = keys::region_state_key(region_id);
-        let state: RegionLocalState = match self.kv_engine().get_msg_cf(CF_RAFT, &state_key) {
+        let state: RegionLocalState = match self.engines.kv.get_msg_cf(CF_RAFT, &state_key) {
             Err(e) => {
                 error!(
                     "{} failed to load region state of {}, ignore: {}",
@@ -2380,7 +2358,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             debug!("compact worker is busy, check space redundancy next time");
         } else if self.region_ranges.is_empty() {
             debug!("there is no range need to check");
-        } else if rocksdb::auto_compactions_is_disabled(&self.kv_engine) {
+        } else if rocksdb::auto_compactions_is_disabled(&self.engines.kv) {
             debug!("skip compact check when disabled auto compactions.");
         } else {
             // Start from last checked key.
@@ -2662,7 +2640,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         self.is_busy = false;
 
         let store_info = StoreInfo {
-            engine: Arc::clone(&self.kv_engine),
+            engine: Arc::clone(&self.engines.kv),
             capacity: self.cfg.capacity.0,
         };
 

--- a/src/raftstore/store/util.rs
+++ b/src/raftstore/store/util.rs
@@ -13,6 +13,7 @@
 
 use std::collections::Bound::Excluded;
 use std::option::Option;
+use std::sync::Arc;
 use std::{fmt, u64};
 
 use kvproto::metapb;
@@ -557,6 +558,21 @@ pub fn conf_state_from_region(region: &metapb::Region) -> ConfState {
         }
     }
     conf_state
+}
+
+#[derive(Clone, Debug)]
+pub struct Engines {
+    pub kv: Arc<DB>,
+    pub raft: Arc<DB>,
+}
+
+impl Engines {
+    pub fn new(kv_engine: Arc<DB>, raft_engine: Arc<DB>) -> Engines {
+        Engines {
+            kv: kv_engine,
+            raft: raft_engine,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -107,7 +107,7 @@ impl Debugger {
 
     /// Get all regions holding region meta data from raft CF in KV storage.
     pub fn get_all_meta_regions(&self) -> Result<Vec<u64>> {
-        let db = &self.engines.kv_engine;
+        let db = &self.engines.kv;
         let cf = CF_RAFT;
         let start_key = keys::REGION_META_MIN_KEY;
         let end_key = keys::REGION_META_MAX_KEY;
@@ -125,8 +125,8 @@ impl Debugger {
 
     fn get_db_from_type(&self, db: DBType) -> Result<&DB> {
         match db {
-            DBType::KV => Ok(&self.engines.kv_engine),
-            DBType::RAFT => Ok(&self.engines.raft_engine),
+            DBType::KV => Ok(&self.engines.kv),
+            DBType::RAFT => Ok(&self.engines.raft),
             _ => Err(box_err!("invalid DBType type")),
         }
     }
@@ -146,7 +146,7 @@ impl Debugger {
 
     pub fn raft_log(&self, region_id: u64, log_index: u64) -> Result<Entry> {
         let key = keys::raft_log_key(region_id, log_index);
-        match self.engines.raft_engine.get_msg(&key) {
+        match self.engines.raft.get_msg(&key) {
             Ok(Some(entry)) => Ok(entry),
             Ok(None) => Err(Error::NotFound(format!(
                 "raft log for region {} at index {}",
@@ -158,23 +158,19 @@ impl Debugger {
 
     pub fn region_info(&self, region_id: u64) -> Result<RegionInfo> {
         let raft_state_key = keys::raft_state_key(region_id);
-        let raft_state = box_try!(
-            self.engines
-                .raft_engine
-                .get_msg::<RaftLocalState>(&raft_state_key)
-        );
+        let raft_state = box_try!(self.engines.raft.get_msg::<RaftLocalState>(&raft_state_key));
 
         let apply_state_key = keys::apply_state_key(region_id);
         let apply_state = box_try!(
             self.engines
-                .kv_engine
+                .kv
                 .get_msg_cf::<RaftApplyState>(CF_RAFT, &apply_state_key)
         );
 
         let region_state_key = keys::region_state_key(region_id);
         let region_state = box_try!(
             self.engines
-                .kv_engine
+                .kv
                 .get_msg_cf::<RegionLocalState>(CF_RAFT, &region_state_key)
         );
 
@@ -194,7 +190,7 @@ impl Debugger {
         let region_state_key = keys::region_state_key(region_id);
         match self
             .engines
-            .kv_engine
+            .kv
             .get_msg_cf::<RegionLocalState>(CF_RAFT, &region_state_key)
         {
             Ok(Some(region_state)) => {
@@ -204,7 +200,7 @@ impl Debugger {
                 let mut sizes = vec![];
                 for cf in cfs {
                     let mut size = 0;
-                    box_try!(self.engines.kv_engine.scan_cf(
+                    box_try!(self.engines.kv.scan_cf(
                         cf.as_ref(),
                         start_key,
                         end_key,
@@ -233,7 +229,7 @@ impl Debugger {
         if end.is_empty() && limit == 0 {
             return Err(Error::InvalidArgument("no limit and to_key".to_owned()));
         }
-        MvccInfoIterator::new(&self.engines.kv_engine, start, end, limit)
+        MvccInfoIterator::new(&self.engines.kv, start, end, limit)
     }
 
     /// Compact the cf[start..end) in the db.
@@ -260,7 +256,7 @@ impl Debugger {
     /// peers, version, and key range) from `region` which comes from PD normally.
     pub fn set_region_tombstone(&self, regions: Vec<Region>) -> Result<Vec<(u64, Error)>> {
         let store_id = self.get_store_id()?;
-        let db = &self.engines.kv_engine;
+        let db = &self.engines.kv;
         let wb = WriteBatch::new();
 
         let mut errors = Vec::with_capacity(regions.len());
@@ -280,7 +276,7 @@ impl Debugger {
     }
 
     pub fn recover_regions(&self, regions: Vec<Region>) -> Result<Vec<(u64, Error)>> {
-        let db = &self.engines.kv_engine;
+        let db = &self.engines.kv;
 
         let mut errors = Vec::with_capacity(regions.len());
         for region in regions {
@@ -323,8 +319,8 @@ impl Debugger {
         let from = keys::REGION_META_MIN_KEY.to_owned();
         let to = keys::REGION_META_MAX_KEY.to_owned();
         let readopts = IterOption::new(Some(from.clone()), Some(to), false).build_read_opts();
-        let handle = box_try!(get_cf_handle(&self.engines.kv_engine, CF_RAFT));
-        let mut iter = DBIterator::new_cf(Arc::clone(&self.engines.kv_engine), handle, readopts);
+        let handle = box_try!(get_cf_handle(&self.engines.kv, CF_RAFT));
+        let mut iter = DBIterator::new_cf(Arc::clone(&self.engines.kv), handle, readopts);
         iter.seek(SeekKey::from(from.as_ref()));
 
         let fake_snap_worker = Worker::new("fake snap worker");
@@ -345,16 +341,15 @@ impl Debugger {
                     Error::Other("RegionLocalState doesn't contains peer itself".into())
                 })?;
 
-            let raft_state = box_try!(init_raft_state(&self.engines.raft_engine, region));
-            let apply_state = box_try!(init_apply_state(&self.engines.kv_engine, region));
+            let raft_state = box_try!(init_raft_state(&self.engines.raft, region));
+            let apply_state = box_try!(init_apply_state(&self.engines.kv, region));
             if raft_state.get_last_index() < apply_state.get_applied_index() {
                 return Err(Error::Other("last index < applied index".into()));
             }
 
             let tag = format!("[region {}] {}", region.get_id(), peer_id);
             let peer_storage = box_try!(PeerStorage::new(
-                Arc::clone(&self.engines.kv_engine),
-                Arc::clone(&self.engines.raft_engine),
+                self.engines.clone(),
                 region,
                 fake_snap_worker.scheduler(),
                 tag.clone(),
@@ -403,7 +398,7 @@ impl Debugger {
             return Err(Error::Other(msg.into()));
         }
         let wb = WriteBatch::new();
-        let handle = box_try!(get_cf_handle(self.engines.kv_engine.as_ref(), CF_RAFT));
+        let handle = box_try!(get_cf_handle(self.engines.kv.as_ref(), CF_RAFT));
         let store_ids = HashSet::<u64>::from_iter(store_ids);
 
         {
@@ -441,7 +436,7 @@ impl Debugger {
             };
 
             if let Some(region_ids) = region_ids {
-                let kv = &self.engines.kv_engine;
+                let kv = &self.engines.kv;
                 for region_id in region_ids {
                     let key = keys::region_state_key(region_id);
                     if let Some(value) = box_try!(kv.get_value_cf(CF_RAFT, &key)) {
@@ -452,7 +447,7 @@ impl Debugger {
                     }
                 }
             } else {
-                box_try!(self.engines.kv_engine.scan_cf(
+                box_try!(self.engines.kv.scan_cf(
                     CF_RAFT,
                     keys::REGION_META_MIN_KEY,
                     keys::REGION_META_MAX_KEY,
@@ -464,14 +459,14 @@ impl Debugger {
 
         let mut write_opts = WriteOptions::new();
         write_opts.set_sync(true);
-        box_try!(self.engines.kv_engine.write_opt(wb, &write_opts));
+        box_try!(self.engines.kv.write_opt(wb, &write_opts));
         Ok(())
     }
 
     pub fn recreate_region(&self, region: Region) -> Result<()> {
         let region_id = region.get_id();
-        let kv = self.engines.kv_engine.as_ref();
-        let raft = self.engines.raft_engine.as_ref();
+        let kv = self.engines.kv.as_ref();
+        let raft = self.engines.raft.as_ref();
 
         let kv_wb = WriteBatch::new();
         let raft_wb = WriteBatch::new();
@@ -481,7 +476,7 @@ impl Debugger {
             return Err(box_err!("Bad region: {:?}", region));
         }
 
-        box_try!(self.engines.kv_engine.scan_cf(
+        box_try!(self.engines.kv.scan_cf(
             CF_RAFT,
             keys::REGION_META_MIN_KEY,
             keys::REGION_META_MAX_KEY,
@@ -547,7 +542,7 @@ impl Debugger {
     }
 
     pub fn get_store_id(&self) -> Result<u64> {
-        let db = &self.engines.kv_engine;
+        let db = &self.engines.kv;
         db.get_msg::<StoreIdent>(keys::STORE_IDENT_KEY)
             .map_err(|e| box_err!(e))
             .and_then(|ident| match ident {
@@ -606,7 +601,7 @@ impl Debugger {
         let region_state_key = keys::region_state_key(region_id);
         let region_state = box_try!(
             self.engines
-                .kv_engine
+                .kv
                 .get_msg_cf::<RegionLocalState>(CF_RAFT, &region_state_key)
         );
         match region_state {
@@ -618,7 +613,7 @@ impl Debugger {
     pub fn get_region_properties(&self, region_id: u64) -> Result<Vec<(String, String)>> {
         let region_state = self.get_region_state(region_id)?;
         let region = region_state.get_region();
-        let db = &self.engines.kv_engine;
+        let db = &self.engines.kv;
 
         let mut num_entries = 0;
         let mut mvcc_properties = MvccProperties::new();
@@ -1265,7 +1260,7 @@ mod tests {
         fn set_store_id(&self, store_id: u64) {
             let mut ident = StoreIdent::new();
             ident.set_store_id(store_id);
-            let db = &self.engines.kv_engine;
+            let db = &self.engines.kv;
             db.put_msg(keys::STORE_IDENT_KEY, &ident).unwrap();
         }
     }
@@ -1273,7 +1268,7 @@ mod tests {
     #[test]
     fn test_get() {
         let debugger = new_debugger();
-        let engine = &debugger.engines.kv_engine;
+        let engine = &debugger.engines.kv;
         let (k, v) = (b"k", b"v");
         engine.put(k, v).unwrap();
         assert_eq!(&*engine.get(k).unwrap().unwrap(), v);
@@ -1290,7 +1285,7 @@ mod tests {
     #[test]
     fn test_raft_log() {
         let debugger = new_debugger();
-        let engine = &debugger.engines.raft_engine;
+        let engine = &debugger.engines.raft;
         let (region_id, log_index) = (1, 1);
         let key = keys::raft_log_key(region_id, log_index);
         let mut entry = Entry::new();
@@ -1311,8 +1306,8 @@ mod tests {
     #[test]
     fn test_region_info() {
         let debugger = new_debugger();
-        let raft_engine = &debugger.engines.raft_engine;
-        let kv_engine = &debugger.engines.kv_engine;
+        let raft_engine = &debugger.engines.raft;
+        let kv_engine = &debugger.engines.kv;
         let raft_cf = kv_engine.cf_handle(CF_RAFT).unwrap();
         let region_id = 1;
 
@@ -1369,7 +1364,7 @@ mod tests {
     #[test]
     fn test_region_size() {
         let debugger = new_debugger();
-        let engine = &debugger.engines.kv_engine;
+        let engine = &debugger.engines.kv;
 
         let region_id = 1;
         let region_state_key = keys::region_state_key(region_id);
@@ -1402,7 +1397,7 @@ mod tests {
     #[test]
     fn test_scan_mvcc() {
         let debugger = new_debugger();
-        let engine = &debugger.engines.kv_engine;
+        let engine = &debugger.engines.kv;
 
         let cf_default_data = vec![(b"k1", b"v", 5), (b"k2", b"x", 10), (b"k3", b"y", 15)];
         for &(prefix, value, ts) in &cf_default_data {
@@ -1460,7 +1455,7 @@ mod tests {
     fn test_tombstone_regions() {
         let debugger = new_debugger();
         debugger.set_store_id(11);
-        let engine = debugger.engines.kv_engine.as_ref();
+        let engine = debugger.engines.kv.as_ref();
 
         // region 1 with peers at stores 11, 12, 13.
         let region_1 = init_region_state(engine, 1, &[11, 12, 13]);
@@ -1508,7 +1503,7 @@ mod tests {
     fn test_remove_failed_stores() {
         let debugger = new_debugger();
         debugger.set_store_id(100);
-        let engine = debugger.engines.kv_engine.as_ref();
+        let engine = debugger.engines.kv.as_ref();
 
         // region 1 with peers at stores 11, 12, 13 and 14.
         init_region_state(engine, 1, &[11, 12, 13, 14]);
@@ -1546,8 +1541,8 @@ mod tests {
     #[test]
     fn test_bad_regions() {
         let debugger = new_debugger();
-        let kv_engine = debugger.engines.kv_engine.as_ref();
-        let raft_engine = debugger.engines.raft_engine.as_ref();
+        let kv_engine = debugger.engines.kv.as_ref();
+        let raft_engine = debugger.engines.raft.as_ref();
         let store_id = 1; // It's a fake id.
 
         let wb1 = WriteBatch::new();
@@ -1621,7 +1616,7 @@ mod tests {
     #[test]
     fn test_modify_tikv_config() {
         let debugger = new_debugger();
-        let engine = &debugger.engines.kv_engine;
+        let engine = &debugger.engines.kv;
 
         let db_opts = engine.get_db_options();
         assert_eq!(db_opts.get_max_background_jobs(), 2);
@@ -1644,7 +1639,7 @@ mod tests {
     #[test]
     fn test_recreate_region() {
         let debugger = new_debugger();
-        let engine = debugger.engines.kv_engine.as_ref();
+        let engine = debugger.engines.kv.as_ref();
 
         let metadata = vec![("", "g"), ("g", "m"), ("m", "")];
 

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -192,9 +192,7 @@ where
     // check store, return store id for the engine.
     // If the store is not bootstrapped, use INVALID_ID.
     fn check_store(&self, engines: &Engines) -> Result<u64> {
-        let res = engines
-            .kv_engine
-            .get_msg::<StoreIdent>(keys::STORE_IDENT_KEY)?;
+        let res = engines.kv.get_msg::<StoreIdent>(keys::STORE_IDENT_KEY)?;
         if res.is_none() {
             return Ok(INVALID_ID);
         }
@@ -254,7 +252,7 @@ where
 
     fn check_prepare_bootstrap_cluster(&self, engines: &Engines) -> Result<()> {
         let res = engines
-            .kv_engine
+            .kv
             .get_msg::<metapb::Region>(keys::PREPARE_BOOTSTRAP_KEY)?;
         if res.is_none() {
             return Ok(());

--- a/src/server/service/debug.rs
+++ b/src/server/service/debug.rs
@@ -322,8 +322,8 @@ impl<T: RaftStoreRouter + 'static + Send> debugpb_grpc::Debug for Service<T> {
             resp.set_prometheus(metrics::dump());
             if req.get_all() {
                 let engines = debugger.get_engine();
-                resp.set_rocksdb_kv(box_try!(rocksdb_stats::dump(&engines.kv_engine)));
-                resp.set_rocksdb_raft(box_try!(rocksdb_stats::dump(&engines.raft_engine)));
+                resp.set_rocksdb_kv(box_try!(rocksdb_stats::dump(&engines.kv)));
+                resp.set_rocksdb_raft(box_try!(rocksdb_stats::dump(&engines.raft)));
                 resp.set_jemalloc(jemalloc::dump_stats());
             }
             Ok(resp)

--- a/src/util/rocksdb/metrics_flusher.rs
+++ b/src/util/rocksdb/metrics_flusher.rs
@@ -41,8 +41,8 @@ impl MetricsFlusher {
     }
 
     pub fn start(&mut self) -> Result<(), io::Error> {
-        let db = Arc::clone(&self.engines.kv_engine);
-        let raft_db = Arc::clone(&self.engines.raft_engine);
+        let db = Arc::clone(&self.engines.kv);
+        let raft_db = Arc::clone(&self.engines.raft);
         let (tx, rx) = mpsc::channel();
         let interval = self.interval;
         self.sender = Some(tx);

--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -165,8 +165,8 @@ impl<T: Simulator> Cluster<T> {
 
     pub fn compact_data(&self) {
         for engine in self.engines.values() {
-            let handle = rocksdb::get_cf_handle(&engine.kv_engine, "default").unwrap();
-            rocksdb::compact_range(&engine.kv_engine, handle, None, None, false, 1);
+            let handle = rocksdb::get_cf_handle(&engine.kv, "default").unwrap();
+            rocksdb::compact_range(&engine.kv, handle, None, None, false, 1);
         }
     }
 
@@ -207,11 +207,11 @@ impl<T: Simulator> Cluster<T> {
     }
 
     pub fn get_engine(&self, node_id: u64) -> Arc<DB> {
-        Arc::clone(&self.engines[&node_id].kv_engine)
+        Arc::clone(&self.engines[&node_id].kv)
     }
 
     pub fn get_raft_engine(&self, node_id: u64) -> Arc<DB> {
-        Arc::clone(&self.engines[&node_id].raft_engine)
+        Arc::clone(&self.engines[&node_id].raft)
     }
 
     pub fn send_raft_msg(&mut self, msg: RaftMessage) -> Result<()> {
@@ -475,7 +475,7 @@ impl<T: Simulator> Cluster<T> {
         let half = self.engines.len() / 2;
         let mut qualified_cnt = 0;
         for (id, engines) in &self.engines {
-            if !condition(&engines.kv_engine) {
+            if !condition(&engines.kv) {
                 debug!("store {} is not qualified yet.", id);
                 continue;
             }
@@ -716,8 +716,8 @@ impl<T: Simulator> Cluster<T> {
 
     pub fn must_flush_cf(&mut self, cf: &str, sync: bool) {
         for engines in &self.dbs {
-            let handle = engines.kv_engine.cf_handle(cf).unwrap();
-            engines.kv_engine.flush_cf(handle, sync).unwrap();
+            let handle = engines.kv.cf_handle(cf).unwrap();
+            engines.kv.flush_cf(handle, sync).unwrap();
         }
     }
 

--- a/tests/raftstore/node.rs
+++ b/tests/raftstore/node.rs
@@ -190,7 +190,7 @@ impl Simulator for NodeCluster {
         let coprocessor_host = CoprocessorHost::new(cfg.coprocessor, node.get_sendch());
 
         let importer = {
-            let dir = Path::new(engines.kv_engine.path()).join("import-sst");
+            let dir = Path::new(engines.kv.path()).join("import-sst");
             Arc::new(SSTImporter::new(dir).unwrap())
         };
 
@@ -205,7 +205,8 @@ impl Simulator for NodeCluster {
             importer,
         ).unwrap();
         assert!(
-            Arc::clone(&engines.kv_engine)
+            engines
+                .kv
                 .get_msg::<metapb::Region>(keys::PREPARE_BOOTSTRAP_KEY)
                 .unwrap()
                 .is_none()

--- a/tests/raftstore/server.rs
+++ b/tests/raftstore/server.rs
@@ -140,13 +140,13 @@ impl Simulator for ServerCluster {
 
         // Create import service.
         let importer = {
-            let dir = Path::new(engines.kv_engine.path()).join("import-sst");
+            let dir = Path::new(engines.kv.path()).join("import-sst");
             Arc::new(SSTImporter::new(dir).unwrap())
         };
         let import_service = ImportSSTService::new(
             cfg.import.clone(),
             sim_router.clone(),
-            Arc::clone(&engines.kv_engine),
+            Arc::clone(&engines.kv),
             Arc::clone(&importer),
         );
 

--- a/tests/raftstore_cases/test_compact_after_delete.rs
+++ b/tests/raftstore_cases/test_compact_after_delete.rs
@@ -50,8 +50,8 @@ fn test_compact_after_delete<T: Simulator>(cluster: &mut Cluster<T>) {
         cluster.must_put_cf(CF_WRITE, &k, &v);
     }
     for engines in cluster.engines.values() {
-        let cf = get_cf_handle(&engines.kv_engine, CF_WRITE).unwrap();
-        engines.kv_engine.flush_cf(cf, true).unwrap();
+        let cf = get_cf_handle(&engines.kv, CF_WRITE).unwrap();
+        engines.kv.flush_cf(cf, true).unwrap();
     }
 
     for i in 0..1000 {
@@ -60,17 +60,17 @@ fn test_compact_after_delete<T: Simulator>(cluster: &mut Cluster<T>) {
         cluster.must_delete_cf(CF_WRITE, &k);
     }
     for engines in cluster.engines.values() {
-        let cf = get_cf_handle(&engines.kv_engine, CF_WRITE).unwrap();
-        engines.kv_engine.flush_cf(cf, true).unwrap();
+        let cf = get_cf_handle(&engines.kv, CF_WRITE).unwrap();
+        engines.kv.flush_cf(cf, true).unwrap();
     }
 
     // wait for compaction.
     sleep_ms(300);
 
     for engines in cluster.engines.values() {
-        let cf_handle = get_cf_handle(&engines.kv_engine, CF_WRITE).unwrap();
+        let cf_handle = get_cf_handle(&engines.kv, CF_WRITE).unwrap();
         let approximate_size = engines
-            .kv_engine
+            .kv
             .get_approximate_sizes_cf(cf_handle, &[Range::new(b"", DATA_MAX_KEY)])[0];
         assert_eq!(approximate_size, 0);
     }

--- a/tests/raftstore_cases/test_compact_lock_cf.rs
+++ b/tests/raftstore_cases/test_compact_lock_cf.rs
@@ -21,8 +21,8 @@ use super::util::*;
 
 fn flush<T: Simulator>(cluster: &mut Cluster<T>) {
     for engines in cluster.engines.values() {
-        let lock_handle = engines.kv_engine.cf_handle(CF_LOCK).unwrap();
-        engines.kv_engine.flush_cf(lock_handle, true).unwrap();
+        let lock_handle = engines.kv.cf_handle(CF_LOCK).unwrap();
+        engines.kv.flush_cf(lock_handle, true).unwrap();
     }
 }
 
@@ -32,7 +32,7 @@ fn flush_then_check<T: Simulator>(cluster: &mut Cluster<T>, interval: u64, writt
     sleep_ms(interval * 2);
     for engines in cluster.engines.values() {
         let compact_write_bytes = engines
-            .kv_engine
+            .kv
             .get_statistics_ticker_count(DBStatisticsTickerType::CompactWriteBytes);
         if written {
             assert!(compact_write_bytes > 0);

--- a/tests/raftstore_cases/test_compact_log.rs
+++ b/tests/raftstore_cases/test_compact_log.rs
@@ -35,7 +35,7 @@ fn test_compact_log<T: Simulator>(cluster: &mut Cluster<T>) {
 
     for (&id, engines) in &cluster.engines {
         let mut state: RaftApplyState =
-            get_msg_cf_or_default(&engines.kv_engine, CF_RAFT, &keys::apply_state_key(1));
+            get_msg_cf_or_default(&engines.kv, CF_RAFT, &keys::apply_state_key(1));
         before_states.insert(id, state.take_truncated_state());
     }
 
@@ -63,7 +63,7 @@ fn check_compacted(
 
     for (&id, engines) in all_engines {
         let mut state: RaftApplyState =
-            get_msg_cf_or_default(&engines.kv_engine, CF_RAFT, &keys::apply_state_key(1));
+            get_msg_cf_or_default(&engines.kv, CF_RAFT, &keys::apply_state_key(1));
         let after_state = state.take_truncated_state();
 
         let before_state = &before_states[&id];
@@ -85,10 +85,10 @@ fn check_compacted(
     for (id, engines) in all_engines {
         for i in 0..compacted_idx[id] {
             let key = keys::raft_log_key(1, i);
-            if engines.raft_engine.get(&key).unwrap().is_none() {
+            if engines.raft.get(&key).unwrap().is_none() {
                 break;
             }
-            assert!(engines.raft_engine.get(&key).unwrap().is_none());
+            assert!(engines.raft.get(&key).unwrap().is_none());
         }
     }
     true
@@ -105,9 +105,9 @@ fn test_compact_count_limit<T: Simulator>(cluster: &mut Cluster<T>) {
     let mut before_states = HashMap::default();
 
     for (&id, engines) in &cluster.engines {
-        must_get_equal(&engines.kv_engine, b"k1", b"v1");
+        must_get_equal(&engines.kv, b"k1", b"v1");
         let mut state: RaftApplyState =
-            get_msg_cf_or_default(&engines.kv_engine, CF_RAFT, &keys::apply_state_key(1));
+            get_msg_cf_or_default(&engines.kv, CF_RAFT, &keys::apply_state_key(1));
         let state = state.take_truncated_state();
         // compact should not start
         assert_eq!(RAFT_INIT_LOG_INDEX, state.get_index());
@@ -127,7 +127,7 @@ fn test_compact_count_limit<T: Simulator>(cluster: &mut Cluster<T>) {
     // limit has not reached, should not gc.
     for (&id, engines) in &cluster.engines {
         let mut state: RaftApplyState =
-            get_msg_cf_or_default(&engines.kv_engine, CF_RAFT, &keys::apply_state_key(1));
+            get_msg_cf_or_default(&engines.kv, CF_RAFT, &keys::apply_state_key(1));
         let after_state = state.take_truncated_state();
 
         let before_state = &before_states[&id];
@@ -161,9 +161,9 @@ fn test_compact_many_times<T: Simulator>(cluster: &mut Cluster<T>) {
     let mut before_states = HashMap::default();
 
     for (&id, engines) in &cluster.engines {
-        must_get_equal(&engines.kv_engine, b"k1", b"v1");
+        must_get_equal(&engines.kv, b"k1", b"v1");
         let mut state: RaftApplyState =
-            get_msg_cf_or_default(&engines.kv_engine, CF_RAFT, &keys::apply_state_key(1));
+            get_msg_cf_or_default(&engines.kv, CF_RAFT, &keys::apply_state_key(1));
         let state = state.take_truncated_state();
         // compact should not start
         assert_eq!(RAFT_INIT_LOG_INDEX, state.get_index());
@@ -221,9 +221,9 @@ fn test_compact_size_limit<T: Simulator>(cluster: &mut Cluster<T>) {
         if id == 1 {
             continue;
         }
-        must_get_equal(&engines.kv_engine, b"k1", b"v1");
+        must_get_equal(&engines.kv, b"k1", b"v1");
         let mut state: RaftApplyState =
-            get_msg_cf_or_default(&engines.kv_engine, CF_RAFT, &keys::apply_state_key(1));
+            get_msg_cf_or_default(&engines.kv, CF_RAFT, &keys::apply_state_key(1));
         let state = state.take_truncated_state();
         // compact should not start
         assert_eq!(RAFT_INIT_LOG_INDEX, state.get_index());
@@ -248,7 +248,7 @@ fn test_compact_size_limit<T: Simulator>(cluster: &mut Cluster<T>) {
             continue;
         }
         let mut state: RaftApplyState =
-            get_msg_cf_or_default(&engines.kv_engine, CF_RAFT, &keys::apply_state_key(1));
+            get_msg_cf_or_default(&engines.kv, CF_RAFT, &keys::apply_state_key(1));
         let after_state = state.take_truncated_state();
 
         let before_state = &before_states[&id];
@@ -274,7 +274,7 @@ fn test_compact_size_limit<T: Simulator>(cluster: &mut Cluster<T>) {
             continue;
         }
         let mut state: RaftApplyState =
-            get_msg_cf_or_default(&engines.kv_engine, CF_RAFT, &keys::apply_state_key(1));
+            get_msg_cf_or_default(&engines.kv, CF_RAFT, &keys::apply_state_key(1));
         let after_state = state.take_truncated_state();
 
         let before_state = &before_states[&id];
@@ -283,7 +283,7 @@ fn test_compact_size_limit<T: Simulator>(cluster: &mut Cluster<T>) {
 
         for i in 0..idx {
             let key = keys::raft_log_key(1, i);
-            assert!(engines.raft_engine.get(&key).unwrap().is_none());
+            assert!(engines.raft.get(&key).unwrap().is_none());
         }
     }
 }

--- a/tests/raftstore_cases/test_multi.rs
+++ b/tests/raftstore_cases/test_multi.rs
@@ -88,12 +88,9 @@ fn test_multi_leader_crash<T: Simulator>(cluster: &mut Cluster<T>) {
 
     cluster.must_put(key2, value2);
     cluster.must_delete(key1);
-    must_get_none(
-        &cluster.engines[&last_leader.get_store_id()].kv_engine,
-        key2,
-    );
+    must_get_none(&cluster.engines[&last_leader.get_store_id()].kv, key2);
     must_get_equal(
-        &cluster.engines[&last_leader.get_store_id()].kv_engine,
+        &cluster.engines[&last_leader.get_store_id()].kv,
         key1,
         value1,
     );
@@ -102,14 +99,11 @@ fn test_multi_leader_crash<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.run_node(last_leader.get_store_id());
 
     must_get_equal(
-        &cluster.engines[&last_leader.get_store_id()].kv_engine,
+        &cluster.engines[&last_leader.get_store_id()].kv,
         key2,
         value2,
     );
-    must_get_none(
-        &cluster.engines[&last_leader.get_store_id()].kv_engine,
-        key1,
-    );
+    must_get_none(&cluster.engines[&last_leader.get_store_id()].kv, key1);
 }
 
 fn test_multi_cluster_restart<T: Simulator>(cluster: &mut Cluster<T>) {

--- a/tests/raftstore_cases/test_split_region.rs
+++ b/tests/raftstore_cases/test_split_region.rs
@@ -267,7 +267,7 @@ fn test_auto_split_region<T: Simulator>(cluster: &mut Cluster<T>) {
     let store_id = leader.get_store_id();
     let mut size = 0;
     cluster.engines[&store_id]
-        .kv_engine
+        .kv
         .scan(&data_key(b""), &data_key(middle_key), false, |k, v| {
             size += k.len() as u64;
             size += v.len() as u64;

--- a/tests/raftstore_cases/test_transport.rs
+++ b/tests/raftstore_cases/test_transport.rs
@@ -22,7 +22,7 @@ fn test_partition_write<T: Simulator>(cluster: &mut Cluster<T>) {
 
     let (key, value) = (b"k1", b"v1");
     cluster.must_put(key, value);
-    must_get_equal(&cluster.engines[&1].kv_engine, key, value);
+    must_get_equal(&cluster.engines[&1].kv, key, value);
 
     let region_id = cluster.get_region_id(key);
 

--- a/tests/raftstore_cases/test_update_region_size.rs
+++ b/tests/raftstore_cases/test_update_region_size.rs
@@ -22,7 +22,7 @@ use super::server::new_server_cluster;
 
 fn flush<T: Simulator>(cluster: &mut Cluster<T>) {
     for engines in cluster.engines.values() {
-        engines.kv_engine.flush(true).unwrap();
+        engines.kv.flush(true).unwrap();
     }
 }
 


### PR DESCRIPTION
This pr cleans up the usage of `Engines`. First, it replaces all places that use both kv and raft engines with `Engines`. Second, it removes the redundant `_engine` suffix.

The changes can also help simplifying `Peer`'s constructor later.