### PR TITLE
aggregation: handle non-integer input for bit related  functions

### DIFF
--- a/src/coprocessor/codec/datum.rs
+++ b/src/coprocessor/codec/datum.rs
@@ -22,7 +22,7 @@ use std::{i64, str};
 
 use super::mysql::{
     self, parse_json_path_expr, Decimal, DecimalEncoder, Duration, Json, JsonEncoder,
-    PathExpression, Time, DEFAULT_FSP, MAX_FSP,
+    PathExpression, RoundMode, Time, DEFAULT_FSP, MAX_FSP,
 };
 use super::{convert, Error, Result};
 use coprocessor::dag::expr::EvalContext;
@@ -335,6 +335,40 @@ impl Datum {
             Datum::Dec(d) => d.as_f64(),
             Datum::Json(j) => j.cast_to_real(ctx),
             _ => Err(box_err!("failed to convert {} to f64", self)),
+        }
+    }
+
+    /// `into_i64` converts self into f64.
+    /// source function name is `ToInt64`.
+    pub fn into_i64(self, ctx: &mut EvalContext) -> Result<i64> {
+        let (lower_bound, upper_bound) = (i64::MIN, i64::MAX);
+        let tp = mysql::types::LONG_LONG;
+        match self {
+            Datum::I64(i) => Ok(i),
+            Datum::U64(u) => convert::convert_uint_to_int(u, upper_bound, tp),
+
+            Datum::F64(f) => convert::convert_float_to_int(f, lower_bound, upper_bound, tp),
+            Datum::Bytes(bs) => convert::bytes_to_int(ctx, &bs),
+            Datum::Time(mut t) => {
+                t.round_frac(mysql::DEFAULT_FSP)?;
+                let d = t.to_decimal()?;
+                d.as_i64().into()
+            }
+            Datum::Dur(mut d) => {
+                d.round_frac(mysql::DEFAULT_FSP)?;
+                let d = d.to_decimal()?;
+                d.as_i64().into()
+            }
+            Datum::Dec(d) => {
+                let res: Result<Decimal> = d.round(mysql::DEFAULT_FSP, RoundMode::HalfEven).into();
+                if let Err(e) = res {
+                    Err(e)
+                } else {
+                    res.unwrap().as_i64().into()
+                }
+            }
+            Datum::Json(j) => Ok(j.cast_to_int()),
+            _ => Err(box_err!("failed to convert {} to i64", self)),
         }
     }
 
@@ -1842,6 +1876,37 @@ mod test {
         for (d, exp) in tests {
             let got = d.into_f64(&mut ctx).unwrap();
             assert_eq!(Datum::F64(got), Datum::F64(exp));
+        }
+    }
+
+    #[test]
+    fn test_into_i64() {
+        let tests = vec![
+            (Datum::Bytes(b"0".to_vec()), 0),
+            (Datum::I64(1), 1),
+            (Datum::U64(1), 1),
+            (Datum::F64(3.3), 3),
+            (Datum::Bytes(b"100".to_vec()), 100),
+            (
+                Datum::Time(Time::parse_utc_datetime("2012-12-31 11:30:45.9999", 0).unwrap()),
+                20121231113046,
+            ),
+            (
+                Datum::Dur(Duration::parse(b"11:30:45.999", 0).unwrap()),
+                113046,
+            ),
+            (
+                Datum::Dec(Decimal::from_bytes(b"11.2").unwrap().unwrap()),
+                11,
+            ),
+            (Datum::Json(Json::from_str(r#"false"#).unwrap()), 0),
+        ];
+
+        let cfg = EvalConfig::new(0, FLAG_IGNORE_TRUNCATE).unwrap();
+        let mut ctx = EvalContext::new(Arc::new(cfg));
+        for (d, exp) in tests {
+            let got = d.into_i64(&mut ctx).unwrap();
+            assert_eq!(got, exp);
         }
     }
 }

--- a/src/coprocessor/codec/mysql/mod.rs
+++ b/src/coprocessor/codec/mysql/mod.rs
@@ -66,7 +66,7 @@ pub mod json;
 pub mod time;
 pub mod types;
 
-pub use self::decimal::{dec_encoded_len, Decimal, DecimalEncoder, Res};
+pub use self::decimal::{dec_encoded_len, Decimal, DecimalEncoder, Res, RoundMode};
 pub use self::duration::{Duration, DurationEncoder};
 pub use self::json::{parse_json_path_expr, Json, JsonEncoder, ModifyType, PathExpression};
 pub use self::time::{Time, TimeEncoder};

--- a/src/coprocessor/dag/executor/aggregate.rs
+++ b/src/coprocessor/dag/executor/aggregate.rs
@@ -353,7 +353,7 @@ mod test {
     }
 
     #[test]
-    fn test_bit_add() {
+    fn test_bit_and() {
         let mut aggr = AggBitAnd {
             c: 0xffffffffffffffff,
         };


### PR DESCRIPTION
## What have you changed? (mandatory)
fix [issue#6987](https://github.com/pingcap/tidb/issues/6987#event-1717221272)
bit_or doesn't handle decimal

## What are the type of the changes (mandatory)?
Bug fix

## How has this PR been tested (mandatory)?
unittest

## Does this PR affect documentation (docs/docs-cn) update? (optional)
No.

## The related PR
https://github.com/pingcap/tidb/pull/6994
@breeswish @XuHuaiyu PTAL