### PR TITLE
ci-build: move tests.out to target so it wont cause rebuild

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -31,6 +31,12 @@ fn main() {
 // build_info returns a string of commit hash and utc time.
 // TODO: use serde.
 fn build_info() -> String {
+    // Re-run if they changes. See more: man 1 git-rev-parse
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs");
+    println!("cargo:rerun-if-changed=.git/refs/tags");
+    println!("cargo:rerun-if-changed=.git/refs/heads");
+
     // explicit separates outputs by '\n'.
     format!(
         "{}\n{}\n{}\n{}",

--- a/ci-build/Makefile
+++ b/ci-build/Makefile
@@ -42,4 +42,4 @@ cover_linux cover_osx:
 	export LOG_LEVEL=DEBUG && \
 	export RUST_BACKTRACE=1 && \
 	export RUST_TEST_THREADS=2 && \
-	grep " Running " tests.out | sed -e 's/Running//g' | xargs -n 1 -I {} ${LOCAL_DIR}/bin/kcov --verify --coveralls-id=${TRAVIS_JOB_ID} --include-pattern tikv/src --exclude-pattern tikv/src/bin --strip-path `pwd`/ target/kcov {} --nocapture
+	grep " Running " target/tests.out | sed -e 's/Running//g' | xargs -n 1 -I {} ${LOCAL_DIR}/bin/kcov --verify --coveralls-id=${TRAVIS_JOB_ID} --include-pattern tikv/src --exclude-pattern tikv/src/bin --strip-path `pwd`/ target/kcov {} --nocapture

--- a/ci-build/test.sh
+++ b/ci-build/test.sh
@@ -35,14 +35,14 @@ export RUSTFLAGS=-Dwarnings
 make clippy || panic "\e[35mplease fix the errors!!!\e[0m"
 
 if [[ "$SKIP_TESTS" != "true" ]]; then
-    make test 2>&1 | tee tests.out
+    make test 2>&1 | tee target/tests.out
 else
     EXTRA_CARGO_ARGS="--no-run" make test
     exit $?
 fi
 status=$?
 git diff-index --quiet HEAD -- || echo "\e[35mplease run tests before creating a pr!!!\e[0m"
-for case in `cat tests.out | python -c "import sys
+for case in `cat target/tests.out | python -c "import sys
 import re
 p = re.compile(\"thread '([^']+)' panicked at\")
 cases = set()
@@ -61,9 +61,9 @@ print ('\n'.join(cases))
 done
 
 rm $LOG_FILE || true
-# don't remove the tests.out, coverage counts on it.
+# don't remove the target/tests.out, coverage counts on it.
 if [[ "$TRAVIS" != "true" ]]; then
-    rm tests.out || true
+    rm target/tests.out || true
 fi
 
 exit $status


### PR DESCRIPTION
It saves about 2m46s on CircleCI.

Previous: 

```
#!/bin/bash -eo pipefail
make trace_test
env CI=true SKIP_FORMAT_CHECK=true FAIL_POINT=1 /home/circleci/tikv-ci/ci-build/test.sh
make[1]: Entering directory `/home/circleci/tikv-ci'
    Finished dev [unoptimized + debuginfo] target(s) in 0.39s
make[1]: Leaving directory `/home/circleci/tikv-ci'
make[1]: Entering directory `/home/circleci/tikv-ci'
# When SIP is enabled, DYLD_LIBRARY_PATH will not work in subshell, so we have to set it
# again here. LOCAL_DIR is defined in .travis.yml.
export DYLD_LIBRARY_PATH=":/home/circleci/.local/lib:/home/circleci/.local/lib:/home/circleci/.local/lib:/lib" && \
	export LOG_LEVEL=DEBUG && \
	export RUST_BACKTRACE=1 && \
	cargo test --features "default portable sse"  -- --nocapture && \
	cargo test --features "default portable sse" --bench benches  -- --nocapture  && \
	if [[ "`uname`" == "Linux" ]]; then \
		export MALLOC_CONF=prof:true,prof_active:false && \
		cargo test --features "default portable sse"  --bin tikv-server -- --nocapture --ignored; \
	fi
 INFO 2018-07-23T03:35:24Z: cargo::core::compiler::fingerprint: fingerprint error for tikv v2.1.0-beta (file:///home/circleci/tikv-ci): precalculated components have changed: 1532316923.853428612s (/home/circleci/tikv-ci/tests.out) != 1532316132.273408917s (/home/circleci/tikv-ci/.circleci/config.yml)
   Compiling tikv v2.1.0-beta (file:///home/circleci/tikv-ci)
    Finished dev [unoptimized + debuginfo] target(s) in 2m 46s
     Running target/debug/deps/tikv-ad2709b06283c708

running 506 tests
```

Now:

```
#!/bin/bash -eo pipefail
make trace_test
env CI=true SKIP_FORMAT_CHECK=true FAIL_POINT=1 /home/circleci/tikv-ci/ci-build/test.sh
make[1]: Entering directory `/home/circleci/tikv-ci'
    Finished dev [unoptimized + debuginfo] target(s) in 0.37s
make[1]: Leaving directory `/home/circleci/tikv-ci'
make[1]: Entering directory `/home/circleci/tikv-ci'
# When SIP is enabled, DYLD_LIBRARY_PATH will not work in subshell, so we have to set it
# again here. LOCAL_DIR is defined in .travis.yml.
export DYLD_LIBRARY_PATH=":/home/circleci/.local/lib:/home/circleci/.local/lib:/home/circleci/.local/lib:/lib" && \
	export LOG_LEVEL=DEBUG && \
	export RUST_BACKTRACE=1 && \
	cargo test --features "default portable sse"  -- --nocapture && \
	cargo test --features "default portable sse" --bench benches  -- --nocapture  && \
	if [[ "`uname`" == "Linux" ]]; then \
		export MALLOC_CONF=prof:true,prof_active:false && \
		cargo test --features "default portable sse"  --bin tikv-server -- --nocapture --ignored; \
	fi
    Finished dev [unoptimized + debuginfo] target(s) in 0.24s  <---- Here
     Running target/debug/deps/tikv-ad2709b06283c708

running 506 tests
```