### PR TITLE
Makefile: flamegraph friendly release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,11 @@ release:
 	@mkdir -p ${BIN_PATH}
 	@cp -f ${CARGO_TARGET_DIR}/release/tikv-ctl ${CARGO_TARGET_DIR}/release/tikv-fail ${CARGO_TARGET_DIR}/release/tikv-server ${CARGO_TARGET_DIR}/release/tikv-importer ${BIN_PATH}/
 
+PERF_BUILD ?= tikv-server
 perf_release:
-	@cargo rustc --bin tikv-server --release --features "${ENABLE_FEATURES}" -- -C no-prepopulate-passes -C force-frame-pointers=y
+	cargo rustc --bin ${PERF_BUILD} --release --features "${ENABLE_FEATURES}" -- -C no-prepopulate-passes -C force-frame-pointers=y
 	@mkdir -p ${BIN_PATH}
-	@cp -f ${CARGO_TARGET_DIR}/release/tikv-server ${BIN_PATH}/
+	@cp -f ${CARGO_TARGET_DIR}/release/${PERF_BUILD} ${BIN_PATH}/
 
 unportable_release:
 	ROCKSDB_SYS_PORTABLE=0 make release

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,11 @@ release:
 	@mkdir -p ${BIN_PATH}
 	@cp -f ${CARGO_TARGET_DIR}/release/tikv-ctl ${CARGO_TARGET_DIR}/release/tikv-fail ${CARGO_TARGET_DIR}/release/tikv-server ${CARGO_TARGET_DIR}/release/tikv-importer ${BIN_PATH}/
 
+perf_release:
+	@cargo rustc --bin tikv-server --release --features "${ENABLE_FEATURES}" -- -C no-prepopulate-passes -C force-frame-pointers=y
+	@mkdir -p ${BIN_PATH}
+	@cp -f ${CARGO_TARGET_DIR}/release/tikv-server ${BIN_PATH}/
+
 unportable_release:
 	ROCKSDB_SYS_PORTABLE=0 make release
 


### PR DESCRIPTION
Disable some optimization to generate readable flamegraphs.

Before:

![screenshot from 2018-07-19 17-56-52](https://user-images.githubusercontent.com/2150711/42935839-4218088c-8b7d-11e8-8c10-5bba3b28c5d6.png)


After:

![screenshot from 2018-07-19 17-56-25](https://user-images.githubusercontent.com/2150711/42935823-381a6ba4-8b7d-11e8-967f-05b00680e357.png)
