### PR TITLE
"RegionNotFound" reported by tikv should be retriable.

### DIFF
--- a/tests/raftstore/cluster.rs
+++ b/tests/raftstore/cluster.rs
@@ -520,11 +520,13 @@ impl<T: Simulator> Cluster<T> {
         }
 
         let err = resp.get_header().get_error();
-        if err.has_stale_command() {
+
+        if err.has_stale_command() || err.has_region_not_found() {
             // command got truncated, leadership may have changed.
             self.reset_leader_of_region(region_id);
             return true;
         }
+
         if !err.has_not_leader() {
             return false;
         }
@@ -830,6 +832,7 @@ impl<T: Simulator> Cluster<T> {
                         if error.has_stale_epoch()
                             || error.has_not_leader()
                             || error.has_stale_command()
+                            || error.has_region_not_found()
                         {
                             warn!("fail to split: {:?}, ignore.", error);
                             return;


### PR DESCRIPTION
## What have you changed? (mandatory)
Change strategy about `RegionNotFound`. This should be treated as a retriable error.

## What are the type of the changes? (mandatory)
Improvement.

## How has this PR been tested? (mandatory)
make dev.

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
No.

## Does this PR affect tidb-ansible update? (mandatory)
No.

