### PR TITLE
Rename scan_lock -> scan_locks

### DIFF
--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -405,7 +405,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
         let timer = GRPC_MSG_HISTOGRAM_VEC.kv_scan_lock.start_coarse_timer();
 
         let (cb, future) = paired_future_callback();
-        let res = self.storage.async_scan_lock(
+        let res = self.storage.async_scan_locks(
             req.take_context(),
             req.get_max_version(),
             req.take_start_key(),

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -804,7 +804,7 @@ impl<E: Engine> Storage<E> {
         Ok(())
     }
 
-    pub fn async_scan_lock(
+    pub fn async_scan_locks(
         &self,
         ctx: Context,
         max_ts: u64,

--- a/src/storage/mvcc/reader.rs
+++ b/src/storage/mvcc/reader.rs
@@ -565,7 +565,7 @@ impl<S: Snapshot> MvccReader<S> {
     }
 
     #[cfg_attr(feature = "cargo-clippy", allow(type_complexity))]
-    pub fn scan_lock<F>(
+    pub fn scan_locks<F>(
         &mut self,
         start: Option<Key>,
         filter: F,

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -510,7 +510,7 @@ fn process_read<E: Engine>(
                 ctx.get_isolation_level(),
             );
             let res = reader
-                .scan_lock(start_key.take(), |lock| lock.ts <= max_ts, limit)
+                .scan_locks(start_key.take(), |lock| lock.ts <= max_ts, limit)
                 .map_err(Error::from)
                 .and_then(|(v, _)| {
                     let mut locks = vec![];
@@ -548,7 +548,7 @@ fn process_read<E: Engine>(
                 ctx.get_isolation_level(),
             );
             let res = reader
-                .scan_lock(
+                .scan_locks(
                     scan_key.take(),
                     |lock| txn_status.contains_key(&lock.ts),
                     RESOLVE_LOCK_BATCH_SIZE,

--- a/tests/storage/assert_storage.rs
+++ b/tests/storage/assert_storage.rs
@@ -483,7 +483,7 @@ impl<E: Engine> AssertionStorage<E> {
         );
     }
 
-    pub fn scan_lock_ok(
+    pub fn scan_locks_ok(
         &self,
         max_ts: u64,
         start_key: Vec<u8>,
@@ -492,7 +492,7 @@ impl<E: Engine> AssertionStorage<E> {
     ) {
         assert_eq!(
             self.store
-                .scan_lock(self.ctx.clone(), max_ts, start_key, limit)
+                .scan_locks(self.ctx.clone(), max_ts, start_key, limit)
                 .unwrap(),
             expect
         );

--- a/tests/storage/sync_storage.rs
+++ b/tests/storage/sync_storage.rs
@@ -158,7 +158,7 @@ impl<E: Engine> SyncStorage<E> {
         wait_op!(|cb| self.store.async_rollback(ctx, keys, start_ts, cb)).unwrap()
     }
 
-    pub fn scan_lock(
+    pub fn scan_locks(
         &self,
         ctx: Context,
         max_ts: u64,
@@ -167,7 +167,7 @@ impl<E: Engine> SyncStorage<E> {
     ) -> Result<Vec<LockInfo>> {
         wait_op!(|cb| self
             .store
-            .async_scan_lock(ctx, max_ts, start_key, limit, cb))
+            .async_scan_locks(ctx, max_ts, start_key, limit, cb))
             .unwrap()
     }
 

--- a/tests/storage_cases/test_raft_storage.rs
+++ b/tests/storage_cases/test_raft_storage.rs
@@ -62,7 +62,7 @@ fn test_raft_storage() {
     );
     assert!(
         storage
-            .scan_lock(ctx.clone(), 20, b"".to_vec(), 100)
+            .scan_locks(ctx.clone(), 20, b"".to_vec(), 100)
             .is_err()
     );
 }
@@ -166,7 +166,7 @@ fn test_raft_storage_store_not_match() {
     );
     assert!(
         storage
-            .scan_lock(ctx.clone(), 20, b"".to_vec(), 100)
+            .scan_locks(ctx.clone(), 20, b"".to_vec(), 100)
             .is_err()
     );
 }

--- a/tests/storage_cases/test_storage.rs
+++ b/tests/storage_cases/test_storage.rs
@@ -477,16 +477,16 @@ fn test_txn_store_scan_lock() {
         vec![Some((b"k1", b"v1")), None, None, None, None],
     );
 
-    store.scan_lock_ok(10, b"".to_vec(), 1, vec![lock(b"p1", b"p1", 5)]);
+    store.scan_locks_ok(10, b"".to_vec(), 1, vec![lock(b"p1", b"p1", 5)]);
 
-    store.scan_lock_ok(
+    store.scan_locks_ok(
         10,
         b"s".to_vec(),
         2,
         vec![lock(b"s1", b"p1", 5), lock(b"s2", b"p2", 10)],
     );
 
-    store.scan_lock_ok(
+    store.scan_locks_ok(
         10,
         b"".to_vec(),
         0,
@@ -498,7 +498,7 @@ fn test_txn_store_scan_lock() {
         ],
     );
 
-    store.scan_lock_ok(
+    store.scan_locks_ok(
         10,
         b"".to_vec(),
         100,
@@ -537,7 +537,7 @@ fn test_txn_store_resolve_lock() {
     store.get_none(b"s1", 30);
     store.get_ok(b"p2", 20, b"v10");
     store.get_ok(b"s2", 30, b"v10");
-    store.scan_lock_ok(30, b"".to_vec(), 100, vec![]);
+    store.scan_locks_ok(30, b"".to_vec(), 100, vec![]);
 }
 
 fn test_txn_store_resolve_lock_batch(key_prefix_len: usize, n: usize) {
@@ -584,7 +584,7 @@ fn test_txn_store_resolve_lock_in_a_batch() {
     store.get_none(b"s1", 30);
     store.get_ok(b"p2", 30, b"v10");
     store.get_ok(b"s2", 30, b"v10");
-    store.scan_lock_ok(30, b"".to_vec(), 100, vec![]);
+    store.scan_locks_ok(30, b"".to_vec(), 100, vec![]);
 }
 
 #[test]


### PR DESCRIPTION
## What have you changed? (mandatory)

This PR is extracted from the [Mvcc Refine PR](https://github.com/pingcap/tikv/pull/3344). It changes the name `scan_lock` in storage into`scan_locks` to conform existing naming conventions (i.e. we have `scan_keys`, `scan_values_xxx`, etc.)

## What are the type of the changes? (mandatory)

- Trivial change

## How has this PR been tested? (mandatory)

Compiler pass

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

