### PR TITLE
storage: rename the scheduler of txn to coordinator

### DIFF
--- a/src/storage/txn/coordinator.rs
+++ b/src/storage/txn/coordinator.rs
@@ -334,7 +334,6 @@ impl Hash for HashableContext {
 
 impl Eq for HashableContext {}
 
-
 // Make clippy happy.
 type MultipleReturnValue = (Option<MvccLock>, Vec<(u64, Write)>, Vec<(u64, Value)>);
 
@@ -846,7 +845,7 @@ impl<E: Engine> Coordinator<E> {
             running_write_bytes: 0,
         }
     }
-    
+
     /// Generates the next command ID.
     fn gen_id(&mut self) -> u64 {
         self.id_alloc += 1;

--- a/src/storage/txn/latch.rs
+++ b/src/storage/txn/latch.rs
@@ -69,7 +69,7 @@ impl Lock {
     }
 }
 
-/// Latches which are used for concurrency control in the scheduler.
+/// Latches which are used for concurrency control in the coordinator.
 ///
 /// Each latch is indexed by a slot ID, hence the term latch and slot are used interchangeably, but
 /// conceptually a latch is a queue, and a slot is an index to the queue.

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -11,14 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod coordinator;
 mod latch;
-mod scheduler;
 mod store;
 
 use std::error;
 use std::io::Error as IoError;
 
-pub use self::scheduler::{Msg, Scheduler, CMD_BATCH_SIZE, RESOLVE_LOCK_BATCH_SIZE};
+pub use self::coordinator::{Coordinator, Msg, CMD_BATCH_SIZE, RESOLVE_LOCK_BATCH_SIZE};
 pub use self::store::{SnapshotStore, StoreScanner};
 
 quick_error! {


### PR DESCRIPTION
## What have you changed? (mandatory)
In storage mod, there are two concepts of `scheduler`, one for worker's `scheduler` and the other for txn `scheduler` which controls write concurrency and wraps a worker's `scheduler`. And this is somewhat confusing, so I rename the `scheduler` of txn to `coordinator` to distinguish them.

## What are the type of the changes? (mandatory)
- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)
No need

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
There some related configurations, but I don't change these names.
```
[storage]
# the number of slots in scheduler latches, concurrency control for write.
# scheduler-concurrency = 2048000

# scheduler's worker pool size, should increase it in heavy write cases,
# also should less than total cpu cores.
# scheduler-worker-pool-size = 4

# When the pending write bytes exceeds this threshold,
# the "scheduler too busy" error is displayed.
# scheduler-pending-write-threshold = "100MB"
```
I'm not sure it is necessary to change these `scheduler`, cause there is a `scheduler` still  in `coordinator` and these configuration names look fine for me. What's your opinion?

## Does this PR affect tidb-ansible update? (mandatory)


