### PR TITLE
Make TiKV compatible with rustc 1.29.0-nightly (6a1c0637c 2018-07-23)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@
 
 #![crate_type = "lib"]
 #![cfg_attr(test, feature(test))]
-#![feature(proc_macro)]
 #![feature(fnbox)]
 #![feature(alloc)]
 #![feature(slice_patterns)]
@@ -23,6 +22,7 @@
 #![feature(proc_macro_non_items)]
 #![feature(proc_macro_gen)]
 #![feature(ascii_ctype)]
+#![feature(use_extern_macros)]
 #![recursion_limit = "200"]
 // Currently this raises some false positives, so we allow it:
 // https://github.com/rust-lang-nursery/rust-clippy/issues/2638


### PR DESCRIPTION
## What have you changed? (mandatory)

- Added `#![feature(use_extern_macros)]` since there's a compilation error without it
- Removed `#![feature(proc_macro)]` since it's already stable

## What are the type of the changes? (mandatory)

- Improvement

## How has this PR been tested? (mandatory)

I installed rustc 1.29.0-nightly (6a1c0637c 2018-07-23) with rustup and ran `make` and got a compilation error. This PR has made it successfully compiled.

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.