### PR TITLE
tests: remove redundant raft rpc case

### DIFF
--- a/tests/raftstore_cases/test_service.rs
+++ b/tests/raftstore_cases/test_service.rs
@@ -466,21 +466,7 @@ fn test_mvcc_resolve_lock_gc_and_delete() {
     assert!(del_resp.error.is_empty());
 }
 
-#[test]
-fn test_raft() {
-    let (_cluster, client, _) = must_new_cluster_and_kv_client();
-
-    // Raft commands
-    let (sink, _) = client.raft().unwrap();
-    sink.send((RaftMessage::new(), Default::default()))
-        .wait()
-        .unwrap();
-
-    let (sink, _) = client.snapshot().unwrap();
-    let mut chunk = SnapshotChunk::new();
-    chunk.set_message(RaftMessage::new());
-    sink.send((chunk, Default::default())).wait().unwrap();
-}
+// raft related RPC is tested as parts of test_snapshot.rs, so skip here.
 
 #[test]
 fn test_coprocessor() {

--- a/tests/raftstore_cases/test_service.rs
+++ b/tests/raftstore_cases/test_service.rs
@@ -19,7 +19,7 @@ use tikv::storage::mvcc::{Lock, LockType};
 use tikv::storage::{Key, CF_DEFAULT, CF_LOCK, CF_RAFT};
 use tikv::util::HandyRwLock;
 
-use futures::{future, Future, Sink, Stream};
+use futures::{future, Future, Stream};
 use grpc::{ChannelBuilder, Environment, Error, RpcStatusCode};
 use kvproto::coprocessor::*;
 use kvproto::debugpb_grpc::DebugClient;


### PR DESCRIPTION
The case fails occasionally as it's not written correctly. Snapshot meta will be validated when it's received. However the meta being sent is empty, so it's meant to be rejected, and the RPC should fail eventually. Whether the case fails depends on how the network performs.

Actually the raft and snapshot RPCs are tested in the test_snapshot files already, so here the case is redundant. Let's remove the case instead of fixing it.

Close #3218.